### PR TITLE
Add redelegation and withdrawing rewards to vesting ADO 

### DIFF
--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -298,8 +298,9 @@ fn execute_delegate(
     amount: Option<Uint128>,
     validator: String,
 ) -> Result<Response, ContractError> {
+    let sender = info.sender.to_string();
     require(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
         ContractError::Unauthorized {},
     )?;
     let config = CONFIG.load(deps.storage)?;
@@ -318,6 +319,7 @@ fn execute_delegate(
     });
 
     Ok(Response::new()
+        .add_message(get_set_withdraw_address_msg(sender))
         .add_message(msg)
         .add_attribute("action", "delegate")
         .add_attribute("validator", validator)
@@ -332,8 +334,9 @@ fn execute_redelegate(
     from: String,
     to: String,
 ) -> Result<Response, ContractError> {
+    let sender = info.sender.to_string();
     require(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
         ContractError::Unauthorized {},
     )?;
     let config = CONFIG.load(deps.storage)?;
@@ -356,6 +359,7 @@ fn execute_redelegate(
     });
 
     Ok(Response::new()
+        .add_message(get_set_withdraw_address_msg(sender))
         .add_message(msg)
         .add_attribute("action", "redelegate")
         .add_attribute("from", from)
@@ -370,8 +374,9 @@ fn execute_undelegate(
     amount: Option<Uint128>,
     validator: String,
 ) -> Result<Response, ContractError> {
+    let sender = info.sender.to_string();
     require(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
         ContractError::Unauthorized {},
     )?;
     let config = CONFIG.load(deps.storage)?;
@@ -393,6 +398,7 @@ fn execute_undelegate(
     });
 
     Ok(Response::new()
+        .add_message(get_set_withdraw_address_msg(sender))
         .add_message(msg)
         .add_attribute("action", "undelegate")
         .add_attribute("validator", validator)
@@ -409,8 +415,6 @@ fn execute_withdraw_rewards(
         ADOContract::default().is_contract_owner(deps.storage, &sender)?,
         ContractError::Unauthorized {},
     )?;
-    let set_address_msg: CosmosMsg =
-        CosmosMsg::Distribution(DistributionMsg::SetWithdrawAddress { address: sender });
     let withdraw_rewards_msgs: Vec<CosmosMsg> = deps
         .querier
         .query_all_delegations(env.contract.address)?
@@ -424,7 +428,7 @@ fn execute_withdraw_rewards(
 
     Ok(Response::new()
         .add_attribute("action", "withdraw_rewards")
-        .add_message(set_address_msg)
+        .add_message(get_set_withdraw_address_msg(sender))
         .add_messages(withdraw_rewards_msgs))
 }
 
@@ -477,6 +481,10 @@ fn get_amount_delegated(
         None => Ok(Uint128::zero()),
         Some(full_delegation) => Ok(full_delegation.amount.amount),
     }
+}
+
+fn get_set_withdraw_address_msg(address: String) -> CosmosMsg {
+    CosmosMsg::Distribution(DistributionMsg::SetWithdrawAddress { address })
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-vesting/src/testing/tests.rs
+++ b/contracts/finance/andromeda-vesting/src/testing/tests.rs
@@ -331,6 +331,11 @@ fn test_create_batch_and_delegate() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Delegate {
                 validator: DEFAULT_VALIDATOR.to_string(),
                 amount: coin(100, "uusd")
@@ -1290,6 +1295,11 @@ fn test_delegate() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Delegate {
                 validator: DEFAULT_VALIDATOR.to_string(),
                 amount: coin(100, "uusd")
@@ -1320,6 +1330,11 @@ fn test_delegate_more_than_balance() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Delegate {
                 validator: DEFAULT_VALIDATOR.to_string(),
                 amount: coin(100, "uusd")
@@ -1386,6 +1401,11 @@ fn test_redelegate() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Redelegate {
                 src_validator: DEFAULT_VALIDATOR.to_owned(),
                 dst_validator: "other_validator".to_string(),
@@ -1418,6 +1438,11 @@ fn test_redelegate_more_than_max() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Redelegate {
                 src_validator: DEFAULT_VALIDATOR.to_owned(),
                 dst_validator: "other_validator".to_string(),
@@ -1483,6 +1508,11 @@ fn test_undelegate() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Undelegate {
                 validator: DEFAULT_VALIDATOR.to_owned(),
                 amount: coin(100, "uusd")
@@ -1512,6 +1542,11 @@ fn test_undelegate_more_than_max() {
 
     assert_eq!(
         Response::new()
+            .add_message(CosmosMsg::Distribution(
+                DistributionMsg::SetWithdrawAddress {
+                    address: "owner".to_string()
+                }
+            ))
             .add_message(CosmosMsg::Staking(StakingMsg::Undelegate {
                 validator: DEFAULT_VALIDATOR.to_owned(),
                 amount: coin(100, "uusd")

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -53,6 +53,13 @@ pub enum ExecuteMsg {
         amount: Option<Uint128>,
         validator: String,
     },
+    /// Redelegates the given amount of tokens, or all from the `from` validator to the `to`
+    /// validator.
+    Redelegate {
+        amount: Option<Uint128>,
+        from: String,
+        to: String,
+    },
     /// Undelegates the given amount of tokens, or all if not specified.
     Undelegate {
         amount: Option<Uint128>,

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -65,6 +65,8 @@ pub enum ExecuteMsg {
         amount: Option<Uint128>,
         validator: String,
     },
+    /// Withdraws rewards from all delegations to the sender.
+    WithdrawRewards {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
# Motivation
This PR adds the ability to redelegate funds and also withdraw staking rewards. 

# Implementation
The redelegation logic is basically identical to undelegate except with a different message. I also added the `SetWithdrawAddress` message to all of the staking-related calls which sets the recipient of the withdrawn staking rewards to the sender of the call. I'm not sure if this should be the sender of the transaction or the hard-coded recipient. 

# Testing

## Unit/Integration tests
Unit tests have been added. 

## On-chain tests
[1. Create batch and delegate 1 junox](https://testnet.mintscan.io/juno-testnet/txs/1BBA3590548D4472819AFE3D75209E9AB86691756E50A660A197C28818AEED72)

[2. Withdraw rewards](https://testnet.mintscan.io/juno-testnet/txs/035B6A7BBBE0ED10D16C631943769BEE481D96F1137751DD8F2658F8340F46F0)

[3. Redelegate](https://testnet.mintscan.io/juno-testnet/txs/6064DD63E7E64F65A18C70311CD60D6CF793A0D372667C9B691B50251EE84082)

# Future work
I am no longer sure about wanting the automatic delegation setup since in this case we'd need to split up a large upfront deposit between multiple validators and not as they trickle in. I dont see a problem with having the owner of each ADO decide the validators they want to delegate to. 