### PR TITLE
ADODB ADO Types Query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-adodb"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ado-base",
  "andromeda-app",

--- a/contracts/app/andromeda-adodb/Cargo.toml
+++ b/contracts/app/andromeda-adodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-adodb"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2018"
 

--- a/contracts/app/andromeda-adodb/src/contract.rs
+++ b/contracts/app/andromeda-adodb/src/contract.rs
@@ -1,4 +1,4 @@
-use crate::state::{read_code_id, store_code_id};
+use crate::state::{read_code_id, store_code_id, CODE_ID};
 use ado_base::state::ADOContract;
 use andromeda_app::adodb::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use common::{
@@ -8,9 +8,11 @@ use common::{
     parse_message,
 };
 use cosmwasm_std::{
-    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Order, Reply, Response,
+    StdError,
 };
 use cw2::{get_contract_version, set_contract_version};
+use cw_storage_plus::Bound;
 use semver::Version;
 
 // version info for migration info
@@ -131,6 +133,9 @@ fn from_semver(err: semver::Error) -> StdError {
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::CodeId { key } => encode_binary(&query_code_id(deps, key)?),
+        QueryMsg::AdoTypes { limit, start_after } => {
+            encode_binary(&query_ado_types(deps, limit, start_after.as_deref())?)
+        }
         QueryMsg::AndrQuery(msg) => handle_andromeda_query(deps, env, msg),
     }
 }
@@ -152,4 +157,22 @@ fn handle_andromeda_query(
 fn query_code_id(deps: Deps, key: String) -> Result<u64, ContractError> {
     let code_id = read_code_id(deps.storage, &key)?;
     Ok(code_id)
+}
+
+const DEFAULT_LIMIT: u32 = 25u32;
+const MAX_LIMIT: u32 = 100u32;
+
+fn query_ado_types(
+    deps: Deps,
+    limit: Option<u32>,
+    start_after: Option<&str>,
+) -> Result<Vec<String>, ContractError> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.map(Bound::exclusive);
+
+    let ado_types: Vec<String> = CODE_ID
+        .keys(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .collect::<Result<Vec<String>, _>>()?;
+    Ok(ado_types)
 }

--- a/contracts/app/andromeda-adodb/src/contract.rs
+++ b/contracts/app/andromeda-adodb/src/contract.rs
@@ -159,8 +159,8 @@ fn query_code_id(deps: Deps, key: String) -> Result<u64, ContractError> {
     Ok(code_id)
 }
 
-const DEFAULT_LIMIT: u32 = 25u32;
-const MAX_LIMIT: u32 = 100u32;
+const DEFAULT_LIMIT: u32 = 25;
+const MAX_LIMIT: u32 = 100;
 
 fn query_ado_types(
     deps: Deps,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -293,7 +293,7 @@ fn execute_buy(
         .add_attribute("action", "buy")
         .add_attribute("token_id", token_id)
         .add_attribute("token_contract", token_sale_state.token_address)
-        .add_attribute("recipient", &info.sender.to_string())
+        .add_attribute("recipient", info.sender.to_string())
         .add_attribute("sale_id", token_sale_state.sale_id))
 }
 

--- a/packages/ado-base/src/execute.rs
+++ b/packages/ado-base/src/execute.rs
@@ -191,7 +191,7 @@ impl<'a> ADOContract<'a> {
             .save(deps.storage, &env!("CARGO_PKG_VERSION").to_string())?;
         Ok(Response::new()
             .add_attribute("action", "update_version")
-            .add_attribute("version", &env!("CARGO_PKG_VERSION").to_string()))
+            .add_attribute("version", env!("CARGO_PKG_VERSION").to_string()))
     }
 }
 

--- a/packages/andromeda-app/src/adodb.rs
+++ b/packages/andromeda-app/src/adodb.rs
@@ -21,4 +21,9 @@ pub enum QueryMsg {
     /// All code IDs for Andromeda contracts
     #[returns(u64)]
     CodeId { key: String },
+    #[returns(Vec<String>)]
+    AdoTypes {
+        limit: Option<u32>,
+        start_after: Option<String>,
+    },
 }


### PR DESCRIPTION
# Motivation
Our ADODB contract had no way to determine all available ADO types.

# Implementation
Added a simple range paginated query to query all ADO types available in the ADO DB.

# Testing
N/A

# Future work
N/A
