### PR TITLE
Percentage splitter lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "schemars",
  "serde",

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -12,6 +12,8 @@ serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 schemars = "0.8.3"
 cw-storage-plus = "0.13.2"
 cw2 = "0.13.2"
+cw-utils = "0.13.4"
+
 
 andromeda-finance = { version = "0.1.0", path = "../../../packages/andromeda-finance" }
 ado-base = { path = "../../../packages/ado-base", version = "0.1.0", features = ["modules"] }

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -44,7 +44,7 @@ pub fn instantiate(
         ContractError::ReachedRecipientLimit {},
     )?;
     let current_time = env.block.time.seconds();
-    match msg.lock_time {
+    let splitter = match msg.lock_time {
         Some(lock_time) => {
             // New lock time can't be too short
             require(lock_time >= ONE_DAY, ContractError::LockTimeTooShort {})?;
@@ -52,21 +52,22 @@ pub fn instantiate(
             // New lock time can't be too long
             require(lock_time <= ONE_YEAR, ContractError::LockTimeTooLong {})?;
 
-            let splitter = Splitter {
+            Splitter {
                 recipients: msg.recipients,
                 lock: Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time)),
-            };
-            SPLITTER.save(deps.storage, &splitter)?;
+            }
         }
         None => {
-            let splitter = Splitter {
+            Splitter {
                 recipients: msg.recipients,
                 // If locking isn't desired upon instantiation, it's automatically set to 0
                 lock: Expiration::AtTime(Timestamp::from_seconds(current_time)),
-            };
-            SPLITTER.save(deps.storage, &splitter)?;
+            }
         }
-    }
+    };
+
+    SPLITTER.save(deps.storage, &splitter)?;
+
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -34,6 +34,11 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     msg.validate()?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    // Max 100 recipients
+    require(
+        msg.recipients.len() <= 100,
+        ContractError::ReachedRecipientLimit {},
+    )?;
     let current_time = env.block.time.seconds();
     let splitter = Splitter {
         recipients: msg.recipients,
@@ -190,6 +195,11 @@ fn execute_update_recipients(
     require(
         splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
+    )?;
+    // Max 100 recipients
+    require(
+        recipients.len() <= 100,
+        ContractError::ReachedRecipientLimit {},
     )?;
 
     splitter.recipients = recipients;

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -38,7 +38,7 @@ pub fn instantiate(
     let splitter = Splitter {
         recipients: msg.recipients,
         // If locking isn't desired upon instantiation, just set it to 0
-        locked: Expiration::AtTime(Timestamp::from_seconds(msg.lock_time + current_time)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(msg.lock_time + current_time)),
     };
 
     SPLITTER.save(deps.storage, &splitter)?;
@@ -188,7 +188,7 @@ fn execute_update_recipients(
     // Can't call this function while the lock isn't expired
 
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
 
@@ -220,7 +220,7 @@ fn execute_update_lock(
     // Can't call this function while the lock isn't expired
 
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
     // Get current time
@@ -235,7 +235,7 @@ fn execute_update_lock(
     // Set new lock time
     let new_lock = Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time));
 
-    splitter.locked = new_lock;
+    splitter.lock = new_lock;
 
     SPLITTER.save(deps.storage, &splitter)?;
 
@@ -306,7 +306,7 @@ mod tests {
         // Start off with an expiration that's behind current time (expired)
         let splitter = Splitter {
             recipients: vec![],
-            locked: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
+            lock: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
         };
 
         SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -341,8 +341,8 @@ mod tests {
 
         //check result
         let splitter = SPLITTER.load(deps.as_ref().storage).unwrap();
-        assert!(!splitter.locked.is_expired(&env.block));
-        assert_eq!(new_lock, splitter.locked);
+        assert!(!splitter.lock.is_expired(&env.block));
+        assert_eq!(new_lock, splitter.lock);
     }
 
     #[test]
@@ -368,7 +368,7 @@ mod tests {
 
         let splitter = Splitter {
             recipients: vec![],
-            locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+            lock: Expiration::AtTime(Timestamp::from_seconds(0)),
         };
 
         SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -433,7 +433,7 @@ mod tests {
 
         let splitter = Splitter {
             recipients: recipient,
-            locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+            lock: Expiration::AtTime(Timestamp::from_seconds(0)),
         };
 
         SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -484,7 +484,7 @@ mod tests {
         let env = mock_env();
         let splitter = Splitter {
             recipients: vec![],
-            locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+            lock: Expiration::AtTime(Timestamp::from_seconds(0)),
         };
 
         SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -536,7 +536,7 @@ mod tests {
 
         let splitter = Splitter {
             recipients: recipient,
-            locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+            lock: Expiration::AtTime(Timestamp::from_seconds(0)),
         };
 
         SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -324,7 +324,7 @@ mod tests {
                 percent: Decimal::one(),
             }],
             modules: None,
-            lock_time: Some(0),
+            lock_time: Some(100_000),
         };
         let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(0, res.messages.len());

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -36,6 +36,7 @@ fn test_modules() {
             recipient: Recipient::from_string(String::from("Some Address")),
             percent: Decimal::percent(100),
         }],
+        lock_time: 0,
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     let expected_res = Response::new()
@@ -102,6 +103,7 @@ fn test_update_app_contract() {
                 percent: Decimal::percent(50),
             },
         ],
+        lock_time: 0,
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -144,6 +146,7 @@ fn test_update_app_contract_invalid_recipient() {
             }),
             percent: Decimal::percent(100),
         }],
+        lock_time: 0,
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -36,7 +36,7 @@ fn test_modules() {
             recipient: Recipient::from_string(String::from("Some Address")),
             percent: Decimal::percent(100),
         }],
-        lock_time: 0,
+        lock_time: Some(0),
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     let expected_res = Response::new()
@@ -103,7 +103,7 @@ fn test_update_app_contract() {
                 percent: Decimal::percent(50),
             },
         ],
