### PR TITLE
Replace old method of retrieving address of instantiated address with one from `cw-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "cw2",
+ "prost",
  "schemars",
  "serde",
 ]
@@ -382,6 +383,7 @@ dependencies = [
  "cw-storage-plus",
  "cw2",
  "cw20",
+ "prost",
  "schemars",
  "serde",
 ]
@@ -397,6 +399,7 @@ dependencies = [
  "cosmwasm-std",
  "cw20",
  "cw721",
+ "prost",
 ]
 
 [[package]]
@@ -467,6 +470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +507,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfg-if"
@@ -782,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +953,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -22,3 +22,4 @@ common = { version = "0.1.0", path = "../../../packages/common" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
 andromeda-testing = { version = "0.1.0", path = "../../../packages/andromeda-testing" }
+prost = "0.9"

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -74,7 +74,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
     let id = msg.id.to_string();
     let descriptor = ADO_DESCRIPTORS.load(deps.storage, &id)?;
 
-    let addr_str = get_reply_address(&msg)?;
+    let addr_str = get_reply_address(msg)?;
     let addr = &deps.api.addr_validate(&addr_str)?;
     ADO_ADDRESSES.save(deps.storage, &descriptor.name, addr)?;
     let assign_app = generate_assign_app_message(addr, &env.contract.address.to_string())?;

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -3,7 +3,9 @@ use crate::{
     state::{ADO_ADDRESSES, ADO_DESCRIPTORS},
 };
 use andromeda_app::app::{AppComponent, ExecuteMsg, InstantiateMsg};
-use andromeda_testing::testing::mock_querier::mock_dependencies_custom;
+use andromeda_testing::{
+    reply::MsgInstantiateContractResponse, testing::mock_querier::mock_dependencies_custom,
+};
 use common::{ado_base::AndromedaMsg, error::ContractError};
 use cosmwasm_std::{
     attr,
@@ -11,6 +13,7 @@ use cosmwasm_std::{
     to_binary, Addr, CosmosMsg, Empty, Event, Reply, ReplyOn, Response, StdError, SubMsg,
     SubMsgResponse, SubMsgResult, WasmMsg,
 };
+use prost::Message;
 
 #[test]
 fn test_empty_instantiation() {
@@ -619,10 +622,20 @@ fn test_reply_assign_app() {
     let mock_reply_event = Event::new("instantiate")
         .add_attribute("contract_address".to_string(), "tokenaddress".to_string());
 
+    let instantiate_reply = MsgInstantiateContractResponse {
+        contract_address: "tokenaddress".to_string(),
+        data: vec![],
+    };
+    let mut encoded_instantiate_reply = Vec::<u8>::with_capacity(instantiate_reply.encoded_len());
+
+    instantiate_reply
+        .encode(&mut encoded_instantiate_reply)
+        .unwrap();
+
     let mock_reply = Reply {
         id: component_idx,
         result: SubMsgResult::Ok(SubMsgResponse {
-            data: None,
+            data: Some(encoded_instantiate_reply.into()),
             events: vec![mock_reply_event],
         }),
     };

--- a/contracts/app/andromeda-factory/src/reply.rs
+++ b/contracts/app/andromeda-factory/src/reply.rs
@@ -7,7 +7,7 @@ use crate::state::store_address;
 pub const REPLY_CREATE_TOKEN: u64 = 1;
 
 pub fn on_token_creation_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    let token_addr = get_reply_address(&msg)?;
+    let token_addr = get_reply_address(msg)?;
     let info = query_token_config(deps.querier, token_addr.to_string())?;
 
     store_address(deps.storage, info.symbol, &token_addr)?;

--- a/contracts/ecosystem/andromeda-swapper/Cargo.toml
+++ b/contracts/ecosystem/andromeda-swapper/Cargo.toml
@@ -23,5 +23,6 @@ ado-base = { path = "../../../packages/ado-base", version = "0.1.0", features = 
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
+prost = "0.9.0"
 
 andromeda-testing = { version = "0.1.0", path = "../../../packages/andromeda-testing" }

--- a/contracts/ecosystem/andromeda-swapper/src/contract.rs
+++ b/contracts/ecosystem/andromeda-swapper/src/contract.rs
@@ -73,7 +73,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
     }
     require(msg.id == 1, ContractError::InvalidReplyId {})?;
 
-    let addr = get_reply_address(&msg)?;
+    let addr = get_reply_address(msg)?;
     SWAPPER_IMPL_ADDR.save(deps.storage, &AndrAddress { identifier: addr })?;
     Ok(Response::default())
 }

--- a/contracts/ecosystem/andromeda-swapper/src/testing/tests.rs
+++ b/contracts/ecosystem/andromeda-swapper/src/testing/tests.rs
@@ -10,12 +10,14 @@ use andromeda_ecosystem::swapper::{
     Cw20HookMsg, ExecuteMsg, InstantiateInfo, InstantiateMsg, QueryMsg, SwapperCw20HookMsg,
     SwapperImpl, SwapperImplCw20HookMsg, SwapperImplExecuteMsg, SwapperMsg,
 };
-use andromeda_testing::testing::mock_querier::{
-    mock_dependencies_custom, MOCK_CW20_CONTRACT, MOCK_CW20_CONTRACT2,
+use andromeda_testing::{
+    reply::MsgInstantiateContractResponse,
+    testing::mock_querier::{mock_dependencies_custom, MOCK_CW20_CONTRACT, MOCK_CW20_CONTRACT2},
 };
 use common::{ado_base::recipient::Recipient, app::AndrAddress, error::ContractError};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
+use prost::Message;
 
 const MOCK_ASTROPORT_WRAPPER_CONTRACT: &str = "astroport_wrapper";
 
@@ -85,10 +87,20 @@ fn test_instantiate_swapper_impl_new() {
         res
     );
 
+    let instantiate_reply = MsgInstantiateContractResponse {
+        contract_address: "swapper_impl_address".to_string(),
+        data: vec![],
+    };
+    let mut encoded_instantiate_reply = Vec::<u8>::with_capacity(instantiate_reply.encoded_len());
+
+    instantiate_reply
+        .encode(&mut encoded_instantiate_reply)
+        .unwrap();
+
     let reply_msg = Reply {
         id: 1,
         result: SubMsgResult::Ok(SubMsgResponse {
-            data: None,
+            data: Some(encoded_instantiate_reply.into()),
             events: vec![
                 Event::new("Type").add_attribute("contract_address", "swapper_impl_address")
             ],

--- a/contracts/non-fungible-tokens/andromeda-wrapped-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-wrapped-cw721/src/contract.rs
@@ -76,7 +76,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
     }
     require(msg.id == 1, ContractError::InvalidReplyId {})?;
 
-    let addr = get_reply_address(&msg)?;
+    let addr = get_reply_address(msg)?;
     ANDROMEDA_CW721_ADDR.save(deps.storage, &addr)?;
     Ok(Response::default())
 }

--- a/packages/andromeda-app/Cargo.toml
+++ b/packages/andromeda-app/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 schemars = "0.8.3"
 
 common = { path = "../common", version = "0.1.0" }
+

--- a/packages/andromeda-testing/Cargo.toml
+++ b/packages/andromeda-testing/Cargo.toml
@@ -15,8 +15,10 @@ crate-type = ["cdylib", "rlib"]
 cosmwasm-std = "1.0.0"
 cw721 = "0.13.2"
 cw20 = "0.13.2"
+prost = "0.9.0"
 
 common = { path = "../common", version = "0.1.0" }
 andromeda-non-fungible-tokens = { version = "0.1.0", path = "../andromeda-non-fungible-tokens" }
 andromeda-app = { version = "0.1.0", path = "../andromeda-app" }
 andromeda-modules = { version = "0.1.0", path = "../andromeda-modules" }
+

--- a/packages/andromeda-testing/src/lib.rs
+++ b/packages/andromeda-testing/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod reply;
 pub mod testing;

--- a/packages/andromeda-testing/src/reply.rs
+++ b/packages/andromeda-testing/src/reply.rs
@@ -1,0 +1,9 @@
+use prost::Message;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct MsgInstantiateContractResponse {
+    #[prost(string, tag = "1")]
+    pub contract_address: ::prost::alloc::string::String,
+    #[prost(bytes, tag = "2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{OverflowError, StdError};
 use cw20_base::ContractError as Cw20ContractError;
 use cw721_base::ContractError as Cw721ContractError;
-use cw_utils::Expiration;
+use cw_utils::{Expiration, ParseReplyError};
 use std::convert::From;
 use std::string::FromUtf8Error;
 use thiserror::Error;
@@ -15,6 +15,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     Hex(#[from] FromHexError),
+
+    #[error("{0}")]
+    ParseReply(#[from] ParseReplyError),
 
     #[error("Unauthorized")]
     Unauthorized {},

--- a/packages/common/src/response.rs
+++ b/packages/common/src/response.rs
@@ -1,16 +1,8 @@
-use cosmwasm_std::{Reply, StdError, StdResult};
+use crate::error::ContractError;
+use cosmwasm_std::Reply;
+use cw_utils::parse_reply_instantiate_data;
 
-pub fn get_reply_address(msg: &Reply) -> StdResult<String> {
-    let res = msg.result.clone().unwrap();
-    let events = &res.events;
-    for event in events.iter() {
-        for attr in event.attributes.iter() {
-            if attr.key == "contract_address" && !attr.value.is_empty() {
-                return Ok(attr.value.clone());
-            }
-        }
-    }
-    Err(StdError::generic_err(
-        "Could not parse reply contract address",
-    ))
+pub fn get_reply_address(msg: Reply) -> Result<String, ContractError> {
+    let res = parse_reply_instantiate_data(msg)?;
+    Ok(res.contract_address)
 }


### PR DESCRIPTION
# Motivation
There was a breaking change between versions 0.16 and 1 for how we handled retrieving the address of instantiated contracts, so we decided to rethink the approach and discovered a better way using the `cw-utils` package.

# Implementation
The `get_reply_address` function's implementation was replaced with one that calls `cw_utils::parse_reply_instantiate_data`. 

# Testing

## Unit/Integration tests
Using [this test](https://github.com/CosmWasm/cw-plus/blob/main/packages/utils/src/parse_reply.rs#L416) as a guide, I modified our tests for getting the reply address. This required declaring a custom struct to act as the protobuf, which I defined in a new `reply.rs` file in `andromeda-testing` to avoid duplication. 

## On-chain tests
Will be done as part of deployment on juno.

# Future work
n/a