### PR TITLE
CU-289uead | Allow swapper impl to be referenced by AndrAddress

### DIFF
--- a/contracts/andromeda_swapper/src/state.rs
+++ b/contracts/andromeda_swapper/src/state.rs
@@ -1,3 +1,5 @@
 use cw_storage_plus::Item;
 
-pub const SWAPPER_IMPL_ADDR: Item<String> = Item::new("swapper_impl_addr");
+use common::mission::AndrAddress;
+
+pub const SWAPPER_IMPL_ADDR: Item<AndrAddress> = Item::new("swapper_impl_addr");

--- a/packages/andromeda_protocol/src/swapper.rs
+++ b/packages/andromeda_protocol/src/swapper.rs
@@ -1,16 +1,12 @@
-use common::ado_base::{recipient::Recipient, AndromedaMsg, AndromedaQuery};
+use common::{
+    ado_base::{recipient::Recipient, AndromedaMsg, AndromedaQuery},
+    mission::AndrAddress,
+};
 use cosmwasm_std::Binary;
 use cw20::Cw20ReceiveMsg;
 use cw_asset::AssetInfo;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum InstantiateType {
-    New(Binary),
-    Address(String),
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -49,9 +45,20 @@ pub struct InstantiateMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct SwapperImpl {
-    pub name: String,
-    pub instantiate_type: InstantiateType,
+#[serde(rename_all = "snake_case")]
+pub enum SwapperImpl {
+    /// Specifies the instantiation specification for the swapper impl.
+    New(InstantiateInfo),
+    /// Specifies the swapper impl by reference to an existing contract.
+    Reference(AndrAddress),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateInfo {
+    /// The instantiate message encoded in base64.
+    pub msg: Binary,
+    /// The ADO type. Used to retrieve the code id.
+    pub ado_type: String,
 }
 
 /// Execute Message for Swapper contract.
@@ -86,6 +93,7 @@ pub enum Cw20HookMsg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
+    SwapperImpl {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]


### PR DESCRIPTION
# Motivation
This ADO was created before we had `AndrAddress` so it needed to be updated to be consistent and get full functionality in a mission. 

# Implementation
I streamlined the instantiate message by making `SwapperImpl` an enum that allows specifying a swapper impl reference that uses an `AndrAddress` or a new one that uses an instantiate message and ado_type. I was playing with the idea of just having the user specify the type of ADO they want, so for example `"astroport"`, and then the swapper creating the instantiate message itself. The issue here is with scaling as we don't want to reference every possible swapper impl instantiate message. It is unclear at this time if all swapper impls will share the same `InstantiateMsg` or not. If so, we can easily integrate this approach. Once we have more possible swapper impls we can revisit this. 

One interesting way of going about this is extending the primitive contract to store `Binary` types to allow predefined instantiate messages. The problem here is it only works for constant messages as they are pre-defined. We'd also need to update these references each time one of the internal components changed, for example, if we want to update the primitive contract address. Something to think about for the future, could tie into ADOP too.

Lastly I also added a query that gets the `AndrAddress` of the swapper impl. It should be fine to leave as is and not get the underlying address as the user can query the mission contract for that. 

# Testing

## Unit/Integration tests
Existing tests were updated and I extended the one that instantiates a swapper impl to also test `reply`. 

## On-chain tests
No, as the core logic is the same, this is really just a refactor. We have tested AndrAddress in the past and it worked without problems. 

# Future work
As mentioned in the implementation section, there are some possible improvements that can be made in the future. 