-        lock_time: 0,
+        lock_time: Some(0),
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -146,7 +146,7 @@ fn test_update_app_contract_invalid_recipient() {
             }),
             percent: Decimal::percent(100),
         }],
-        lock_time: 0,
+        lock_time: Some(0),
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -36,7 +36,7 @@ fn test_modules() {
             recipient: Recipient::from_string(String::from("Some Address")),
             percent: Decimal::percent(100),
         }],
-        lock_time: Some(0),
+        lock_time: Some(100_000),
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     let expected_res = Response::new()
@@ -103,7 +103,7 @@ fn test_update_app_contract() {
                 percent: Decimal::percent(50),
             },
         ],
-        lock_time: Some(0),
+        lock_time: None,
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -146,7 +146,7 @@ fn test_update_app_contract_invalid_recipient() {
             }),
             percent: Decimal::percent(100),
         }],
-        lock_time: Some(0),
+        lock_time: None,
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -349,7 +349,7 @@ fn execute_remove_recipient(
     recipient: Recipient,
 ) -> Result<Response, ContractError> {
     require(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+        ADOContract::default().is_owner_or_operator(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -399,7 +399,7 @@ fn execute_update_lock(
     lock_time: u64,
 ) -> Result<Response, ContractError> {
     require(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+        ADOContract::default().is_owner_or_operator(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -47,7 +47,7 @@ pub fn instantiate(
         ContractError::ReachedRecipientLimit {},
     )?;
     let current_time = env.block.time.seconds();
-    match msg.lock_time {
+    let splitter = match msg.lock_time {
         Some(lock_time) => {
             // New lock time can't be too short
             require(lock_time >= ONE_DAY, ContractError::LockTimeTooShort {})?;
@@ -55,21 +55,21 @@ pub fn instantiate(
             // New lock time can't be too long
             require(lock_time <= ONE_YEAR, ContractError::LockTimeTooLong {})?;
 
-            let splitter = Splitter {
+            Splitter {
                 recipients: msg.recipients,
                 lock: Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time)),
-            };
-            SPLITTER.save(deps.storage, &splitter)?;
+            }
         }
         None => {
-            let splitter = Splitter {
+            Splitter {
                 recipients: msg.recipients,
                 // If locking isn't desired upon instantiation, it's automatically set to 0
                 lock: Expiration::AtTime(Timestamp::from_seconds(current_time)),
-            };
-            SPLITTER.save(deps.storage, &splitter)?;
+            }
         }
-    }
+    };
+
+    SPLITTER.save(deps.storage, &splitter)?;
 
     ADOContract::default().instantiate(
         deps.storage,

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -44,7 +44,12 @@ pub fn instantiate(
     let current_time = env.block.time.seconds();
     match msg.lock_time {
         Some(lock_time) => {
+            // New lock time can't be too short (At least 1 day)
+            require(lock_time >= 86400, ContractError::LockTimeTooShort {})?;
+
+            // New lock time can't be too long (Max 1 year)
             require(lock_time <= 31_536_000, ContractError::LockTimeTooLong {})?;
+
             let splitter = Splitter {
                 recipients: msg.recipients,
                 lock: Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time)),

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -44,7 +44,7 @@ pub fn instantiate(
     let splitter = Splitter {
         recipients: msg.recipients,
         // If locking isn't desired upon instantiation, just set it to 0
-        locked: Expiration::AtTime(Timestamp::from_seconds(msg.lock_time + current_time)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(msg.lock_time + current_time)),
     };
 
     SPLITTER.save(deps.storage, &splitter)?;
@@ -137,7 +137,7 @@ pub fn execute_update_recipient_weight(
     let mut splitter = SPLITTER.load(deps.storage)?;
 
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
 
@@ -182,7 +182,7 @@ pub fn execute_add_recipient(
     // Can't add recipients while the lock isn't expired
 
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
 
@@ -211,7 +211,7 @@ pub fn execute_add_recipient(
     splitter.recipients.push(recipient);
     let new_splitter = Splitter {
         recipients: splitter.recipients,
-        locked: splitter.locked,
+        lock: splitter.lock,
     };
     SPLITTER.save(deps.storage, &new_splitter)?;
 
@@ -321,7 +321,7 @@ fn execute_update_recipients(
 
     // Can't update recipients while lock isn't expired
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
 
@@ -364,7 +364,7 @@ fn execute_remove_recipient(
     // Can't remove recipients while lock isn't expired
 
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
 
@@ -384,7 +384,7 @@ fn execute_remove_recipient(
         splitter.recipients.swap_remove(i);
         let new_splitter = Splitter {
             recipients: splitter.recipients,
-            locked: splitter.locked,
+            lock: splitter.lock,
         };
         SPLITTER.save(deps.storage, &new_splitter)?;
     };
@@ -414,7 +414,7 @@ fn execute_update_lock(
     // Can't call this function while the lock isn't expired
 
     require(
-        splitter.locked.is_expired(&env.block),
+        splitter.lock.is_expired(&env.block),
         ContractError::ContractLocked {},
     )?;
     // Get current time
@@ -429,7 +429,7 @@ fn execute_update_lock(
     // Set new lock time
     let new_lock = Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time));
 
-    splitter.locked = new_lock;
+    splitter.lock = new_lock;
 
     SPLITTER.save(deps.storage, &splitter)?;
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -28,6 +28,11 @@ use cw2::{get_contract_version, set_contract_version};
 const CONTRACT_NAME: &str = "crates.io:andromeda-weighted-splitter";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+// 1 day in seconds
+const ONE_DAY: u64 = 86_400;
+// 1 year in seconds
+const ONE_YEAR: u64 = 31_536_000;
+
 #[entry_point]
 pub fn instantiate(
     deps: DepsMut,
@@ -44,28 +49,17 @@ pub fn instantiate(
     let current_time = env.block.time.seconds();
     match msg.lock_time {
         Some(lock_time) => {
-            // New lock time can't be too short (At least 1 day)
-            require(lock_time >= 86400, ContractError::LockTimeTooShort {})?;
+            // New lock time can't be too short
+            require(lock_time >= ONE_DAY, ContractError::LockTimeTooShort {})?;
 
-            // New lock time can't be too long (Max 1 year)
-            require(lock_time <= 31_536_000, ContractError::LockTimeTooLong {})?;
+            // New lock time can't be too long
+            require(lock_time <= ONE_YEAR, ContractError::LockTimeTooLong {})?;
 
             let splitter = Splitter {
                 recipients: msg.recipients,
                 lock: Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time)),
             };
             SPLITTER.save(deps.storage, &splitter)?;
-            ADOContract::default().instantiate(
-                deps.storage,
-                deps.api,
-                info,
-                BaseInstantiateMsg {
-                    ado_type: "weighted-splitter".to_string(),
-                    operators: None,
-                    modules: msg.modules,
-                    primitive_contract: None,
-                },
-            )
         }
         None => {
             let splitter = Splitter {
@@ -74,19 +68,20 @@ pub fn instantiate(
                 lock: Expiration::AtTime(Timestamp::from_seconds(current_time)),
             };
             SPLITTER.save(deps.storage, &splitter)?;
-            ADOContract::default().instantiate(
-                deps.storage,
-                deps.api,
-                info,
-                BaseInstantiateMsg {
-                    ado_type: "weighted-splitter".to_string(),
-                    operators: None,
-                    modules: msg.modules,
-                    primitive_contract: None,
-                },
-            )
         }
     }
+
+    ADOContract::default().instantiate(
+        deps.storage,
+        deps.api,
+        info,
+        BaseInstantiateMsg {
+            ado_type: "weighted-splitter".to_string(),
+            operators: None,
+            modules: msg.modules,
+            primitive_contract: None,
+        },
+    )
 }
 
 #[entry_point]
@@ -448,11 +443,11 @@ fn execute_update_lock(
     // Get current time
     let current_time = env.block.time.seconds();
 
-    // New lock time can't be too short (At least 1 day)
-    require(lock_time >= 86400, ContractError::LockTimeTooShort {})?;
+    // New lock time can't be too short
+    require(lock_time >= ONE_DAY, ContractError::LockTimeTooShort {})?;
 
-    // New lock time can't be unreasonably long (No more than 1 year)
-    require(lock_time <= 31_536_000, ContractError::LockTimeTooLong {})?;
+    // New lock time can't be unreasonably long
+    require(lock_time <= ONE_YEAR, ContractError::LockTimeTooLong {})?;
 
     // Set new lock time
     let new_lock = Expiration::AtTime(Timestamp::from_seconds(lock_time + current_time));

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -42,7 +42,7 @@ fn test_modules() {
             recipient: Recipient::from_string(String::from("Some Address")),
             weight: Uint128::new(100),
         }],
-        lock_time: Some(10),
+        lock_time: None,
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     let expected_res = Response::new()
@@ -109,7 +109,7 @@ fn test_update_app_contract() {
                 weight: Uint128::new(50),
             },
         ],
-        lock_time: Some(10),
+        lock_time: None,
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -152,7 +152,7 @@ fn test_update_app_contract_invalid_recipient() {
             }),
             weight: Uint128::new(100),
         }],
-        lock_time: Some(10),
+        lock_time: Some(100_000),
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -182,7 +182,7 @@ fn test_instantiate() {
             weight: Uint128::new(1),
         }],
         modules: None,
-        lock_time: Some(10),
+        lock_time: None,
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     assert_eq!(0, res.messages.len());
@@ -323,7 +323,7 @@ fn test_execute_update_lock_already_locked() {
     let env = mock_env();
 
     let current_time = env.block.time.seconds();
-    let lock_time = 10_000;
+    let lock_time = 100_000;
 
     let owner = "creator";
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -201,7 +201,7 @@ fn test_execute_update_lock() {
     // Start off with an expiration that's behind current time (expired)
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -236,7 +236,7 @@ fn test_execute_update_lock() {
 
     //check result
     let splitter = SPLITTER.load(deps.as_ref().storage).unwrap();
-    assert!(!splitter.locked.is_expired(&env.block));
+    assert!(!splitter.lock.is_expired(&env.block));
 }
 
 #[test]
@@ -252,7 +252,7 @@ fn test_execute_update_lock_too_short() {
     // Start off with an expiration that's behind current time (expired)
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -291,7 +291,7 @@ fn test_execute_update_lock_too_long() {
     // Start off with an expiration that's behind current time (expired)
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -330,7 +330,7 @@ fn test_execute_update_lock_already_locked() {
     // Start off with an expiration that's ahead current time (unexpired)
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time + 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time + 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -369,7 +369,7 @@ fn test_execute_update_lock_unauthorized() {
 
     let splitter = Splitter {
         recipients: vec![],
-        locked: new_lock,
+        lock: new_lock,
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -439,7 +439,7 @@ fn test_execute_remove_recipient() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -464,7 +464,7 @@ fn test_execute_remove_recipient() {
                 weight: Uint128::new(60),
             },
         ],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
     assert_eq!(expected_splitter, splitter);
     assert_eq!(
@@ -528,7 +528,7 @@ fn test_execute_remove_recipient_not_on_list() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -588,7 +588,7 @@ fn test_execute_remove_recipient_contract_locked() {
     };
     let splitter = Splitter {
         recipients: recipient.clone(),
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -597,7 +597,7 @@ fn test_execute_remove_recipient_contract_locked() {
 
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(env.block.time.seconds() + 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(env.block.time.seconds() + 1)),
     };
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
 
@@ -704,7 +704,7 @@ fn test_update_recipient_weight() {
     };
     let splitter = Splitter {
         recipients: recipient.clone(),
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -714,7 +714,7 @@ fn test_update_recipient_weight() {
     // Works
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -745,7 +745,7 @@ fn test_update_recipient_weight() {
                 weight: Uint128::new(50),
             },
         ],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
     assert_eq!(expected_splitter, splitter);
 }
@@ -794,7 +794,7 @@ fn test_update_recipient_weight_locked_contract() {
     let current_time = env.block.time.seconds();
     let splitter = Splitter {
         recipients: recipient.clone(),
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time - 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -804,7 +804,7 @@ fn test_update_recipient_weight_locked_contract() {
     // Locked contract
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time + 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time + 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -868,7 +868,7 @@ fn test_update_recipient_weight_user_not_found() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -937,7 +937,7 @@ fn test_update_recipient_weight_invalid_weight() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -998,7 +998,7 @@ fn test_execute_add_recipient() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1040,7 +1040,7 @@ fn test_execute_add_recipient() {
                 weight: Uint128::new(100),
             },
         ],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
     assert_eq!(expected_splitter, splitter);
 
@@ -1100,7 +1100,7 @@ fn test_execute_add_recipient_duplicate_recipient() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1175,7 +1175,7 @@ fn test_execute_add_recipient_invalid_weight() {
     };
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1237,7 +1237,7 @@ fn test_execute_add_recipient_locked_contract() {
     let info = mock_info(owner, &[]);
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(env.block.time.seconds() + 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(env.block.time.seconds() + 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1298,7 +1298,7 @@ fn test_execute_update_recipients() {
 
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1366,7 +1366,7 @@ fn test_execute_update_recipients_invalid_weight() {
 
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1418,7 +1418,7 @@ fn test_execute_update_recipients_contract_locked() {
 
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(current_time + 1)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(current_time + 1)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1468,7 +1468,7 @@ fn test_execute_update_recipients_unauthorized() {
 
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1522,7 +1522,7 @@ fn test_execute_send() {
 
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     let info = mock_info(owner, &[Coin::new(10000_u128, "uluna")]);
@@ -1574,7 +1574,7 @@ fn test_query_splitter() {
     let env = mock_env();
     let splitter = Splitter {
         recipients: vec![],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1600,7 +1600,7 @@ fn test_query_user_weight() {
     };
     let splitter = Splitter {
         recipients: vec![user1, user2],
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1655,7 +1655,7 @@ fn test_execute_send_error() {
     );
     let splitter = Splitter {
         recipients: recipient.clone(),
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
@@ -1670,7 +1670,7 @@ fn test_execute_send_error() {
     let info = mock_info(owner, &[]);
     let splitter = Splitter {
         recipients: recipient,
-        locked: Expiration::AtTime(Timestamp::from_seconds(0)),
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
     };
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -42,7 +42,7 @@ fn test_modules() {
             recipient: Recipient::from_string(String::from("Some Address")),
             weight: Uint128::new(100),
         }],
-        lock_time: 10,
+        lock_time: Some(10),
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     let expected_res = Response::new()
@@ -109,7 +109,7 @@ fn test_update_app_contract() {
                 weight: Uint128::new(50),
             },
         ],
-        lock_time: 10,
+        lock_time: Some(10),
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -152,7 +152,7 @@ fn test_update_app_contract_invalid_recipient() {
             }),
             weight: Uint128::new(100),
         }],
-        lock_time: 10,
+        lock_time: Some(10),
     };
 
     let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -182,7 +182,7 @@ fn test_instantiate() {
             weight: Uint128::new(1),
         }],
         modules: None,
-        lock_time: 10,
+        lock_time: Some(10),
     };
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     assert_eq!(0, res.messages.len());

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -1506,7 +1506,7 @@ fn test_execute_send() {
     let recip_weight1 = Uint128::new(10); // Weight of 10
 
     let recip_address2 = "address2".to_string();
-    let recip_percent2 = Uint128::new(20); // Weight of 20
+    let recip_weight2 = Uint128::new(20); // Weight of 20
 
     let recipient = vec![
         AddressWeight {
@@ -1515,7 +1515,7 @@ fn test_execute_send() {
         },
         AddressWeight {
             recipient: Recipient::Addr(recip_address2.clone()),
-            weight: recip_percent2,
+            weight: recip_weight2,
         },
     ];
     let msg = ExecuteMsg::Send {};

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -4,6 +4,7 @@ use common::{
     require,
 };
 use cosmwasm_std::Decimal;
+use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,7 +20,7 @@ pub struct Splitter {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is sent the amount sent will be divided amongst these recipients depending on their assigned percentage.
     pub recipients: Vec<AddressPercent>,
     /// Whether or not the contract is currently locked. This restricts updating any config related fields.
-    pub locked: bool,
+    pub locked: Expiration,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -27,6 +28,7 @@ pub struct InstantiateMsg {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is
     /// sent the amount sent will be divided amongst these recipients depending on their assigned percentage.
     pub recipients: Vec<AddressPercent>,
+    pub lock_time: u64,
     pub modules: Option<Vec<Module>>,
 }
 
@@ -46,7 +48,7 @@ pub enum ExecuteMsg {
     },
     /// Used to lock/unlock the contract allowing the config to be updated.
     UpdateLock {
-        lock: bool,
+        lock_time: u64,
     },
     /// Divides any attached funds to the message amongst the recipients list.
     Send {},

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -28,7 +28,7 @@ pub struct InstantiateMsg {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is
     /// sent the amount sent will be divided amongst these recipients depending on their assigned percentage.
     pub recipients: Vec<AddressPercent>,
-    pub lock_time: u64,
+    pub lock_time: Option<u64>,
     pub modules: Option<Vec<Module>>,
 }
 

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -20,7 +20,7 @@ pub struct Splitter {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is sent the amount sent will be divided amongst these recipients depending on their assigned percentage.
     pub recipients: Vec<AddressPercent>,
     /// Whether or not the contract is currently locked. This restricts updating any config related fields.
-    pub locked: Expiration,
+    pub lock: Expiration,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -16,7 +16,7 @@ pub struct Splitter {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is sent the amount sent will be divided amongst these recipients depending on their assigned weight.
     pub recipients: Vec<AddressWeight>,
     /// Whether or not the contract is currently locked. This restricts updating any config related fields.
-    pub locked: Expiration,
+    pub lock: Expiration,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -24,7 +24,7 @@ pub struct InstantiateMsg {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is
     /// sent the amount sent will be divided amongst these recipients depending on their assigned weight.
     pub recipients: Vec<AddressWeight>,
-    pub lock_time: u64,
+    pub lock_time: Option<u64>,
     pub modules: Option<Vec<Module>>,
 }
 


### PR DESCRIPTION
# Motivation
The lock now depends on a set duration of time. Until that specified point in time is reached (between 1 day and 1 year), no changes can be made to the contract. This gives recipients a guarantee that their presence in the list and specific percentages won’t be altered while the contract’s locked. 

# Implementation
Same implementation for the lock as in the weighted distribution splitter.
Limited recipients to 100.
Setting a lock time is now optional during instantiation for both splitter contracts. If no time is included, it will set the current time as expiration.

# Testing
Unit and On-chain tests work as expected.
## Unit/Integration tests
Same test for the lock as in the weighted distribution splitter. 

## On-chain tests
[Store](https://testnet.mintscan.io/juno-testnet/txs/E2E70A4E2D66680462263B525C4B87341653EA44A43B1A9D3B0EFE5FF453D9DC) & [Instantiate](https://testnet.mintscan.io/juno-testnet/txs/407DF5BD89F3C9DED74ED2CEFB68072A4484D27996E54F7EF8BA435143581B9E) with two recipients
[UpdateLock(too_short)](https://testnet.mintscan.io/juno-testnet/txs/73ED6C401344E36F7982B6EF2F85C2F5C1724FCC1F62332ADDB8D80656586580)
[UpdateLock(too_long)](https://testnet.mintscan.io/juno-testnet/txs/A71D58CB20D569F55FFA8BD23CABA5C0726B6D4AC7DBF8C4F5F5CF3CB82E2338)
[UpdateLock](https://testnet.mintscan.io/juno-testnet/txs/FF822B42EF2EBDF83FB2AD6CA7C1D9BB77B2DC3D06CADD4428E2469258C6DBEA)
[ContractLocked](https://testnet.mintscan.io/juno-testnet/txs/77A38238CF3C95D4293B818C7DA5C72883F30C70403F109CB393168A81E713A9)
[ContractLocked(update_recipients)](https://testnet.mintscan.io/juno-testnet/txs/B5B53EB68F4B76AFFD058186C0C869E7DA3701C16CEDADD839D8BCCA55A655C5)

Nothing but the lock related code was altered, so I didn’t see the need for testing the rest of the functions. 

# Future work
We may want to add list of approved coins to avoid receiving random and unwanted ones. 
Decide on a cap for the number of recipients (using 100 for now).