### PR TITLE
Validate Modules Execution Order

### DIFF
--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -5,7 +5,7 @@ use andromeda_finance::rate_limiting_withdrawals::{
     QueryMsg,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook, AndromedaMsg, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
     primitive::GetValueResponse,
@@ -82,10 +82,9 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
 
-    // Do this before the hooks get fired off to ensure that there are no errors from the app
-    // address not being fully setup yet.
-    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
-        return contract.execute_update_app_contract(deps, info, address, None);
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -94,6 +94,7 @@ pub fn execute(
 
     // Do this before the hooks get fired off to ensure that there is no conflict with the app
     // contract not being whitelisted.
+    // Handled separately due to extra data required
     if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
         let splitter = SPLITTER.load(deps.storage)?;
         let mut andr_addresses: Vec<AndrAddress> = vec![];
@@ -103,6 +104,11 @@ pub fn execute(
             }
         }
         return contract.execute_update_app_contract(deps, info, address, Some(andr_addresses));
+    };
+
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/finance/andromeda-timelock/src/contract.rs
+++ b/contracts/finance/andromeda-timelock/src/contract.rs
@@ -9,10 +9,7 @@ use andromeda_finance::timelock::{
     GetLockedFundsResponse, InstantiateMsg, MigrateMsg, QueryMsg,
 };
 use common::{
-    ado_base::{
-        hooks::AndromedaHook, recipient::Recipient, AndromedaMsg,
-        InstantiateMsg as BaseInstantiateMsg,
-    },
+    ado_base::{hooks::AndromedaHook, recipient::Recipient, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
 };
@@ -56,10 +53,9 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
 
-    // Do this before the hooks get fired off to ensure that there is no conflict with the app
-    // contract not being whitelisted.
-    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
-        return contract.execute_update_app_contract(deps, info, address, None);
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -97,6 +97,7 @@ pub fn execute(
 
     // Do this before the hooks get fired off to ensure that there is no conflict with the app
     // contract not being whitelisted.
+    // Handled separately due to extra data required
     if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
         let splitter = SPLITTER.load(deps.storage)?;
         let mut andr_addresses: Vec<AndrAddress> = vec![];
@@ -106,6 +107,11 @@ pub fn execute(
             }
         }
         return contract.execute_update_app_contract(deps, info, address, Some(andr_addresses));
+    };
+
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 use ado_base::ADOContract;
 use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use common::{
-    ado_base::{hooks::AndromedaHook, AndromedaMsg, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     error::ContractError,
     Funds,
 };
@@ -62,10 +62,9 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
 
-    // Do this before the hooks get fired off to ensure that there are no errors from the app
-    // address not being fully setup yet.
-    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
-        return contract.execute_update_app_contract(deps, info, address, None);
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -8,7 +8,7 @@ use andromeda_non_fungible_tokens::auction::{
     InstantiateMsg, MigrateMsg, QueryMsg,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg, AndromedaMsg},
+    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
     expiration::{expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO},
@@ -61,10 +61,9 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
 
-    // Do this before the hooks get fired off to ensure that there are no errors from the app
-    // address not being fully setup yet.
-    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
-        return contract.execute_update_app_contract(deps, info, address, None);
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -8,7 +8,7 @@ use andromeda_non_fungible_tokens::auction::{
     InstantiateMsg, MigrateMsg, QueryMsg,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg, AndromedaMsg},
     encode_binary,
     error::ContractError,
     expiration::{expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO},
@@ -60,6 +60,12 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there are no errors from the app
+    // address not being fully setup yet.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
+        return contract.execute_update_app_contract(deps, info, address, None);
+    };
 
     contract.module_hook::<Response>(
         deps.storage,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -92,6 +92,7 @@ pub fn execute(
 
     // Do this before the hooks get fired off to ensure that there are no errors from the app
     // address not being fully setup yet.
+    // Handled separately due to extra data required
     if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
         let config = CONFIG.load(deps.storage)?;
         return contract.execute_update_app_contract(
@@ -100,6 +101,11 @@ pub fn execute(
             address,
             Some(vec![config.token_address]),
         );
+    };
+
+    //Andromeda Messages can be executed without modules, if they are a wrapped execute message they will loop back
+    if let ExecuteMsg::AndrReceive(andr_msg) = msg {
+        return contract.execute(deps, env, info, andr_msg, execute);
     };
 
     contract.module_hook::<Response>(

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -7,7 +7,7 @@ use andromeda_non_fungible_tokens::marketplace::{
     SaleStateResponse, Status,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg, AndromedaMsg},
+    ado_base::{hooks::AndromedaHook, AndromedaMsg, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
     rates::get_tax_amount,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -7,7 +7,7 @@ use andromeda_non_fungible_tokens::marketplace::{
     SaleStateResponse, Status,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg, AndromedaMsg},
     encode_binary,
     error::ContractError,
     rates::get_tax_amount,
@@ -58,6 +58,12 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there are no errors from the app
+    // address not being fully setup yet.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateAppContract { address }) = msg {
+        return contract.execute_update_app_contract(deps, info, address, None);
+    };
 
     contract.module_hook::<Response>(
         deps.storage,


### PR DESCRIPTION
# Motivation
Creating an app with a module and an auction contract was erroring.

# Implementation
Modules were being execute in the auction contract even when the message was to validate that the modules were correct, causing it to error.

In similar fashion to the other contracts with modules there is an exemption for the validation message that is used before the modules.

# Testing

## Unit/Integration tests
N/A

## On-chain tests
[Instantiated App with Auction and Rates](https://ping.wildsage.io/Andromeda/tx/ACBEDD97F8D16169AEAAD967E1AF59A5D1DAC5AE526632AA79F0D5B556A8F0D4)

# Future work
N/A
