### PR TITLE
#20 Update Address List in Splitter

### DIFF
--- a/packages/andromeda_protocol/src/splitter.rs
+++ b/packages/andromeda_protocol/src/splitter.rs
@@ -51,11 +51,19 @@ impl InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    UpdateRecipients { recipients: Vec<AddressPercent> },
-    UpdateLock { lock: bool },
-    UpdateAddressList { address_list: AddressListModule },
+    UpdateRecipients {
+        recipients: Vec<AddressPercent>,
+    },
+    UpdateLock {
+        lock: bool,
+    },
+    UpdateAddressList {
+        address_list: Option<AddressListModule>,
+    },
     Send {},
-    UpdateOwner { address: String },
+    UpdateOwner {
+        address: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
- Changed Splitter's `ExecuteMsg::UpdateAddress` `address_list` field to be optional, allowing removal of the address list
- Added an `InstantiateMsg` to the `ExecuteMsg::UpdateAddress` handler if the new address list has the appropriate configuration