### PR TITLE
CU-29audyu | Add base messages to auction ado

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -48,6 +48,9 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
+        ExecuteMsg::AndrReceive(msg) => {
+            ADOContract::default().execute(deps, env, info, msg, execute)
+        }
         ExecuteMsg::ReceiveNft(msg) => handle_receive_cw721(deps, env, info, msg),
         ExecuteMsg::UpdateAuction {
             token_id,
@@ -494,8 +497,9 @@ fn get_and_increment_next_auction_id(
 }
 
 #[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
+        QueryMsg::AndrQuery(msg) => ADOContract::default().query(deps, env, msg, query),
         QueryMsg::LatestAuctionState {
             token_id,
             token_address,

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -1,4 +1,7 @@
-use common::OrderBy;
+use common::{
+    ado_base::{AndromedaMsg, AndromedaQuery},
+    OrderBy,
+};
 use cosmwasm_std::{Addr, Timestamp, Uint128};
 use cw721::{Cw721ReceiveMsg, Expiration};
 use schemars::JsonSchema;
@@ -10,6 +13,7 @@ pub struct InstantiateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    AndrReceive(AndromedaMsg),
     ReceiveNft(Cw721ReceiveMsg),
     /// Places a bid on the current auction for the given token_id. The previous largest bid gets
     /// automatically sent back to the bidder when they are outbid.
@@ -55,6 +59,7 @@ pub enum Cw721HookMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    AndrQuery(AndromedaQuery),
     /// Gets the latest auction state for the given token. This will either be the current auction
     /// if there is one in progress or the last completed one.
     LatestAuctionState {


### PR DESCRIPTION
# Motivation
This PR adds AndromedaMsg and AndromedaQuery to the auction ADO. They were missing since this contract was initially used generically without the need of ADO specific logic. 

# Implementation
Very simply just added the two messages to this ADO as they are in any other. 

# Testing

## Unit/Integration tests
None needed.

## On-chain tests
None needed.

# Future work
We may want to add module support to the auction ADO as well.