### PR TITLE
Add governance voting to vesting ado

### DIFF
--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -22,7 +22,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking"] }
+cosmwasm-std = { version = "1.0.0", features = ["staking", "stargate"] }
 cw-storage-plus = "0.13.2"
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }

--- a/packages/andromeda-finance/Cargo.toml
+++ b/packages/andromeda-finance/Cargo.toml
@@ -11,7 +11,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = { version = "1.0.0", features = ["stargate"] }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 schemars = "0.8.3"
 cw-utils = "0.13.2"

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -2,7 +2,7 @@ use common::{
     ado_base::{recipient::Recipient, AndromedaMsg, AndromedaQuery},
     withdraw::WithdrawalType,
 };
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Uint128, VoteOption};
 use cw_utils::Duration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -57,6 +57,11 @@ pub enum ExecuteMsg {
     Undelegate {
         amount: Option<Uint128>,
         validator: String,
+    },
+    /// Votes on the specified proposal with the specified vote.
+    Vote {
+        proposal_id: u64,
+        vote: VoteOption,
     },
 }
 


### PR DESCRIPTION
# Motivation
This is a necessary feature since the user whose funds are being locked up cannot vote on their own. 

# Implementation
Quite simply just a proxy message that allows voting on a gov proposal. 

# Testing

## Unit/Integration tests
Added unit tests for the change. 

## On-chain tests
Not done since it is fairly convoluted to test this and the logic is simple enough that it shouldn't be a problem. In any case this will be tested eventually. 

# Future work
The validator logic still needs to be updated to the automatic approach. 