### PR TITLE
Auction No Bid Claim Hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ado-base",
  "andromeda-modules",

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
@@ -17,7 +17,9 @@ use andromeda_fungible_tokens::cw20_staking::{
     AllocationConfig, AllocationState, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
     RewardToken, RewardTokenUnchecked, RewardType, StakerResponse,
 };
-use common::{app::AndrAddress, error::ContractError};
+use common::{
+    app::AndrAddress, error::ContractError, expiration::MILLISECONDS_TO_NANOSECONDS_RATIO,
+};
 use cw_asset::{AssetInfo, AssetInfoUnchecked};
 
 const MOCK_STAKING_TOKEN: &str = "staking_token";
@@ -210,7 +212,7 @@ fn test_instantiate_start_time_in_past() {
     assert_eq!(
         ContractError::StartTimeInThePast {
             current_block: env.block.height,
-            current_time: env.block.time.nanos()
+            current_time: env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO
         },
         res.unwrap_err()
     );

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
@@ -210,7 +210,7 @@ fn test_instantiate_start_time_in_past() {
     assert_eq!(
         ContractError::StartTimeInThePast {
             current_block: env.block.height,
-            current_seconds: env.block.time.seconds()
+            current_time: env.block.time.nanos()
         },
         res.unwrap_err()
     );

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -14,7 +14,10 @@ use andromeda_fungible_tokens::lockdrop::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StateResponse,
     UserInfoResponse,
 };
-use common::{ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError};
+use common::{
+    ado_base::InstantiateMsg as BaseInstantiateMsg, encode_binary, error::ContractError,
+    expiration::MILLISECONDS_TO_NANOSECONDS_RATIO,
+};
 
 use crate::state::{Config, State, CONFIG, STATE, USER_INFO};
 use cw_utils::nonpayable;
@@ -41,7 +44,7 @@ pub fn instantiate(
     ensure!(
         msg.init_timestamp >= env.block.time.seconds(),
         ContractError::StartTimeInThePast {
-            current_time: env.block.time.nanos(),
+            current_time: env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO,
             current_block: env.block.height,
         }
     );

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -41,7 +41,7 @@ pub fn instantiate(
     ensure!(
         msg.init_timestamp >= env.block.time.seconds(),
         ContractError::StartTimeInThePast {
-            current_seconds: env.block.time.seconds(),
+            current_time: env.block.time.nanos(),
             current_block: env.block.height,
         }
     );

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
@@ -12,7 +12,7 @@ use andromeda_fungible_tokens::lockdrop::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, StateResponse,
     UserInfoResponse,
 };
-use common::error::ContractError;
+use common::{error::ContractError, expiration::MILLISECONDS_TO_NANOSECONDS_RATIO};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
 const MOCK_INCENTIVE_TOKEN: &str = "mock_incentive_token";
@@ -97,7 +97,7 @@ fn test_instantiate_init_timestamp_past() {
 
     assert_eq!(
         ContractError::StartTimeInThePast {
-            current_time: env.block.time.nanos(),
+            current_time: env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO,
             current_block: env.block.height,
         },
         res.unwrap_err()

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
@@ -97,7 +97,7 @@ fn test_instantiate_init_timestamp_past() {
 
     assert_eq!(
         ContractError::StartTimeInThePast {
-            current_seconds: env.block.time.seconds(),
+            current_time: env.block.time.nanos(),
             current_block: env.block.height,
         },
         res.unwrap_err()

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/execute_msg.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/execute_msg.json
@@ -86,7 +86,7 @@
           "type": "object",
           "required": [
             "coin_denom",
-            "end_time",
+            "duration",
             "start_time",
             "token_address",
             "token_id"
@@ -95,8 +95,10 @@
             "coin_denom": {
               "type": "string"
             },
-            "end_time": {
-              "$ref": "#/definitions/Expiration"
+            "duration": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             },
             "min_bid": {
               "anyOf": [
@@ -109,7 +111,9 @@
               ]
             },
             "start_time": {
-              "$ref": "#/definitions/Expiration"
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             },
             "token_address": {
               "type": "string"
@@ -460,52 +464,6 @@
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
-    "Expiration": {
-      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "oneOf": [
-        {
-          "description": "AtHeight will expire when `env.block.height` >= height",
-          "type": "object",
-          "required": [
-            "at_height"
-          ],
-          "properties": {
-            "at_height": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "AtTime will expire when `env.block.time` >= time",
-          "type": "object",
-          "required": [
-            "at_time"
-          ],
-          "properties": {
-            "at_time": {
-              "$ref": "#/definitions/Timestamp"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Never will never expire. Used to express the empty variant",
-          "type": "object",
-          "required": [
-            "never"
-          ],
-          "properties": {
-            "never": {
-              "type": "object"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "Module": {
       "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
       "type": "object",
@@ -552,14 +510,6 @@
             }
           },
           "additionalProperties": false
-        }
-      ]
-    },
-    "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Uint64"
         }
       ]
     },

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -229,7 +229,7 @@ fn execute_update_auction(
     );
     ensure!(
         start_time > 0 && duration > 0,
-        ContractError::InvalidExpirationTime{}
+        ContractError::InvalidExpirationTime {}
     );
 
     let start_exp = expiration_from_milliseconds(start_time)?;
@@ -1405,10 +1405,7 @@ mod tests {
         let info = mock_info(MOCK_TOKEN_OWNER, &[]);
         let res = execute(deps.as_mut(), env, info, msg);
 
-        assert_eq!(
-            ContractError::InvalidExpirationTime {  },
-            res.unwrap_err()
-        );
+        assert_eq!(ContractError::InvalidExpirationTime {}, res.unwrap_err());
     }
 
     #[test]
@@ -1471,7 +1468,7 @@ mod tests {
         let info = mock_info(MOCK_TOKEN_OWNER, &[]);
         let res = execute(deps.as_mut(), env, info, msg);
 
-        assert_eq!(ContractError::InvalidExpirationTime {  }, res.unwrap_err());
+        assert_eq!(ContractError::InvalidExpirationTime {}, res.unwrap_err());
     }
 
     #[test]

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -2,6 +2,7 @@ use common::{
     ado_base::{AndromedaMsg, AndromedaQuery},
     app::AndrAddress,
     error::ContractError,
+    expiration::MILLISECONDS_TO_NANOSECONDS_RATIO,
 };
 use cosmwasm_std::{ensure, Api, BlockInfo, Decimal, Decimal256, Uint128};
 use cw20::Cw20ReceiveMsg;
@@ -104,7 +105,7 @@ impl RewardTokenUnchecked {
                     init_timestamp >= block_info.time.seconds(),
                     ContractError::StartTimeInThePast {
                         current_block: block_info.height,
-                        current_time: block_info.time.nanos(),
+                        current_time: block_info.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO,
                     }
                 );
 

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -104,7 +104,7 @@ impl RewardTokenUnchecked {
                     init_timestamp >= block_info.time.seconds(),
                     ContractError::StartTimeInThePast {
                         current_block: block_info.height,
-                        current_seconds: block_info.time.seconds(),
+                        current_time: block_info.time.nanos(),
                     }
                 );
 

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -31,8 +31,8 @@ pub enum ExecuteMsg {
     UpdateAuction {
         token_id: String,
         token_address: String,
-        start_time: Expiration,
-        end_time: Expiration,
+        start_time: u64,
+        duration: u64,
         coin_denom: String,
         whitelist: Option<Vec<Addr>>,
         min_bid: Option<Uint128>,

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -43,7 +43,7 @@ pub enum ExecuteMsg {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Cw721HookMsg {
     /// Starts a new auction with the given parameters. The auction info can be modified before it
@@ -51,7 +51,7 @@ pub enum Cw721HookMsg {
     StartAuction {
         /// Start time in milliseconds since epoch
         start_time: u64,
-        /// Duration in milliseconds since epoch
+        /// Duration in milliseconds
         duration: u64,
         coin_denom: String,
         min_bid: Option<Uint128>,

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -49,11 +49,13 @@ pub enum Cw721HookMsg {
     /// Starts a new auction with the given parameters. The auction info can be modified before it
     /// has started but is immutable after that.
     StartAuction {
-        start_time: Expiration,
-        end_time: Expiration,
+        /// Start time in milliseconds since epoch
+        start_time: u64,
+        /// Duration in milliseconds since epoch
+        duration: u64,
         coin_denom: String,
-        whitelist: Option<Vec<Addr>>,
         min_bid: Option<Uint128>,
+        whitelist: Option<Vec<Addr>>,
     },
 }
 

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -197,9 +197,7 @@ pub enum ContractError {
     #[error("StartTimeAfterEndTime")]
     StartTimeAfterEndTime {},
 
-    #[error(
-        "Start time in past. Current time: {current_time}. Current block: {current_block}"
-    )]
+    #[error("Start time in past. Current time: {current_time}. Current block: {current_block}")]
     StartTimeInThePast {
         current_time: u64,
         current_block: u64,
@@ -470,6 +468,9 @@ pub enum ContractError {
 
     #[error("Not an assigned operator, {msg:?}")]
     NotAssignedOperator { msg: Option<String> },
+
+    #[error("Invalid Expiration Time")]
+    InvalidExpirationTime {},
 }
 
 impl From<Cw20ContractError> for ContractError {

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -198,10 +198,10 @@ pub enum ContractError {
     StartTimeAfterEndTime {},
 
     #[error(
-        "Start time in past. Current seconds: {current_seconds}. Current block: {current_block}"
+        "Start time in past. Current time: {current_time}. Current block: {current_block}"
     )]
     StartTimeInThePast {
-        current_seconds: u64,
+        current_time: u64,
         current_block: u64,
     },
 

--- a/packages/common/src/expiration.rs
+++ b/packages/common/src/expiration.rs
@@ -1,0 +1,43 @@
+use cosmwasm_std::{ensure, Timestamp};
+use cw_utils::Expiration;
+
+use crate::error::ContractError;
+
+pub const MILLISECONDS_TO_NANOSECONDS_RATIO: u64 = 1000000;
+
+/// Creates a CosmWasm Expiration struct given a time in milliseconds
+/// # Arguments
+///
+/// * `time` - The expiration time in milliseconds since the Epoch
+///
+/// Returns a `cw_utils::Expiration::AtTime` struct with the given expiration time
+pub fn expiration_from_milliseconds(time: u64) -> Result<Expiration, ContractError> {
+    // Make sure that multiplying by above ratio does not exceed u64 limit
+    ensure!(
+        time <= u64::MAX / MILLISECONDS_TO_NANOSECONDS_RATIO,
+        ContractError::InvalidExpirationTime {}
+    );
+
+    Ok(Expiration::AtTime(Timestamp::from_nanos(
+        time * MILLISECONDS_TO_NANOSECONDS_RATIO,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expiration_from_milliseconds() {
+        let time = u64::MAX;
+        let result = expiration_from_milliseconds(time).unwrap_err();
+        assert_eq!(result, ContractError::InvalidExpirationTime {});
+
+        let valid_time = 100;
+        let result = expiration_from_milliseconds(valid_time).unwrap();
+        assert_eq!(
+            Expiration::AtTime(Timestamp::from_nanos(100000000u64)),
+            result
+        )
+    }
+}

--- a/packages/common/src/lib.rs
+++ b/packages/common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod ado_base;
 pub mod app;
 pub mod error;
+pub mod expiration;
 pub mod primitive;
 pub mod rates;
 pub mod response;


### PR DESCRIPTION
# Motivation
When an auction was created and no bids were placed the NFT would be locked in the auction contract due to an error. This PR also includes a change to how auctions are started, now using a millisecond based `u64` start time and a `duration: u64` field instead of `end_time` for clarity and ease of use.

# Implementation
The error was caused by an attribute being empty, primarily the `recipient` attribute. This attribute was changed to use the token `owner`, which fixed the issue and is more logical. 

The new start time and duration fields were implemented using an `expiration_from_milliseconds` function that returns a `cw_utils::Expiration::AtTime` struct when given a `u64` timestamp. This also includes a check to ensure that the given time in milliseconds can be converted correctly to nanoseconds. There is no other functional changes as the conversion takes place when the auction is started.

# Testing

## Unit/Integration tests
A unit test was written for the new `expiration_from_milliseconds` function.

## On-chain tests
**Claiming Error**
[Creating Auction](https://testnet.mintscan.io/juno-testnet/txs/16D1065AA10F271A7CB9611DD9BE7BBD101B3F632B91D08ADC6AE82D055F51AB)
[Claiming With No Bids](https://testnet.mintscan.io/juno-testnet/txs/8DE04C934FF545A9F7B327ABAD0420994A0586985398986C123C17F1953D3092)

**New Start and Duration Fields**
[Creating Auction](https://testnet.mintscan.io/juno-testnet/txs/191769BB4FB7380A4F699A5F3089FB7D644BFDDDBBF57AE22CDF83932E0839AE)
Encoded Message:
```{ "start_auction":{"start_time": 1663246445126, "duration": 90000, "coin_denom": "ujunox" }}```
[Placing Bid](https://testnet.mintscan.io/juno-testnet/txs/68F159060F8350BBD4339ED2F4B2146932123EDA532F0486BA243A925B05FF7C)
[Claiming](https://testnet.mintscan.io/juno-testnet/txs/4FEBA4557D847A287AA1D187610605AA1CA0A8E6FBD0A9ABABFCECD37DB769DA)

[Creating Auction](https://testnet.mintscan.io/juno-testnet/txs/632B219E5E6AFF92C54BC5F087482B291F3537863CE1B90A7912BA0A0E05503A)
[Updating Auction](https://testnet.mintscan.io/juno-testnet/txs/1DF52A969EB4C970D55EDFB38A9E3DB142A9A8E5EFC85D7E7353FC799E8AA930)

# Future work
Consider changing the `crowdfund` contract to use the new start time and duration structure.
