### PR TITLE
Replacing require

### DIFF
--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -12,14 +12,14 @@ use common::{
     ado_base::{AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
-    parse_message, require,
+    parse_message,
     response::get_reply_address,
 };
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply, ReplyOn,
-    Response, StdError, Storage, SubMsg, WasmMsg,
+    ensure, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply,
+    ReplyOn, Response, StdError, Storage, SubMsg, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
 
@@ -38,7 +38,7 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     APP_NAME.save(deps.storage, &msg.name)?;
-    require(msg.app.len() <= 50, ContractError::TooManyAppComponents {})?;
+    ensure!(msg.app.len() <= 50, ContractError::TooManyAppComponents {});
 
     let sender = info.sender.to_string();
     let resp = ADOContract::default()
@@ -114,13 +114,13 @@ fn execute_add_app_component(
     component: AppComponent,
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
-    require(
+    ensure!(
         contract.is_contract_owner(storage, sender)?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let current_addr = ADO_ADDRESSES.may_load(storage, &component.name)?;
-    require(current_addr.is_none(), ContractError::NameAlreadyTaken {})?;
+    ensure!(current_addr.is_none(), ContractError::NameAlreadyTaken {});
 
     // This is a default value that will be overridden on `reply`.
     ADO_ADDRESSES.save(storage, &component.name, &Addr::unchecked(""))?;
@@ -147,10 +147,10 @@ fn execute_claim_ownership(
     sender: &str,
     name_opt: Option<String>,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         ADOContract::default().is_contract_owner(storage, sender)?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let mut msgs: Vec<SubMsg> = vec![];
     if let Some(name) = name_opt {
@@ -175,10 +175,10 @@ fn execute_message(
     msg: Binary,
 ) -> Result<Response, ContractError> {
     //Temporary until message sender attached to Andromeda Comms
-    require(
+    ensure!(
         ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let addr = ADO_ADDRESSES.load(deps.storage, name.as_str())?;
     let proxy_msg = SubMsg {
@@ -213,10 +213,10 @@ fn execute_update_address(
     addr: String,
 ) -> Result<Response, ContractError> {
     let ado_addr = ADO_ADDRESSES.load(deps.storage, &name)?;
-    require(
+    ensure!(
         has_update_address_privilege(deps.storage, info.sender.as_str(), ado_addr.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let new_addr = deps.api.addr_validate(&addr)?;
     ADO_ADDRESSES.save(deps.storage, &name, &new_addr)?;
@@ -238,20 +238,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/app/andromeda-factory/src/contract.rs
+++ b/contracts/app/andromeda-factory/src/contract.rs
@@ -10,10 +10,10 @@ use common::{
     ado_base::{AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
-    parse_message, require,
+    parse_message,
 };
 use cosmwasm_std::{
-    attr, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
 };
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;
@@ -91,10 +91,10 @@ pub fn create(
 ) -> Result<Response, ContractError> {
     //let config = read_config(deps.storage)?;
 
-    require(
+    ensure!(
         !is_address_defined(deps.storage, symbol)?,
-        ContractError::SymbolInUse {},
-    )?;
+        ContractError::SymbolInUse {}
+    );
     //TODO: make this work with new cw721
     Ok(Response::new())
 
@@ -177,11 +177,11 @@ pub fn update_address(
     symbol: String,
     new_address: String,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         is_creator(&deps, symbol.clone(), info.sender.to_string())?
             || ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     store_address(deps.storage, symbol, &new_address)?;
 
@@ -195,10 +195,10 @@ pub fn add_update_code_id(
     code_id_key: String,
     code_id: u64,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         ADOContract::default().is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     store_code_id(deps.storage, &code_id_key, code_id)?;
 
     Ok(Response::default().add_attributes(vec![
@@ -219,20 +219,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/data-storage/andromeda-primitive/src/contract.rs
+++ b/contracts/data-storage/andromeda-primitive/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError};
+use cosmwasm_std::{ensure, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError};
 use cw2::{get_contract_version, set_contract_version};
 
 use crate::state::{DATA, DEFAULT_KEY};
@@ -12,7 +12,6 @@ use common::{
     error::ContractError,
     parse_message,
     primitive::{GetValueResponse, Primitive},
-    require,
 };
 use cw_utils::nonpayable;
 use semver::Version;
@@ -69,10 +68,10 @@ pub fn execute_set_value(
     nonpayable(&info)?;
 
     let sender = info.sender.to_string();
-    require(
+    ensure!(
         ADOContract::default().is_owner_or_operator(deps.storage, &sender)?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     if value.is_invalid() {
         return Err(ContractError::InvalidPrimitive {});
     }
@@ -96,10 +95,10 @@ pub fn execute_delete_value(
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
     let sender = info.sender.to_string();
-    require(
+    ensure!(
         ADOContract::default().is_owner_or_operator(deps.storage, &sender)?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let key = get_key_or_default(&key);
     DATA.remove(deps.storage, key);
     Ok(Response::new()
@@ -119,20 +118,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/defunct/andromeda-astroport/src/contract.rs
+++ b/contracts/defunct/andromeda-astroport/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_binary, Addr, Api, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, QuerierWrapper, Response, SubMsg, Uint128, WasmMsg,
+    ensure, entry_point, from_binary, Addr, Api, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut,
+    Env, MessageInfo, QuerierWrapper, Response, SubMsg, Uint128, WasmMsg,
 };
 
 use crate::{
@@ -31,7 +31,6 @@ use common::{
     ado_base::{recipient::Recipient, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
-    require,
 };
 
 use cw2::{get_contract_version, set_contract_version};
@@ -139,10 +138,10 @@ fn execute_provide_liquidity(
     let sender = info.sender.as_str();
     let contract = ADOContract::default();
     let astroport_factory = contract.get_cached_address(deps.storage, ASTROPORT_FACTORY)?;
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, sender)?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let assets = [
         assets[0].check(deps.api, None)?,
@@ -228,10 +227,10 @@ fn execute_withdraw_liquidity(
 ) -> Result<Response, ContractError> {
     let sender = info.sender.as_str();
     let contract = ADOContract::default();
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, sender)?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let recipient = recipient.unwrap_or_else(|| Recipient::Addr(sender.to_owned()));
     let pair_info = query_pair_given_address(&deps.querier, pair_address)?;
     let lp_token_asset_info = AssetInfo::cw20(pair_info.liquidity_token.clone());
@@ -277,7 +276,7 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         !cw20_msg.amount.is_zero(),
         ContractError::InvalidFunds {
             msg: "Amount must be non-zero".to_string(),
@@ -452,7 +451,7 @@ pub fn execute_astroport_msg(
     contract_addr: String,
     msg_binary: Binary,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         funds.is_empty() || funds.len() == 1,
         ContractError::InvalidFunds {
             msg: "Astroport expects no funds or a single type of fund to be deposited.".to_string(),
@@ -479,7 +478,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
@@ -487,7 +486,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     )?;
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,

--- a/contracts/defunct/andromeda-astroport/src/staking.rs
+++ b/contracts/defunct/andromeda-astroport/src/staking.rs
@@ -12,7 +12,7 @@ use astroport::{
     generator::{Cw20HookMsg as GeneratorCw20HookMsg, ExecuteMsg as GeneratorExecuteMsg},
     staking::Cw20HookMsg as StakingCw20HookMsg,
 };
-use common::{encode_binary, error::ContractError, require};
+use common::{encode_binary, error::ContractError, ensure!};
 use cw20::Cw20ExecuteMsg;
 use cw_asset::AssetInfo;
 use std::cmp;
@@ -26,10 +26,10 @@ pub fn execute_stake_lp(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
     let astroport_generator = contract.get_cached_address(deps.storage, ASTROPORT_GENERATOR)?;
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let lp_token = AssetInfo::cw20(deps.api.addr_validate(&lp_token_contract)?);
     let balance = lp_token.query_balance(&deps.querier, env.contract.address)?;
     let amount = cmp::min(amount.unwrap_or(balance), balance);
@@ -58,10 +58,10 @@ pub fn execute_unstake_lp(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
     let astroport_generator = contract.get_cached_address(deps.storage, ASTROPORT_GENERATOR)?;
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let lp_token = deps.api.addr_validate(&lp_token_contract)?;
     let amount_staked = query_amount_staked(
         &deps.querier,
@@ -91,10 +91,10 @@ pub fn execute_claim_lp_staking_rewards(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
     let astroport_generator = contract.get_cached_address(deps.storage, ASTROPORT_GENERATOR)?;
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let lp_token = deps.api.addr_validate(&lp_token_contract)?;
     let lp_unstake_msg: CosmosMsg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: astroport_generator.clone(),
@@ -170,10 +170,10 @@ fn stake_or_unstake_astro(
     let astroport_astro = contract.get_cached_address(deps.storage, ASTROPORT_ASTRO)?;
     let astroport_xastro = contract.get_cached_address(deps.storage, ASTROPORT_XASTRO)?;
     let astroport_staking = contract.get_cached_address(deps.storage, ASTROPORT_STAKING)?;
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let (token_addr, msg, action) = if stake {
         (astroport_astro, StakingCw20HookMsg::Enter {}, "stake_astro")

--- a/contracts/defunct/andromeda-mirror/src/contract.rs
+++ b/contracts/defunct/andromeda-mirror/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_binary, Addr, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, Storage,
-    Uint128, WasmMsg,
+    ensure, from_binary, Addr, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
+    Storage, Uint128, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
 
@@ -14,9 +14,7 @@ use andromeda_ecosystem::mirror::{
     Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, MirrorLockExecuteMsg,
     MirrorMintCw20HookMsg, MirrorMintExecuteMsg, MirrorStakingExecuteMsg, QueryMsg,
 };
-use common::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError, require,
-};
+use common::{ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
 use terraswap::asset::AssetInfo as TerraSwapAssetInfo;
@@ -246,7 +244,7 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         !cw20_msg.amount.is_zero(),
         ContractError::InvalidFunds {
             msg: "Amount must be non-zero".to_string(),
@@ -346,11 +344,11 @@ pub fn execute_mirror_msg(
     contract_addr: String,
     msg_binary: Binary,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         ADOContract::default().is_owner_or_operator(deps.storage, sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
-    require(
+        ContractError::Unauthorized {}
+    );
+    ensure!(
         funds.is_empty() || funds.len() == 1,
         ContractError::InvalidFunds {
             msg: "Mirror expects zero or one coin to be sent".to_string(),
@@ -376,7 +374,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
@@ -384,7 +382,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     )?;
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,

--- a/contracts/defunct/andromeda-mirror/src/testing/tests.rs
+++ b/contracts/defunct/andromeda-mirror/src/testing/tests.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, coins, from_binary,
+    coin, coins, ensure, from_binary,
     testing::{mock_env, mock_info},
     to_binary, Addr, Binary, CosmosMsg, Decimal, Deps, DepsMut, MessageInfo, Order, Response,
     Uint128, WasmMsg,

--- a/contracts/ecosystem/andromeda-swapper/src/contract.rs
+++ b/contracts/ecosystem/andromeda-swapper/src/contract.rs
@@ -9,12 +9,11 @@ use common::{
     app::AndrAddress,
     encode_binary,
     error::ContractError,
-    require,
     response::get_reply_address,
 };
 use cosmwasm_std::{
-    entry_point, from_binary, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply,
-    Response, StdError, SubMsg, Uint128, WasmMsg,
+    ensure, entry_point, from_binary, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    Reply, Response, StdError, SubMsg, Uint128, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20Coin, Cw20ExecuteMsg, Cw20ReceiveMsg};
@@ -74,7 +73,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
             msg.result.unwrap_err(),
         )));
     }
-    require(msg.id == 1, ContractError::InvalidReplyId {})?;
+    ensure!(msg.id == 1, ContractError::InvalidReplyId {});
 
     let addr = get_reply_address(msg)?;
     SWAPPER_IMPL_ADDR.save(deps.storage, &AndrAddress { identifier: addr })?;
@@ -112,18 +111,18 @@ fn execute_swap(
     recipient: Option<Recipient>,
 ) -> Result<Response, ContractError> {
     let recipient = recipient.unwrap_or_else(|| Recipient::Addr(info.sender.to_string()));
-    require(
+    ensure!(
         info.funds.len() <= 1,
         ContractError::InvalidFunds {
             msg: "Must send at most one native coin".to_string(),
-        },
-    )?;
-    require(
+        }
+    );
+    ensure!(
         !info.funds.is_empty() && info.funds[0].amount > Uint128::zero(),
         ContractError::InvalidFunds {
             msg: "Must send funds to swap".to_string(),
-        },
-    )?;
+        }
+    );
 
     let coin = &info.funds[0];
     if let AssetInfo::Native(denom) = &ask_asset_info {
@@ -173,10 +172,10 @@ fn execute_send(
     ask_asset_info: AssetInfo,
     recipient: Recipient,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         info.sender == env.contract.address,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let msg: SubMsg = match &ask_asset_info {
         AssetInfo::Native(denom) => {
             let amount = ask_asset_info.query_balance(&deps.querier, env.contract.address)?;
@@ -214,12 +213,12 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         !cw20_msg.amount.is_zero(),
         ContractError::InvalidFunds {
             msg: "Amount must be non-zero".to_string(),
-        },
-    )?;
+        }
+    );
 
     match from_binary(&cw20_msg.msg)? {
         Cw20HookMsg::Swap {
@@ -315,20 +314,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/finance/andromeda-vesting/src/state.rs
+++ b/contracts/finance/andromeda-vesting/src/state.rs
@@ -1,7 +1,5 @@
-use common::{
-    ado_base::recipient::Recipient, error::ContractError, require, withdraw::WithdrawalType,
-};
-use cosmwasm_std::{Order, Storage, Uint128};
+use common::{ado_base::recipient::Recipient, error::ContractError, withdraw::WithdrawalType};
+use cosmwasm_std::{ensure, Order, Storage, Uint128};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, MultiIndex};
 use cw_utils::Duration;
 use schemars::JsonSchema;
@@ -79,10 +77,10 @@ pub(crate) fn save_new_batch(
     config: &Config,
 ) -> Result<(), ContractError> {
     let next_id = NEXT_ID.may_load(storage)?.unwrap_or(1);
-    require(
+    ensure!(
         next_id == 1 || config.is_multi_batch_enabled,
-        ContractError::MultiBatchNotSupported {},
-    )?;
+        ContractError::MultiBatchNotSupported {}
+    );
     batches().save(storage, next_id, &batch)?;
     NEXT_ID.save(storage, &(next_id + 1))?;
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -1725,7 +1725,7 @@ fn test_execute_send_error() {
     let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
 
     let expected_res = ContractError::InvalidFunds {
-        msg: "Require at least one coin to be sent".to_string(),
+        msg: "ensure! at least one coin to be sent".to_string(),
     };
 
     assert_eq!(res, expected_res);

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    ensure, from_binary, to_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, StdError, StdResult, Storage, SubMsg, Uint128, WasmMsg,
 };
 
@@ -10,7 +10,7 @@ use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, MigrateMsg, Qu
 use common::{
     ado_base::{hooks::AndromedaHook, AndromedaMsg, InstantiateMsg as BaseInstantiateMsg},
     error::ContractError,
-    require, Funds,
+    Funds,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20Coin, Cw20ExecuteMsg};
@@ -272,20 +272,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -3,7 +3,7 @@
 
 use cosmwasm_std::{
     ensure, entry_point, from_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, Timestamp, Uint128,
+    StdError, Uint128,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20ReceiveMsg;

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -3,7 +3,7 @@
 
 use cosmwasm_std::{
     ensure, entry_point, from_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, Uint128,
+    StdError, Timestamp, Uint128,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20ReceiveMsg;
@@ -569,7 +569,7 @@ fn is_withdraw_open(current_timestamp: u64, config: &Config) -> bool {
 /// @dev Helper function to calculate maximum % of NATIVE deposited that can be withdrawn
 /// @params current_timestamp : Current block timestamp
 /// @params config : Contract configuration
-fn allowed_withdrawal_percent(current_timestamp: u64, config: &Config) -> Decimal {
+pub fn allowed_withdrawal_percent(current_timestamp: u64, config: &Config) -> Decimal {
     let withdrawal_cutoff_init_point = config.init_timestamp + config.deposit_window;
 
     // Deposit window :: 100% withdrawals allowed

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -2,8 +2,8 @@
 // https://github.com/mars-protocol/mars-periphery/tree/main/contracts/lockdrop
 
 use cosmwasm_std::{
-    entry_point, from_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response, StdError,
-    Uint128,
+    ensure, entry_point, from_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
+    StdError, Uint128,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20ReceiveMsg;
@@ -14,9 +14,7 @@ use andromeda_fungible_tokens::lockdrop::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StateResponse,
     UserInfoResponse,
 };
-use common::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError, require,
-};
+use common::{ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError};
 
 use crate::state::{Config, State, CONFIG, STATE, USER_INFO};
 use cw_utils::nonpayable;
@@ -40,21 +38,21 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     // CHECK :: init_timestamp needs to be valid
-    require(
+    ensure!(
         msg.init_timestamp >= env.block.time.seconds(),
         ContractError::StartTimeInThePast {
             current_seconds: env.block.time.seconds(),
             current_block: env.block.height,
-        },
-    )?;
+        }
+    );
 
     // CHECK :: deposit_window,withdrawal_window need to be valid (withdrawal_window < deposit_window)
-    require(
+    ensure!(
         msg.deposit_window > 0
             && msg.withdrawal_window > 0
             && msg.withdrawal_window < msg.deposit_window,
-        ContractError::InvalidWindow {},
-    )?;
+        ContractError::InvalidWindow {}
+    );
 
     let config = Config {
         // bootstrap_contract_address: msg.bootstrap_contract,
@@ -117,20 +115,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
@@ -151,12 +149,12 @@ pub fn receive_cw20(
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     // CHECK :: Tokens sent > 0
-    require(
+    ensure!(
         !cw20_msg.amount.is_zero(),
         ContractError::InvalidFunds {
             msg: "Number of tokens should be > 0".to_string(),
-        },
-    )?;
+        }
+    );
 
     match from_binary(&cw20_msg.msg)? {
         Cw20HookMsg::IncreaseIncentives {} => {
@@ -192,17 +190,17 @@ pub fn execute_increase_incentives(
 ) -> Result<Response, ContractError> {
     let mut config = CONFIG.load(deps.storage)?;
 
-    require(
+    ensure!(
         info.sender == config.incentive_token,
         ContractError::InvalidFunds {
             msg: "Only incentive tokens are valid".to_string(),
-        },
-    )?;
+        }
+    );
 
-    require(
+    ensure!(
         is_withdraw_open(env.block.time.seconds(), &config),
-        ContractError::TokenAlreadyBeingDistributed {},
-    )?;
+        ContractError::TokenAlreadyBeingDistributed {}
+    );
 
     config.lockdrop_incentives += amount;
     CONFIG.save(deps.storage, &config)?;
@@ -223,34 +221,34 @@ pub fn execute_deposit_native(
     let depositor_address = info.sender;
 
     // CHECK :: Lockdrop deposit window open
-    require(
+    ensure!(
         is_deposit_open(env.block.time.seconds(), &config),
-        ContractError::DepositWindowClosed {},
-    )?;
+        ContractError::DepositWindowClosed {}
+    );
 
     // Check if multiple native coins sent by the user
-    require(
+    ensure!(
         info.funds.len() == 1,
         ContractError::InvalidFunds {
             msg: "Must deposit a single fund".to_string(),
-        },
-    )?;
+        }
+    );
 
     let native_token = info.funds.first().unwrap();
-    require(
+    ensure!(
         native_token.denom == config.native_denom,
         ContractError::InvalidFunds {
             msg: format!("Only {} accepted", config.native_denom),
-        },
-    )?;
+        }
+    );
 
     // CHECK ::: Amount needs to be valid
-    require(
+    ensure!(
         !native_token.amount.is_zero(),
         ContractError::InvalidFunds {
             msg: "Amount must be greater than 0".to_string(),
-        },
-    )?;
+        }
+    );
 
     // USER INFO :: RETRIEVE --> UPDATE
     let mut user_info = USER_INFO
@@ -288,36 +286,36 @@ pub fn execute_withdraw_native(
     let withdrawer_address = info.sender;
 
     // CHECK :: Lockdrop withdrawal window open
-    require(
+    ensure!(
         is_withdraw_open(env.block.time.seconds(), &config),
         ContractError::InvalidWithdrawal {
             msg: Some("Withdrawals not available".to_string()),
-        },
-    )?;
+        }
+    );
 
     // Check :: Amount should be within the allowed withdrawal limit bounds
     let max_withdrawal_percent = allowed_withdrawal_percent(env.block.time.seconds(), &config);
     let max_withdrawal_allowed = user_info.total_native_locked * max_withdrawal_percent;
     let withdraw_amount = withdraw_amount.unwrap_or(max_withdrawal_allowed);
-    require(
+    ensure!(
         withdraw_amount <= max_withdrawal_allowed,
         ContractError::InvalidWithdrawal {
             msg: Some(format!(
                 "Amount exceeds max allowed withdrawal limit of {}",
                 max_withdrawal_allowed
             )),
-        },
-    )?;
+        }
+    );
 
     // Update withdrawal flag after the deposit window
     if env.block.time.seconds() > config.init_timestamp + config.deposit_window {
         // CHECK :: Max 1 withdrawal allowed
-        require(
+        ensure!(
             !user_info.withdrawal_flag,
             ContractError::InvalidWithdrawal {
                 msg: Some("Max 1 withdrawal allowed".to_string()),
-            },
-        )?;
+            }
+        );
 
         user_info.withdrawal_flag = true;
     }
@@ -362,23 +360,23 @@ pub fn execute_enable_claims(
     //         bootstrap_contract_address.get_address(deps.api, &deps.querier, app_contract)?;
 
     //     // CHECK :: ONLY BOOTSTRAP CONTRACT CAN CALL THIS FUNCTION
-    //     require(
+    //     ensure!(
     //         info.sender == bootstrap_contract_address,
     //         ContractError::Unauthorized {},
     //     )?;
     // }
 
     // CHECK :: Claims can only be enabled after the deposit / withdrawal windows are closed
-    require(
+    ensure!(
         !is_withdraw_open(env.block.time.seconds(), &config),
-        ContractError::PhaseOngoing {},
-    )?;
+        ContractError::PhaseOngoing {}
+    );
 
     // CHECK ::: Claims are only enabled once
-    require(
+    ensure!(
         !state.are_claims_allowed,
-        ContractError::ClaimsAlreadyAllowed {},
-    )?;
+        ContractError::ClaimsAlreadyAllowed {}
+    );
     state.are_claims_allowed = true;
 
     STATE.save(deps.storage, &state)?;
@@ -399,15 +397,15 @@ pub fn execute_claim_rewards(
         .may_load(deps.storage, &user_address)?
         .unwrap_or_default();
 
-    require(
+    ensure!(
         !user_info.lockdrop_claimed,
-        ContractError::LockdropAlreadyClaimed {},
-    )?;
-    require(
+        ContractError::LockdropAlreadyClaimed {}
+    );
+    ensure!(
         !user_info.total_native_locked.is_zero(),
-        ContractError::NoLockup {},
-    )?;
-    require(state.are_claims_allowed, ContractError::ClaimsNotAllowed {})?;
+        ContractError::NoLockup {}
+    );
+    ensure!(state.are_claims_allowed, ContractError::ClaimsNotAllowed {});
 
     let total_incentives = config
         .lockdrop_incentives
@@ -441,31 +439,31 @@ fn execute_withdraw_proceeds(
     let config = CONFIG.load(deps.storage)?;
     let state = STATE.load(deps.storage)?;
     // CHECK :: Only Owner can call this function
-    require(
+    ensure!(
         ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     // CHECK :: Lockdrop withdrawal window should be closed
     let current_timestamp = env.block.time.seconds();
-    require(
+    ensure!(
         current_timestamp >= config.init_timestamp && !is_withdraw_open(current_timestamp, &config),
         ContractError::InvalidWithdrawal {
             msg: Some("Lockdrop withdrawals haven't concluded yet".to_string()),
-        },
-    )?;
+        }
+    );
 
     let native_token = Asset::native(config.native_denom, state.total_native_locked);
 
     let balance = native_token
         .info
         .query_balance(&deps.querier, env.contract.address)?;
-    require(
+    ensure!(
         balance >= state.total_native_locked,
         ContractError::InvalidWithdrawal {
             msg: Some("Already withdrew funds".to_string()),
-        },
-    )?;
+        }
+    );
 
     let transfer_msg = native_token.transfer_msg(recipient)?;
 

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{attr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError};
+use cosmwasm_std::{attr, ensure, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError};
 use cw2::{get_contract_version, set_contract_version};
 
 use crate::state::{add_address, includes_address, remove_address, IS_INCLUSIVE};
@@ -12,7 +12,7 @@ use common::{
     ado_base::{hooks::AndromedaHook, AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
-    parse_message, require,
+    parse_message,
 };
 use cw_utils::nonpayable;
 use semver::Version;
@@ -67,10 +67,10 @@ fn execute_add_address(
     address: String,
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
-    require(
+    ensure!(
         ADOContract::default().is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     add_address(deps.storage, &address)?;
 
     Ok(Response::new().add_attributes(vec![
@@ -86,10 +86,10 @@ fn execute_remove_address(
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
 
-    require(
+    ensure!(
         ADOContract::default().is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     remove_address(deps.storage, &address);
 
@@ -110,20 +110,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -11,11 +11,11 @@ use common::{
     },
     deduct_funds, encode_binary,
     error::ContractError,
-    parse_message, require, Funds,
+    parse_message, Funds,
 };
 use cosmwasm_std::{
-    attr, coin, entry_point, to_binary, Binary, Coin, Deps, DepsMut, Env, Event, MessageInfo,
-    Response, StdError, SubMsg,
+    attr, coin, ensure, entry_point, to_binary, Binary, Coin, Deps, DepsMut, Env, Event,
+    MessageInfo, Response, StdError, SubMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20Coin;
@@ -86,10 +86,10 @@ fn execute_update_rates(
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
 
-    require(
+    ensure!(
         ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let mut config = CONFIG.load(deps.storage)?;
     config.rates = rates;
     CONFIG.save(deps.storage, &config)?;
@@ -108,20 +108,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/modules/andromeda-receipt/src/contract.rs
+++ b/contracts/modules/andromeda-receipt/src/contract.rs
@@ -13,10 +13,11 @@ use common::{
     },
     encode_binary,
     error::ContractError,
-    parse_message, require,
+    parse_message,
 };
 use cosmwasm_std::{
-    attr, entry_point, Binary, Deps, DepsMut, Env, Event, MessageInfo, Response, StdError, Uint128,
+    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, Event, MessageInfo, Response, StdError,
+    Uint128,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw_utils::nonpayable;
@@ -76,10 +77,10 @@ fn execute_store_receipt(
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
 
-    require(
+    ensure!(
         can_mint_receipt(deps.storage, info.sender.as_ref())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     let receipt_id = increment_num_receipt(deps.storage)?;
     store_receipt(deps.storage, receipt_id, &receipt)?;
     Ok(Response::new().add_attributes(vec![
@@ -94,10 +95,10 @@ fn execute_edit_receipt(
     receipt_id: Uint128,
     receipt: Receipt,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         can_mint_receipt(deps.storage, info.sender.as_ref())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     read_receipt(deps.storage, receipt_id)?;
     store_receipt(deps.storage, receipt_id, &receipt)?;
 
@@ -119,20 +120,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -9,12 +9,12 @@ use andromeda_non_fungible_tokens::auction::{
 };
 use common::{
     ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError,
-    rates::get_tax_amount, require, Funds, OrderBy,
+    rates::get_tax_amount, Funds, OrderBy,
 };
 use cosmwasm_std::{
-    attr, coins, entry_point, from_binary, Addr, Api, BankMsg, Binary, BlockInfo, Coin, CosmosMsg,
-    Deps, DepsMut, Env, MessageInfo, QuerierWrapper, QueryRequest, Response, StdError, Storage,
-    SubMsg, Uint128, WasmMsg, WasmQuery,
+    attr, coins, ensure, entry_point, from_binary, Addr, Api, BankMsg, Binary, BlockInfo, Coin,
+    CosmosMsg, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, QueryRequest, Response, StdError,
+    Storage, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, Expiration, OwnerOfResponse};
@@ -134,26 +134,26 @@ fn execute_start_auction(
     coin_denom: String,
     whitelist: Option<Vec<Addr>>,
 ) -> Result<Response, ContractError> {
-    require(
+    ensure!(
         start_time != Expiration::Never {} && end_time != Expiration::Never {},
-        ContractError::ExpirationMustNotBeNever {},
-    )?;
-    require(
+        ContractError::ExpirationMustNotBeNever {}
+    );
+    ensure!(
         start_time.partial_cmp(&end_time) != None,
-        ContractError::ExpirationsMustBeOfSameType {},
-    )?;
-    require(
+        ContractError::ExpirationsMustBeOfSameType {}
+    );
+    ensure!(
         start_time < end_time,
-        ContractError::StartTimeAfterEndTime {},
-    )?;
+        ContractError::StartTimeAfterEndTime {}
+    );
     let block_time = block_to_expiration(&env.block, start_time).unwrap();
-    require(
+    ensure!(
         start_time > block_time,
         ContractError::StartTimeInThePast {
             current_seconds: env.block.time.seconds(),
             current_block: env.block.height,
-        },
-    )?;
+        }
+    );
 
     let auction_id = get_and_increment_next_auction_id(deps.storage, &token_id, &token_address)?;
     BIDS.save(deps.storage, auction_id.u128(), &vec![])?;
@@ -203,33 +203,33 @@ fn execute_update_auction(
 
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
-    require(
+    ensure!(
         info.sender == token_auction_state.owner,
-        ContractError::Unauthorized {},
-    )?;
-    require(
+        ContractError::Unauthorized {}
+    );
+    ensure!(
         !token_auction_state.start_time.is_expired(&env.block),
-        ContractError::AuctionAlreadyStarted {},
-    )?;
-    require(
+        ContractError::AuctionAlreadyStarted {}
+    );
+    ensure!(
         start_time != Expiration::Never {} && end_time != Expiration::Never {},
-        ContractError::ExpirationMustNotBeNever {},
-    )?;
-    require(
+        ContractError::ExpirationMustNotBeNever {}
+    );
+    ensure!(
         start_time.partial_cmp(&end_time) != None,
-        ContractError::ExpirationsMustBeOfSameType {},
-    )?;
-    require(
+        ContractError::ExpirationsMustBeOfSameType {}
+    );
+    ensure!(
         start_time < end_time,
-        ContractError::StartTimeAfterEndTime {},
-    )?;
-    require(
+        ContractError::StartTimeAfterEndTime {}
+    );
+    ensure!(
         !start_time.is_expired(&env.block),
         ContractError::StartTimeInThePast {
             current_seconds: env.block.time.seconds(),
             current_block: env.block.height,
-        },
-    )?;
+        }
+    );
 
     token_auction_state.start_time = start_time;
     token_auction_state.end_time = end_time;
@@ -260,55 +260,55 @@ fn execute_place_bid(
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
 
-    require(
+    ensure!(
         !token_auction_state.is_cancelled,
-        ContractError::AuctionCancelled {},
-    )?;
+        ContractError::AuctionCancelled {}
+    );
 
-    require(
+    ensure!(
         token_auction_state.start_time.is_expired(&env.block),
-        ContractError::AuctionNotStarted {},
-    )?;
-    require(
+        ContractError::AuctionNotStarted {}
+    );
+    ensure!(
         !token_auction_state.end_time.is_expired(&env.block),
-        ContractError::AuctionEnded {},
-    )?;
+        ContractError::AuctionEnded {}
+    );
 
-    require(
+    ensure!(
         token_auction_state.owner != info.sender,
-        ContractError::TokenOwnerCannotBid {},
-    )?;
+        ContractError::TokenOwnerCannotBid {}
+    );
 
-    require(
+    ensure!(
         info.funds.len() == 1,
         ContractError::InvalidFunds {
-            msg: "Auctions require exactly one coin to be sent.".to_string(),
-        },
-    )?;
+            msg: "Auctions ensure! exactly one coin to be sent.".to_string(),
+        }
+    );
     if let Some(ref whitelist) = token_auction_state.whitelist {
-        require(
+        ensure!(
             whitelist.iter().any(|x| x == &info.sender),
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
     }
 
-    require(
+    ensure!(
         token_auction_state.high_bidder_addr != info.sender,
-        ContractError::HighestBidderCannotOutBid {},
-    )?;
+        ContractError::HighestBidderCannotOutBid {}
+    );
 
     let coin_denom = token_auction_state.coin_denom.clone();
     let payment: &Coin = &info.funds[0];
-    require(
+    ensure!(
         payment.denom == coin_denom && payment.amount > Uint128::zero(),
         ContractError::InvalidFunds {
             msg: format!("No {} assets are provided to auction", coin_denom),
-        },
-    )?;
-    require(
+        }
+    );
+    ensure!(
         token_auction_state.high_bidder_amount < payment.amount,
-        ContractError::BidSmallerThanHighestBid {},
-    )?;
+        ContractError::BidSmallerThanHighestBid {}
+    );
 
     let mut messages: Vec<CosmosMsg> = vec![];
     // Send back previous bid unless there was no previous bid.
@@ -354,14 +354,14 @@ fn execute_cancel(
 
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
-    require(
+    ensure!(
         info.sender == token_auction_state.owner,
-        ContractError::Unauthorized {},
-    )?;
-    require(
+        ContractError::Unauthorized {}
+    );
+    ensure!(
         !token_auction_state.end_time.is_expired(&env.block),
-        ContractError::AuctionEnded {},
-    )?;
+        ContractError::AuctionEnded {}
+    );
     let mut messages: Vec<CosmosMsg> = vec![CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: token_auction_state.token_address.clone(),
         msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
@@ -402,22 +402,22 @@ fn execute_claim(
     nonpayable(&info)?;
     let token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
-    require(
+    ensure!(
         token_auction_state.end_time.is_expired(&env.block),
-        ContractError::AuctionNotEnded {},
-    )?;
+        ContractError::AuctionNotEnded {}
+    );
     let token_owner = query_owner_of(
         deps.querier,
         token_auction_state.token_address.clone(),
         token_id.clone(),
     )?
     .owner;
-    require(
+    ensure!(
         // If this is false then the token is no longer held by the contract so the token has been
         // claimed.
         token_owner == env.contract.address,
-        ContractError::AuctionAlreadyClaimed {},
-    )?;
+        ContractError::AuctionAlreadyClaimed {}
+    );
     // This is the case where no-one bid on the token.
     if token_auction_state.high_bidder_amount.is_zero() {
         return Ok(Response::new()
@@ -682,20 +682,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
@@ -975,7 +975,7 @@ mod tests {
         env.block.time = Timestamp::from_seconds(150);
 
         let error = ContractError::InvalidFunds {
-            msg: "Auctions require exactly one coin to be sent.".to_string(),
+            msg: "Auctions ensure! exactly one coin to be sent.".to_string(),
         };
         let msg = ExecuteMsg::PlaceBid {
             token_id: MOCK_UNCLAIMED_TOKEN.to_string(),

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -90,9 +90,6 @@ pub fn execute(
             token_id,
             token_address,
         } => execute_claim(deps, env, info, token_id, token_address),
-        ExecuteMsg::UpdateOwner { address } => {
-            ADOContract::default().execute_update_owner(deps, info, address)
-        }
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/state.rs
@@ -1,6 +1,6 @@
 use andromeda_non_fungible_tokens::auction::{AuctionStateResponse, Bid};
 use common::{error::ContractError, OrderBy};
-use cosmwasm_std::{Addr, Order, StdResult, Storage, SubMsg, Uint128};
+use cosmwasm_std::{Addr, Order, StdResult, Storage, Uint128};
 use cw721::Expiration;
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 use schemars::JsonSchema;
@@ -23,18 +23,6 @@ pub struct TokenAuctionState {
     pub token_id: String,
     pub token_address: String,
     pub is_cancelled: bool,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Purchase {
-    /// The token id being purchased.
-    pub token_id: String,
-    /// Amount of tax paid.
-    pub tax_amount: Uint128,
-    /// sub messages for sending funds for rates.
-    pub msgs: Vec<SubMsg>,
-    /// The purchaser of the token.
-    pub purchaser: String,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/contracts/non-fungible-tokens/andromeda-cw721-timelock/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721-timelock/src/contract.rs
@@ -60,9 +60,6 @@ pub fn execute(
         }
         ExecuteMsg::ReceiveNft(msg) => handle_receive_cw721(deps, env, info, msg),
         ExecuteMsg::Claim { lock_id } => execute_claim(deps, env, info, lock_id),
-        ExecuteMsg::UpdateOwner { address } => {
-            ADOContract::default().execute_update_owner(deps, info, address)
-        }
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-cw721-timelock/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721-timelock/src/contract.rs
@@ -2,11 +2,9 @@ use ado_base::state::ADOContract;
 use andromeda_non_fungible_tokens::cw721_timelock::{
     Cw721HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
 };
-use common::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError, require,
-};
+use common::{ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError};
 use cosmwasm_std::{
-    entry_point, from_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
+    ensure, entry_point, from_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
     StdError, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
@@ -99,17 +97,17 @@ fn execute_lock(
     andromeda_cw721_contract: String,
 ) -> Result<Response, ContractError> {
     // Lock time can't be too long
-    require(lock_time <= ONE_YEAR, ContractError::LockTimeTooLong {})?;
+    ensure!(lock_time <= ONE_YEAR, ContractError::LockTimeTooLong {});
 
     // Lock time can't be too short
-    require(lock_time >= ONE_DAY, ContractError::LockTimeTooShort {})?;
+    ensure!(lock_time >= ONE_DAY, ContractError::LockTimeTooShort {});
 
     // Concatenate NFT's contract address and ID to form a unique ID for each NFT
     let lock_id = format!("{andromeda_cw721_contract}{nft_id}");
 
     // Make sure NFT isn't already locked in this contract
     let lock_id_check = LOCKED_ITEMS.may_load(deps.storage, &lock_id)?;
-    require(lock_id_check.is_none(), ContractError::LockedNFT {})?;
+    ensure!(lock_id_check.is_none(), ContractError::LockedNFT {});
 
     // Validate recipient's address if given, and set the sender as recipient if none was provided
     let recip = if let Some(recipient) = recipient {
@@ -152,10 +150,10 @@ fn execute_claim(
     if let Some(locked_nft) = locked_item {
         // Check if lock is expired
         let expiration = locked_nft.expiration;
-        require(
+        ensure!(
             expiration.is_expired(&env.block),
-            ContractError::LockedNFT {},
-        )?;
+            ContractError::LockedNFT {}
+        );
 
         // Remove NFT from the list of locked items
         LOCKED_ITEMS.remove(deps.storage, &lock_id);
@@ -203,20 +201,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, has_coins, to_binary, Addr, Api, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty,
-    Env, MessageInfo, QuerierWrapper, Response, StdError, Storage, SubMsg, Uint128,
+    attr, ensure, has_coins, to_binary, Addr, Api, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut,
+    Empty, Env, MessageInfo, QuerierWrapper, Response, StdError, Storage, SubMsg, Uint128,
 };
 
 use crate::state::{is_archived, ANDR_MINTER, ARCHIVED, TRANSFER_AGREEMENTS};
@@ -21,7 +21,7 @@ use common::{
     encode_binary,
     error::ContractError,
     rates::get_tax_amount,
-    require, Funds,
+    Funds,
 };
 use cw721::ContractInfoResponse;
 use cw721_base::{state::TokenInfo, Cw721Contract, MintMsg};
@@ -105,10 +105,10 @@ pub fn execute(
     )?;
 
     if let ExecuteMsg::Approve { token_id, .. } = &msg {
-        require(
+        ensure!(
             !is_archived(execute_env.deps.storage, token_id)?,
-            ContractError::TokenIsArchived {},
-        )?;
+            ContractError::TokenIsArchived {}
+        );
     }
 
     match msg {
@@ -225,10 +225,10 @@ fn execute_transfer(
 
     let contract = AndrCW721Contract::default();
     let mut token = contract.tokens.load(deps.storage, &token_id)?;
-    require(
+    ensure!(
         !is_archived(deps.storage, &token_id)?,
-        ContractError::TokenIsArchived {},
-    )?;
+        ContractError::TokenIsArchived {}
+    );
 
     let tax_amount = if let Some(agreement) =
         &TRANSFER_AGREEMENTS.may_load(deps.storage, &token_id)?
@@ -259,10 +259,10 @@ fn execute_transfer(
         Uint128::zero()
     };
 
-    require(
+    ensure!(
         !is_archived(deps.storage, &token_id)?,
-        ContractError::TokenIsArchived {},
-    )?;
+        ContractError::TokenIsArchived {}
+    );
     check_can_send(deps.as_ref(), env, info, &token_id, &token, tax_amount)?;
     token.owner = deps.api.addr_validate(&recipient)?;
     token.approvals.clear();
@@ -308,7 +308,7 @@ fn check_can_send(
         let app_contract = ADOContract::default().get_app_contract(deps.storage)?;
         let agreement_amount =
             get_transfer_agreement_amount(deps.api, &deps.querier, app_contract, agreement)?;
-        require(
+        ensure!(
             has_coins(
                 &info.funds,
                 &Coin {
@@ -317,8 +317,8 @@ fn check_can_send(
                     amount: agreement_amount.amount + tax_amount,
                 },
             ),
-            ContractError::InsufficientFunds {},
-        )?;
+            ContractError::InsufficientFunds {}
+        );
         if agreement.purchaser == info.sender || agreement.purchaser == "*" {
             return Ok(());
         }
@@ -357,11 +357,11 @@ fn execute_update_transfer_agreement(
     let ExecuteEnv { deps, info, .. } = env;
     let contract = AndrCW721Contract::default();
     let token = contract.tokens.load(deps.storage, &token_id)?;
-    require(token.owner == info.sender, ContractError::Unauthorized {})?;
-    require(
+    ensure!(token.owner == info.sender, ContractError::Unauthorized {});
+    ensure!(
         !is_archived(deps.storage, &token_id)?,
-        ContractError::TokenIsArchived {},
-    )?;
+        ContractError::TokenIsArchived {}
+    );
     if let Some(xfer_agreement) = &agreement {
         TRANSFER_AGREEMENTS.save(deps.storage, &token_id, xfer_agreement)?;
         if xfer_agreement.purchaser != "*" {
@@ -380,13 +380,13 @@ fn execute_update_transfer_agreement(
 
 fn execute_archive(env: ExecuteEnv, token_id: String) -> Result<Response, ContractError> {
     let ExecuteEnv { deps, info, .. } = env;
-    require(
+    ensure!(
         !is_archived(deps.storage, &token_id)?,
-        ContractError::TokenIsArchived {},
-    )?;
+        ContractError::TokenIsArchived {}
+    );
     let contract = AndrCW721Contract::default();
     let token = contract.tokens.load(deps.storage, &token_id)?;
-    require(token.owner == info.sender, ContractError::Unauthorized {})?;
+    ensure!(token.owner == info.sender, ContractError::Unauthorized {});
 
     ARCHIVED.save(deps.storage, &token_id, &true)?;
 
@@ -399,11 +399,11 @@ fn execute_burn(env: ExecuteEnv, token_id: String) -> Result<Response, ContractE
     let ExecuteEnv { deps, info, .. } = env;
     let contract = AndrCW721Contract::default();
     let token = contract.tokens.load(deps.storage, &token_id)?;
-    require(token.owner == info.sender, ContractError::Unauthorized {})?;
-    require(
+    ensure!(token.owner == info.sender, ContractError::Unauthorized {});
+    ensure!(
         !is_archived(deps.storage, &token_id)?,
-        ContractError::TokenIsArchived {},
-    )?;
+        ContractError::TokenIsArchived {}
+    );
 
     contract.tokens.remove(deps.storage, &token_id)?;
 
@@ -475,20 +475,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/contracts/non-fungible-tokens/andromeda-gumball/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-gumball/src/contract.rs
@@ -12,12 +12,11 @@ use common::{
     ado_base::{recipient::Recipient, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
-    require,
 };
 use cosmwasm_std::{attr, entry_point, Binary, Storage};
 use cosmwasm_std::{
-    Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest, Response, StdError, Uint128,
-    WasmMsg, WasmQuery,
+    ensure, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest, Response, StdError,
+    Uint128, WasmMsg, WasmQuery,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw_utils::nonpayable;
@@ -91,10 +90,10 @@ fn execute_update_required_coin(
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         contract.is_owner_or_operator(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     REQUIRED_COIN.save(deps.storage, &new_coin)?;
 
@@ -108,13 +107,13 @@ fn execute_switch_status(deps: DepsMut, info: MessageInfo) -> Result<Response, C
 
     let contract = ADOContract::default();
     let mut status = STATUS.load(deps.storage)?;
-    require(
+    ensure!(
         contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     // in case owner forgot to set the state, can't allow purchasing without the sale details set
     let state = STATE.may_load(deps.storage)?;
-    require(state.is_some(), ContractError::PriceNotSet {})?;
+    ensure!(state.is_some(), ContractError::PriceNotSet {});
     // Automatically switch to opposite status
     status = !status;
     STATUS.save(deps.storage, &status)?;
@@ -134,29 +133,29 @@ fn execute_sale_details(
     let contract = ADOContract::default();
     let status = STATUS.load(deps.storage)?;
     // Check status, can't change sale details while buying is allowed
-    require(!status, ContractError::Refilling {})?;
+    ensure!(!status, ContractError::Refilling {});
     // Check authority
-    require(
+    ensure!(
         contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
     // Check valid amount
-    require(!price.amount.is_zero(), ContractError::InvalidZeroAmount {})?;
+    ensure!(!price.amount.is_zero(), ContractError::InvalidZeroAmount {});
     // Check valid denomination
     let required_coin = REQUIRED_COIN.load(deps.storage)?;
-    require(
+    ensure!(
         price.denom == required_coin,
         ContractError::InvalidFunds {
             msg: "Please send the required coin".to_string(),
-        },
-    )?;
+        }
+    );
     // Check valid max amount per wallet
     let max_amount_per_wallet = max_amount_per_wallet.unwrap_or_else(|| Uint128::from(1u128));
 
-    require(
+    ensure!(
         !max_amount_per_wallet.is_zero(),
-        ContractError::InvalidZeroAmount {},
-    )?;
+        ContractError::InvalidZeroAmount {}
+    );
     // This is to prevent cloning price.
     let price_str = price.to_string();
 
@@ -189,21 +188,21 @@ fn execute_mint(
 ) -> Result<Response, ContractError> {
     nonpayable(&info)?;
 
-    require(
+    ensure!(
         mint_msgs.len() <= MAX_MINT_LIMIT as usize,
         ContractError::TooManyMintMessages {
             limit: MAX_MINT_LIMIT,
-        },
-    )?;
+        }
+    );
     let status = STATUS.load(deps.storage)?;
     // Can only mint when in "refill" mode, and that's when status is set to false.
-    require(!status, ContractError::NotInRefillMode {})?;
+    ensure!(!status, ContractError::NotInRefillMode {});
     let contract = ADOContract::default();
     // check authority
-    require(
+    ensure!(
         contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+        ContractError::Unauthorized {}
+    );
 
     let app_contract = contract.get_app_contract(deps.storage)?;
 
@@ -262,34 +261,34 @@ fn mint(
 fn execute_buy(deps: DepsMut, _env: Env, info: MessageInfo) -> Result<Response, ContractError> {
     let status = STATUS.load(deps.storage)?;
     // check gumball's status
-    require(status, ContractError::Refilling {})?;
+    ensure!(status, ContractError::Refilling {});
     let mut list = LIST.load(deps.storage)?;
     let n_of_nfts = list.len();
     // check if we still have any NFTs left
-    require(n_of_nfts > 0, ContractError::OutOfNFTs {})?;
+    ensure!(n_of_nfts > 0, ContractError::OutOfNFTs {});
     // check if more than one type of coin was sent
-    require(
+    ensure!(
         info.funds.len() == 1,
         ContractError::InvalidFunds {
             msg: "Only one type of coin is allowed.".to_string(),
-        },
-    )?;
+        }
+    );
     let sent_funds = &info.funds[0];
     let required_coin = REQUIRED_COIN.load(deps.storage)?;
     // check for correct denomination
-    require(
+    ensure!(
         sent_funds.denom == required_coin,
         ContractError::InvalidFunds {
             msg: "Please send the required coin".to_string(),
-        },
-    )?;
+        }
+    );
 
     let state = STATE.load(deps.storage)?;
     // check for correct amount of funds
-    require(
+    ensure!(
         sent_funds.amount == state.price.amount,
-        ContractError::InsufficientFunds {},
-    )?;
+        ContractError::InsufficientFunds {}
+    );
     let randomness_source = RANDOMNESS_PROVIDER.load(deps.storage)?;
     let random_response: LatestRandomResponse =
         deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
@@ -343,20 +342,20 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     let contract = ADOContract::default();
 
-    require(
+    ensure!(
         stored.contract == CONTRACT_NAME,
         ContractError::CannotMigrate {
             previous_contract: stored.contract,
-        },
-    )?;
+        }
+    );
 
     // New version has to be newer/greater than the old version
-    require(
+    ensure!(
         storage_version < version,
         ContractError::CannotMigrate {
             previous_contract: stored.version,
-        },
-    )?;
+        }
+    );
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 

--- a/packages/ado-base/src/app.rs
+++ b/packages/ado-base/src/app.rs
@@ -1,9 +1,9 @@
-use cosmwasm_std::{Addr, Api, Deps, QuerierWrapper, Storage};
+use cosmwasm_std::{ensure, Addr, Api, Deps, QuerierWrapper, Storage};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::ADOContract;
-use common::{app::AndrAddress, error::ContractError, require};
+use common::{app::AndrAddress, error::ContractError};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -22,10 +22,10 @@ impl<'a> ADOContract<'a> {
         mut addresses: Vec<AndrAddress>,
     ) -> Result<(), ContractError> {
         let app_contract = self.get_app_contract(deps.storage)?;
-        require(
+        ensure!(
             app_contract.is_some(),
-            ContractError::AppContractNotSpecified {},
-        )?;
+            ContractError::AppContractNotSpecified {}
+        );
         #[cfg(feature = "modules")]
         {
             let modules = self.load_modules(deps.storage)?;
@@ -57,10 +57,10 @@ impl<'a> ADOContract<'a> {
         // If the address passes this check then it doesn't refer to a app component by
         // name.
         if api.addr_validate(&identifier).is_err() {
-            require(
+            ensure!(
                 self.component_exists(querier, identifier.clone(), app_contract)?,
-                ContractError::InvalidComponent { name: identifier },
-            )?;
+                ContractError::InvalidComponent { name: identifier }
+            );
         }
         Ok(())
     }

--- a/packages/ado-base/src/execute.rs
+++ b/packages/ado-base/src/execute.rs
@@ -3,10 +3,10 @@ use common::{
     ado_base::{modules::Module, AndromedaMsg, ExecuteMsg, InstantiateMsg},
     app::AndrAddress,
     error::ContractError,
-    parse_message, require,
+    parse_message,
 };
 use cosmwasm_std::{
-    attr, Api, DepsMut, Env, MessageInfo, Order, QuerierWrapper, Response, Storage,
+    attr, ensure, Api, DepsMut, Env, MessageInfo, Order, QuerierWrapper, Response, Storage,
 };
 use serde::de::DeserializeOwned;
 
@@ -53,10 +53,10 @@ impl<'a> ADOContract<'a> {
     ) -> Result<Response, ContractError> {
         match msg {
             AndromedaMsg::Receive(data) => {
-                require(
+                ensure!(
                     !self.is_nested::<ExecuteMsg>(&data),
-                    ContractError::NestedAndromedaMsg {},
-                )?;
+                    ContractError::NestedAndromedaMsg {}
+                );
                 let received: E = parse_message(&data)?;
                 (execute_function)(deps, env, info, received)
             }
@@ -126,10 +126,10 @@ impl<'a> ADOContract<'a> {
         info: MessageInfo,
         new_owner: String,
     ) -> Result<Response, ContractError> {
-        require(
+        ensure!(
             self.is_contract_owner(deps.storage, info.sender.as_str())?,
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
         let new_owner_addr = deps.api.addr_validate(&new_owner)?;
         self.owner.save(deps.storage, &new_owner_addr)?;
 
@@ -145,10 +145,10 @@ impl<'a> ADOContract<'a> {
         info: MessageInfo,
         operators: Vec<String>,
     ) -> Result<Response, ContractError> {
-        require(
+        ensure!(
             self.is_contract_owner(deps.storage, info.sender.as_str())?,
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
 
         let keys: Vec<String> = self
             .operators
@@ -172,10 +172,10 @@ impl<'a> ADOContract<'a> {
         address: String,
         addresses: Option<Vec<AndrAddress>>,
     ) -> Result<Response, ContractError> {
-        require(
+        ensure!(
             self.is_contract_owner(deps.storage, info.sender.as_str())?,
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
         self.app_contract
             .save(deps.storage, &deps.api.addr_validate(&address)?)?;
         self.validate_andr_addresses(deps.as_ref(), addresses.unwrap_or_default())?;

--- a/packages/ado-base/src/modules/execute.rs
+++ b/packages/ado-base/src/modules/execute.rs
@@ -1,6 +1,6 @@
 use crate::ADOContract;
-use common::{ado_base::modules::Module, error::ContractError, require};
-use cosmwasm_std::{DepsMut, MessageInfo, Response, Storage, Uint64};
+use common::{ado_base::modules::Module, error::ContractError};
+use cosmwasm_std::{ensure, DepsMut, MessageInfo, Response, Storage, Uint64};
 
 impl<'a> ADOContract<'a> {
     /// A wrapper for `fn register_module`. The parameters are "extracted" from `DepsMut` to be able to
@@ -12,10 +12,10 @@ impl<'a> ADOContract<'a> {
         module: Module,
         should_validate: bool,
     ) -> Result<Response, ContractError> {
-        require(
+        ensure!(
             self.is_owner_or_operator(storage, sender)?,
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
         let resp = Response::default();
         let idx = self.register_module(storage, &module)?;
         if should_validate {
@@ -35,10 +35,10 @@ impl<'a> ADOContract<'a> {
         module: Module,
     ) -> Result<Response, ContractError> {
         let addr = info.sender.as_str();
-        require(
+        ensure!(
             self.is_owner_or_operator(deps.storage, addr)?,
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
         self.alter_module(deps.storage, module_idx, &module)?;
         self.validate_modules(
             &self.load_modules(deps.storage)?,
@@ -57,10 +57,10 @@ impl<'a> ADOContract<'a> {
         module_idx: Uint64,
     ) -> Result<Response, ContractError> {
         let addr = info.sender.as_str();
-        require(
+        ensure!(
             self.is_owner_or_operator(deps.storage, addr)?,
-            ContractError::Unauthorized {},
-        )?;
+            ContractError::Unauthorized {}
+        );
         self.deregister_module(deps.storage, module_idx)?;
         Ok(Response::default()
             .add_attribute("action", "deregister_module")

--- a/packages/ado-base/src/modules/mod.rs
+++ b/packages/ado-base/src/modules/mod.rs
@@ -201,7 +201,7 @@ impl<'a> ADOContract<'a> {
             }
 
             let id = msg.id.to_string();
-            require(
+            ensure!(
                 self.module_info.has(deps.storage, &id),
                 ContractError::InvalidReplyId {},
             )?;

--- a/packages/ado-base/src/query.rs
+++ b/packages/ado-base/src/query.rs
@@ -10,9 +10,9 @@ use common::{
     },
     encode_binary,
     error::ContractError,
-    parse_message, require,
+    parse_message,
 };
-use cosmwasm_std::{Binary, Deps, Env, Order};
+use cosmwasm_std::{ensure, Binary, Deps, Env, Order};
 use serde::de::DeserializeOwned;
 
 type QueryFunction<Q> = fn(Deps, Env, Q) -> Result<Binary, ContractError>;
@@ -28,10 +28,10 @@ impl<'a> ADOContract<'a> {
     ) -> Result<Binary, ContractError> {
         match msg {
             AndromedaQuery::Get(data) => {
-                require(
+                ensure!(
                     !self.is_nested::<QueryMsg>(&data),
-                    ContractError::NestedAndromedaMsg {},
-                )?;
+                    ContractError::NestedAndromedaMsg {}
+                );
                 let received: Q = parse_message(&data)?;
                 (query_function)(deps, env, received)
             }

--- a/packages/ado-base/src/withdraw.rs
+++ b/packages/ado-base/src/withdraw.rs
@@ -1,5 +1,5 @@
 use crate::ADOContract;
-use common::{ado_base::recipient::Recipient, error::ContractError, require, withdraw::Withdrawal};
+use common::{ado_base::recipient::Recipient, error::ContractError, withdraw::Withdrawal};
 use cosmwasm_std::{coin, DepsMut, Env, MessageInfo, Order, Response, StdError, Storage, SubMsg};
 use cw20::Cw20Coin;
 
@@ -38,7 +38,7 @@ impl<'a> ADOContract<'a> {
     ) -> Result<Response, ContractError> {
         let recipient = recipient.unwrap_or_else(|| Recipient::Addr(info.sender.to_string()));
         let sender = info.sender.as_str();
-        require(
+        ensure!(
             self.is_owner_or_operator(deps.storage, sender)?,
             ContractError::Unauthorized {},
         )?;
@@ -107,7 +107,7 @@ impl<'a> ADOContract<'a> {
                 msgs.push(msg);
             }
         }
-        require(
+        ensure!(
             !msgs.is_empty(),
             ContractError::InvalidFunds {
                 msg: "No funds to withdraw".to_string(),

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -1,9 +1,8 @@
 use common::{
     ado_base::{modules::Module, recipient::Recipient, AndromedaMsg, AndromedaQuery},
     error::ContractError,
-    require,
 };
-use cosmwasm_std::Decimal;
+use cosmwasm_std::{ensure, Decimal};
 use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -77,10 +76,10 @@ pub struct GetSplitterConfigResponse {
 /// * Must include at least one recipient
 /// * The combined percentage of the recipients must not exceed 100
 pub fn validate_recipient_list(recipients: Vec<AddressPercent>) -> Result<bool, ContractError> {
-    require(
+    ensure!(
         !recipients.is_empty(),
-        ContractError::EmptyRecipientsList {},
-    )?;
+        ContractError::EmptyRecipientsList {}
+    );
 
     let mut percent_sum: Decimal = Decimal::zero();
     for rec in recipients {
@@ -88,10 +87,10 @@ pub fn validate_recipient_list(recipients: Vec<AddressPercent>) -> Result<bool, 
         percent_sum += rec.percent;
     }
 
-    require(
+    ensure!(
         percent_sum <= Decimal::one(),
-        ContractError::AmountExceededHundredPrecent {},
-    )?;
+        ContractError::AmountExceededHundredPrecent {}
+    );
 
     Ok(true)
 }

--- a/packages/andromeda-finance/src/timelock.rs
+++ b/packages/andromeda-finance/src/timelock.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Api, BlockInfo, Coin};
+use cosmwasm_std::{ensure, Api, BlockInfo, Coin};
 use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use common::{
     ado_base::{modules::Module, recipient::Recipient, AndromedaMsg, AndromedaQuery},
     error::ContractError,
-    merge_coins, require,
+    merge_coins,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -39,31 +39,31 @@ impl Escrow {
     /// * The Escrow recipient must be a valid address
     /// * Expiration cannot be "Never" or before current time/block
     pub fn validate(&self, api: &dyn Api, block: &BlockInfo) -> Result<(), ContractError> {
-        require(
+        ensure!(
             !self.coins.is_empty(),
             ContractError::InvalidFunds {
-                msg: "Require at least one coin to be sent".to_string(),
-            },
-        )?;
-        require(
+                msg: "ensure! at least one coin to be sent".to_string(),
+            }
+        );
+        ensure!(
             api.addr_validate(&self.recipient_addr).is_ok(),
-            ContractError::InvalidAddress {},
-        )?;
+            ContractError::InvalidAddress {}
+        );
 
         if let Some(EscrowCondition::MinimumFunds(funds)) = &self.condition {
-            require(
+            ensure!(
                 !funds.is_empty(),
                 ContractError::InvalidFunds {
                     msg: "Minumum funds must not be empty".to_string(),
-                },
-            )?;
+                }
+            );
             let mut funds: Vec<Coin> = funds.clone();
             funds.sort_by(|a, b| a.denom.cmp(&b.denom));
             for i in 0..funds.len() - 1 {
-                require(
+                ensure!(
                     funds[i].denom != funds[i + 1].denom,
-                    ContractError::DuplicateCoinDenoms {},
-                )?;
+                    ContractError::DuplicateCoinDenoms {}
+                );
             }
             // Explicitly stop here as it is alright if the Escrow is unlocked in this case, ie,
             // the intially deposited funds are greater or equal to the minimum imposed by this
@@ -71,10 +71,10 @@ impl Escrow {
             return Ok(());
         }
 
-        require(
+        ensure!(
             self.is_locked(block)? || self.condition.is_none(),
-            ContractError::ExpirationInPast {},
-        )?;
+            ContractError::ExpirationInPast {}
+        );
         Ok(())
     }
 
@@ -243,7 +243,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             ContractError::InvalidFunds {
-                msg: "Require at least one coin to be sent".to_string()
+                msg: "ensure! at least one coin to be sent".to_string()
             },
             resp
         );

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -2,9 +2,8 @@ use common::{
     ado_base::{AndromedaMsg, AndromedaQuery},
     app::AndrAddress,
     error::ContractError,
-    require,
 };
-use cosmwasm_std::{Api, BlockInfo, Decimal, Decimal256, Uint128};
+use cosmwasm_std::{ensure, Api, BlockInfo, Decimal, Decimal256, Uint128};
 use cw20::Cw20ReceiveMsg;
 use cw_asset::{AssetInfo, AssetInfoUnchecked};
 use schemars::JsonSchema;
@@ -101,26 +100,26 @@ impl RewardTokenUnchecked {
                 let cycle_rewards = allocation_config.cycle_rewards;
                 let reward_increase = allocation_config.reward_increase;
 
-                require(
+                ensure!(
                     init_timestamp >= block_info.time.seconds(),
                     ContractError::StartTimeInThePast {
                         current_block: block_info.height,
                         current_seconds: block_info.time.seconds(),
-                    },
-                )?;
+                    }
+                );
 
-                require(
+                ensure!(
                     init_timestamp < till_timestamp,
-                    ContractError::StartTimeAfterEndTime {},
-                )?;
+                    ContractError::StartTimeAfterEndTime {}
+                );
 
-                require(cycle_duration > 0, ContractError::InvalidCycleDuration {})?;
+                ensure!(cycle_duration > 0, ContractError::InvalidCycleDuration {});
 
                 if let Some(reward_increase) = reward_increase {
-                    require(
+                    ensure!(
                         reward_increase < Decimal::one(),
-                        ContractError::InvalidRewardIncrease {},
-                    )?;
+                        ContractError::InvalidRewardIncrease {}
+                    );
                 }
 
                 RewardType::Allocated {

--- a/packages/andromeda-modules/src/rates.rs
+++ b/packages/andromeda-modules/src/rates.rs
@@ -7,9 +7,11 @@ use common::{
     encode_binary,
     error::ContractError,
     primitive::{Primitive, PrimitivePointer},
-    require, Funds,
+    Funds,
 };
-use cosmwasm_std::{Addr, Api, Coin, Decimal, Fraction, QuerierWrapper, QueryRequest, WasmQuery};
+use cosmwasm_std::{
+    ensure, Addr, Api, Coin, Decimal, Fraction, QuerierWrapper, QueryRequest, WasmQuery,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -94,10 +96,10 @@ impl Rate {
         app_contract: Option<Addr>,
     ) -> Result<Rate, ContractError> {
         let rate = self.clone().get_rate(api, querier, app_contract)?;
-        require(rate.is_non_zero()?, ContractError::InvalidRate {})?;
+        ensure!(rate.is_non_zero()?, ContractError::InvalidRate {});
 
         if let Rate::Percent(PercentRate { percent }) = rate {
-            require(percent <= Decimal::one(), ContractError::InvalidRate {})?;
+            ensure!(percent <= Decimal::one(), ContractError::InvalidRate {});
         }
 
         Ok(rate)
@@ -174,12 +176,11 @@ pub fn calculate_fee(fee_rate: Rate, payment: &Coin) -> Result<Coin, ContractErr
         Rate::Flat(rate) => Ok(Coin::new(rate.amount.u128(), rate.denom)),
         Rate::Percent(PercentRate { percent }) => {
             // [COM-03] Make sure that fee_rate between 0 and 100.
-            require(
+            ensure!(
                 // No need for rate >=0 due to type limits (Question: Should add or remove?)
                 percent <= Decimal::one() && !percent.is_zero(),
-                ContractError::InvalidRate {},
-            )
-            .unwrap();
+                ContractError::InvalidRate {}
+            );
             let mut fee_amount = payment.amount * percent;
 
             // Always round any remainder up and prioritise the fee receiver.

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -36,9 +36,6 @@ pub enum ExecuteMsg {
         coin_denom: String,
         whitelist: Option<Vec<Addr>>,
     },
-    UpdateOwner {
-        address: String,
-    },
     CancelAuction {
         token_id: String,
         token_address: String,

--- a/packages/andromeda-non-fungible-tokens/src/cw721_timelock.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721_timelock.rs
@@ -16,9 +16,6 @@ pub enum ExecuteMsg {
         lock_id: String,
     },
     ReceiveNft(Cw721ReceiveMsg),
-    UpdateOwner {
-        address: String,
-    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/packages/common/src/ado_base/modules.rs
+++ b/packages/common/src/ado_base/modules.rs
@@ -1,4 +1,5 @@
-use crate::{app::AndrAddress, error::ContractError, require};
+use crate::{app::AndrAddress, error::ContractError};
+use cosmwasm_std::ensure;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -50,7 +51,7 @@ impl Module {
     pub fn validate(&self, modules: &[Module], ado_type: &str) -> Result<(), ContractError> {
         // We allow multiple rates modules.
         if self.module_type != RATES {
-            require(self.is_unique(modules), ContractError::ModuleNotUnique {})?;
+            ensure!(self.is_unique(modules), ContractError::ModuleNotUnique {});
         }
 
         if ado_type == "cw20" && contains_module(modules, AUCTION) {

--- a/packages/common/src/lib.rs
+++ b/packages/common/src/lib.rs
@@ -11,8 +11,8 @@ pub mod withdraw;
 use crate::error::ContractError;
 use ado_base::{AndromedaQuery, QueryMsg};
 use cosmwasm_std::{
-    from_binary, to_binary, BankMsg, Binary, Coin, CosmosMsg, QuerierWrapper, QueryRequest, SubMsg,
-    WasmQuery,
+    ensure, from_binary, to_binary, BankMsg, Binary, Coin, CosmosMsg, QuerierWrapper, QueryRequest,
+    SubMsg, WasmQuery,
 };
 use cw20::Cw20Coin;
 use schemars::JsonSchema;
@@ -79,7 +79,7 @@ where
     Ok(resp)
 }
 
-/// A simple implementation of Solidity's "require" function. Takes a precondition and an error to return if the precondition is not met.
+/// A simple implementation of Solidity's "ensure!" function. Takes a precondition and an error to return if the precondition is not met.
 ///
 /// ## Arguments
 ///
@@ -90,15 +90,9 @@ where
 /// ```
 /// use common::error::ContractError;
 /// use cosmwasm_std::StdError;
-/// use common::require;
-/// require(false, ContractError::Std(StdError::generic_err("Some boolean condition was not met")));
+/// use common::ensure!;
+/// ensure!(false, ContractError::Std(StdError::generic_err("Some boolean condition was not met")));
 /// ```
-pub fn require(precond: bool, err: ContractError) -> Result<bool, ContractError> {
-    match precond {
-        true => Ok(true),
-        false => Err(err),
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum Funds {
@@ -193,10 +187,10 @@ pub fn deduct_funds(coins: &mut [Coin], funds: &Coin) -> Result<bool, ContractEr
 
     match coin_amount {
         Some(c) => {
-            require(
+            ensure!(
                 c.amount >= funds.amount,
-                ContractError::InsufficientFunds {},
-            )?;
+                ContractError::InsufficientFunds {}
+            );
             c.amount -= funds.amount;
             Ok(true)
         }

--- a/packages/common/src/lib.rs
+++ b/packages/common/src/lib.rs
@@ -90,7 +90,6 @@ where
 /// ```
 /// use common::error::ContractError;
 /// use cosmwasm_std::StdError;
-/// use common::ensure!;
 /// ensure!(false, ContractError::Std(StdError::generic_err("Some boolean condition was not met")));
 /// ```
 

--- a/packages/common/src/lib.rs
+++ b/packages/common/src/lib.rs
@@ -79,20 +79,6 @@ where
     Ok(resp)
 }
 
-/// A simple implementation of Solidity's "ensure!" function. Takes a precondition and an error to return if the precondition is not met.
-///
-/// ## Arguments
-///
-/// * `precond` - The required precondition, will return provided "err" parameter if precondition is false
-/// * `err` - The error to return if the required precondition is false
-///
-/// ## Example
-/// ```
-/// use common::error::ContractError;
-/// use cosmwasm_std::StdError;
-/// ensure!(false, ContractError::Std(StdError::generic_err("Some boolean condition was not met")));
-/// ```
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum Funds {
     Native(Coin),

--- a/packages/common/src/withdraw.rs
+++ b/packages/common/src/withdraw.rs
@@ -1,5 +1,5 @@
-use crate::{error::ContractError, require};
-use cosmwasm_std::{Decimal, Uint128};
+use crate::error::ContractError;
+use cosmwasm_std::{ensure, Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp;
@@ -32,7 +32,7 @@ impl WithdrawalType {
     pub fn get_amount(&self, balance: Uint128) -> Result<Uint128, ContractError> {
         match self {
             WithdrawalType::Percentage(percent) => {
-                require(*percent <= Decimal::one(), ContractError::InvalidRate {})?;
+                ensure!(*percent <= Decimal::one(), ContractError::InvalidRate {});
                 Ok(balance * *percent)
             }
             WithdrawalType::Amount(amount) => Ok(cmp::min(*amount, balance)),


### PR DESCRIPTION
# Motivation
Switched from using our custom `require` to CosmWasm's `ensure`.
Removed the redundant `UpdateOwner` function.
Removed unused `struct Purchase` from Auction ADO
 
# Implementation
Imported `ensure` from `cosmwasm_std` in all files that used `require`.
Replaced all instances of `require` with `ensure`
Removed `require` from `common`
# Testing

## Unit/Integration tests
All tests still work
## On-chain tests
Instantiated a cw721 contract and tried to transfer an NFT from an account that didn't own the NFT. Got the expected error: `junod tx wasm execute juno1qrkwtkx3md3h000ml36qsdq348sus32jz82etqpednw3hh6f296sfqhfkc '{
 "transfer_nft": { "recipient": "juno146zj7cfjyk6mwzcgqtfsdg0ur0x87pjvafg6e92ln5hwg0nc69hq9jef08", "token_id": "10"}}' --from juno1huznp78sj0mk8kmly32gddtnf80qpl8jcwl68l --gas-prices 0.1ujunox --gas auto --gas-adjustment 1.3 -b block -y
Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: Unauthorized: execute wasm contract failed: invalid request`
I think that's enough to verify that `ensure` works as expected across all our contracts
# Future work
N/A