### PR TITLE
#CU-862j125kn | AMP Virtual File System

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "ado-base"
 version = "0.1.0"
 dependencies = [
+ "andromeda-os",
  "common",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -767,6 +768,7 @@ dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-os",
  "andromeda-primitive",
+ "andromeda-vfs",
  "common",
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "andromeda-vfs"
+version = "0.1.0"
+dependencies = [
+ "ado-base",
+ "amp",
+ "andromeda-os",
+ "andromeda-testing",
+ "common",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus 0.16.0",
+ "cw2 0.16.0",
+ "cw721",
+ "schemars",
+ "semver",
+ "serde",
+]
+
+[[package]]
 name = "andromeda-weighted-distribution-splitter"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "ado-base",
  "andromeda-app",
  "andromeda-automation",
+ "andromeda-os",
  "andromeda-testing",
  "common",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "amp"
 version = "0.1.0"
 dependencies = [
@@ -585,6 +594,7 @@ dependencies = [
  "cw-storage-plus 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
+ "regex",
  "schemars",
  "semver",
  "serde",
@@ -856,6 +866,7 @@ dependencies = [
  "cw-storage-plus 0.16.0",
  "cw2 0.16.0",
  "cw721",
+ "regex",
  "schemars",
  "semver",
  "serde",
@@ -1588,6 +1599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1681,23 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rfc6979"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "andromeda-splitter",
  "andromeda-testing",
  "andromeda-vault",
+ "andromeda-vfs",
  "andromeda-wrapped-cw721",
  "common",
  "cosmwasm-std",

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -20,6 +20,8 @@ andromeda-automation = { version = "0.1.0", path = "../../../packages/andromeda-
 andromeda-app = { version = "0.1.0", path = "../../../packages/andromeda-app" }
 ado-base = { path = "../../../packages/ado-base", version = "0.1.0", features=["instantiate"] }
 common = { version = "0.1.0", path = "../../../packages/common" }
+andromeda-os = { version = "0.1.0", path = "../../../packages/andromeda-os" }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { version = "0.16.0", optional = true }
 

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -96,7 +96,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
     let addr_str = get_reply_address(msg)?;
     let addr = &deps.api.addr_validate(&addr_str)?;
     ADO_ADDRESSES.save(deps.storage, &descriptor.name, addr)?;
-    let assign_app = generate_assign_app_message(&addr, env.contract.address.as_ref())?;
+    let assign_app = generate_assign_app_message(addr, env.contract.address.as_ref())?;
 
     let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
     let register_component_path_msg = register_component_path(

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -124,7 +124,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
 
     let mut resp = Response::default().add_submessage(assign_app);
 
-    if descriptor.name.chars().next().unwrap() != '.' {
+    if !descriptor.name.starts_with('.') {
         let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
         let register_component_path_msg = register_component_path(
             kernel_address.to_string(),

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -122,16 +122,21 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
     ADO_ADDRESSES.save(deps.storage, &descriptor.name, addr)?;
     let assign_app = generate_assign_app_message(addr, env.contract.address.as_ref())?;
 
-    let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
-    let register_component_path_msg = register_component_path(
-        kernel_address.to_string(),
-        &deps.querier,
-        descriptor.name,
-        addr.clone(),
-    )?;
-    Ok(Response::default()
-        .add_submessage(assign_app)
-        .add_submessage(register_component_path_msg))
+    let mut resp = Response::default().add_submessage(assign_app);
+
+    if descriptor.name.chars().next().unwrap() != '.' {
+        let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
+        let register_component_path_msg = register_component_path(
+            kernel_address.to_string(),
+            &deps.querier,
+            descriptor.name,
+            addr.clone(),
+        )?;
+
+        resp = resp.add_submessage(register_component_path_msg)
+    }
+
+    Ok(resp)
 }
 
 pub fn register_component_path(

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -11,7 +11,7 @@ use andromeda_app::app::{
 use andromeda_automation::condition::ExecuteMsg as ConditionExecuteMsg;
 use andromeda_os::{
     kernel::QueryMsg as KernelQueryMsg,
-    vfs::{validate_component_name, ExecuteMsg as VFSExecuteMsg},
+    vfs::{convert_component_name, validate_component_name, ExecuteMsg as VFSExecuteMsg},
 };
 use common::{
     ado_base::{AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
@@ -92,7 +92,7 @@ pub fn instantiate(
         .query_wasm_smart(msg.kernel_address, &vfs_address_query)?;
 
     let add_path_msg = VFSExecuteMsg::AddParentPath {
-        name: msg.name,
+        name: convert_component_name(msg.name),
         parent_address: info.sender,
     };
     let cosmos_msg: CosmosMsg<Empty> = CosmosMsg::Wasm(WasmMsg::Execute {

--- a/contracts/app/andromeda-app-contract/src/mock.rs
+++ b/contracts/app/andromeda-app-contract/src/mock.rs
@@ -1,6 +1,7 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 use crate::contract::{execute, instantiate, query, reply};
 use andromeda_app::app::{AppComponent, ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_os::kernel;
 use cosmwasm_std::Empty;
 use cw_multi_test::{Contract, ContractWrapper};
 
@@ -10,16 +11,15 @@ pub fn mock_andromeda_app() -> Box<dyn Contract<Empty>> {
 }
 
 pub fn mock_app_instantiate_msg(
-    name: String,
+    name: impl Into<String>,
     app_components: Vec<AppComponent>,
-    primitive_contract: String,
+    kernel_address: impl Into<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         app_components,
-        name,
-        primitive_contract,
+        name: name.into(),
         target_ados: None,
-        kernel_address: None,
+        kernel_address: kernel_address.into(),
     }
 }
 

--- a/contracts/app/andromeda-app-contract/src/mock.rs
+++ b/contracts/app/andromeda-app-contract/src/mock.rs
@@ -1,7 +1,7 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 use crate::contract::{execute, instantiate, query, reply};
 use andromeda_app::app::{AppComponent, ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_os::kernel;
+
 use cosmwasm_std::Empty;
 use cw_multi_test::{Contract, ContractWrapper};
 

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -1,22 +1,18 @@
 use crate::{
     contract::*,
-    state::{ADO_ADDRESSES, ADO_DESCRIPTORS, TARGET_ADOS},
+    state::{ADO_ADDRESSES, TARGET_ADOS},
 };
 use andromeda_app::app::{AppComponent, ExecuteMsg, InstantiateMsg};
 use andromeda_automation::condition::ExecuteMsg as ConditionExecuteMsg;
 use andromeda_os::vfs::ExecuteMsg as VFSExecuteMsg;
-use andromeda_testing::{
-    reply::MsgInstantiateContractResponse, testing::mock_querier::mock_dependencies_custom,
-};
+use andromeda_testing::testing::mock_querier::mock_dependencies_custom;
 
 use common::{ado_base::AndromedaMsg, encode_binary, error::ContractError};
 use cosmwasm_std::{
     attr,
     testing::{mock_env, mock_info},
-    to_binary, Addr, CosmosMsg, Empty, Event, Reply, ReplyOn, Response, StdError, SubMsg,
-    SubMsgResponse, SubMsgResult, WasmMsg,
+    to_binary, Addr, CosmosMsg, Empty, ReplyOn, Response, StdError, SubMsg, WasmMsg,
 };
-use prost::Message;
 
 #[test]
 fn test_empty_instantiation() {

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use andromeda_app::app::{AppComponent, ExecuteMsg, InstantiateMsg};
 use andromeda_automation::condition::ExecuteMsg as ConditionExecuteMsg;
-use andromeda_os::vfs::ExecuteMsg as VFSExecuteMsg;
+use andromeda_os::vfs::{convert_component_name, ExecuteMsg as VFSExecuteMsg};
 use andromeda_testing::testing::mock_querier::mock_dependencies_custom;
 
 use common::{ado_base::AndromedaMsg, encode_binary, error::ContractError};
@@ -66,7 +66,7 @@ fn test_instantiation() {
         msg: CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: "vfs_contract".to_string(),
             msg: to_binary(&VFSExecuteMsg::AddParentPath {
-                name: "Some App".to_string(),
+                name: convert_component_name("Some App".to_string()),
                 parent_address: info.sender,
             })
             .unwrap(),

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -566,7 +566,6 @@ fn test_fire_condition_works() {
     );
     let msg = ExecuteMsg::Fire {};
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-    println!("{res:?}");
 
     let expected_res = Response::new()
         .add_submessage(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -24,9 +24,8 @@ fn test_empty_instantiation() {
     let msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
     let info = mock_info("creator", &[]);
 
@@ -46,9 +45,8 @@ fn test_instantiation() {
             instantiate_msg: to_binary(&true).unwrap(),
         }],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
     let info = mock_info("creator", &[]);
 
@@ -101,9 +99,8 @@ fn test_instantiation_duplicate_components() {
             },
         ],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
     let info = mock_info("creator", &[]);
 
@@ -119,9 +116,8 @@ fn test_add_app_component_unauthorized() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info, inst_msg).unwrap();
@@ -151,9 +147,9 @@ fn test_add_app_component_duplicate_name() {
             instantiate_msg: to_binary(&true).unwrap(),
         }],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -185,9 +181,8 @@ fn test_add_app_component() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -238,9 +233,9 @@ fn test_claim_ownership_unauth() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info, inst_msg).unwrap();
@@ -260,9 +255,9 @@ fn test_claim_ownership_not_found() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -288,9 +283,9 @@ fn test_claim_ownership_empty() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -309,9 +304,9 @@ fn test_claim_ownership_all() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -376,9 +371,9 @@ fn test_claim_ownership() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -432,9 +427,9 @@ fn test_proxy_message_unauth() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info, inst_msg).unwrap();
@@ -457,9 +452,9 @@ fn test_proxy_message_not_found() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -486,9 +481,9 @@ fn test_fire_condition_works() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -586,9 +581,9 @@ fn test_proxy_message() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
     ADO_ADDRESSES
         .save(
@@ -634,9 +629,9 @@ fn test_update_address_unauth() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     ADO_ADDRESSES
@@ -666,9 +661,9 @@ fn test_update_address_not_found() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -695,9 +690,9 @@ fn test_update_address() {
     let inst_msg = InstantiateMsg {
         app_components: vec![],
         name: String::from("Some App"),
-        primitive_contract: String::from("primitive_contract"),
+
         target_ados: Some(vec!["condition1".to_string(), "condition2".to_string()]),
-        kernel_address: None,
+        kernel_address: "kernel_contract".to_string(),
     };
 
     ADO_ADDRESSES

--- a/contracts/automation/andromeda-oracle/src/contract.rs
+++ b/contracts/automation/andromeda-oracle/src/contract.rs
@@ -234,7 +234,6 @@ mod tests {
 
         let binary = to_binary(&query_response).unwrap();
         let json_value: Value = serde_json_wasm::from_slice(&binary).unwrap();
-        println!("The JSON value as object is: {:?}", json_value.as_object());
 
         let json_map: String = match json_value.as_object() {
             Some(obj) => {
@@ -277,10 +276,8 @@ mod tests {
         assert_eq!(addr, MOCK_COUNTER_CONTRACT.to_string());
 
         let res = query_target(deps.as_ref()).unwrap();
-        println!("Response: {res:?}");
 
         let from_stringg: Uint128 = res.parse().unwrap();
-        println!("Parsed version: {from_stringg:?}");
         assert_eq!(from_stringg, Uint128::new(1))
     }
 
@@ -308,10 +305,8 @@ mod tests {
         assert_eq!(addr, MOCK_COUNTER_CONTRACT.to_string());
 
         let res = query_target(deps.as_ref()).unwrap();
-        println!("Response: {res:?}");
 
         let from_stringg: u32 = res.parse().unwrap();
-        println!("Parsed version: {from_stringg:?}");
         assert_eq!(from_stringg, 1)
         // We can now assume that we can parse into any type of number
     }
@@ -337,10 +332,7 @@ mod tests {
 
         let res: String = query_target(deps.as_ref()).unwrap();
 
-        println!("Pre-parsed result: {res:?}");
         let parsed_result: bool = res.parse().unwrap();
-
-        println!("Parsed result: {parsed_result:?}");
 
         // The mock querier always returns false
         assert!(!parsed_result)
@@ -367,10 +359,7 @@ mod tests {
 
         let res: String = query_target(deps.as_ref()).unwrap();
 
-        println!("Pre-parsed result: {res:?}");
-
         let parsed_result: Uint128 = res.parse().unwrap();
-        println!("From String version: {parsed_result:?}");
 
         assert_eq!(parsed_result, Uint128::new(1));
     }
@@ -419,9 +408,7 @@ mod tests {
 
         let res = query_target(deps.as_ref()).unwrap();
 
-        println!("Pre-parsed result: {res:?}");
         let parsed_result: Uint128 = res.parse().unwrap();
-        println!("From String version: {parsed_result:?}");
 
         assert_eq!(parsed_result, Uint128::zero());
     }

--- a/contracts/automation/andromeda-process/src/contract.rs
+++ b/contracts/automation/andromeda-process/src/contract.rs
@@ -55,7 +55,7 @@ pub fn instantiate(
                 ado_version: CONTRACT_VERSION.to_string(),
                 operators: None,
                 modules: None,
-                primitive_contract: Some(msg.primitive_contract),
+                primitive_contract: None,
                 kernel_address: msg.kernel_address,
             },
         )?

--- a/contracts/automation/andromeda-process/src/testing/mod.rs
+++ b/contracts/automation/andromeda-process/src/testing/mod.rs
@@ -326,7 +326,6 @@ fn test_fire_condition_works() {
     );
     let msg = ExecuteMsg::Fire {};
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-    println!("{res:?}");
 
     let expected_res = Response::new()
         .add_submessage(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {

--- a/contracts/automation/andromeda-process/src/testing/mod.rs
+++ b/contracts/automation/andromeda-process/src/testing/mod.rs
@@ -23,9 +23,9 @@ fn test_empty_instantiation() {
     let msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
     let info = mock_info("creator", &[]);
 
@@ -45,9 +45,9 @@ fn test_instantiation() {
             instantiate_msg: to_binary(&true).unwrap(),
         }],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
     let info = mock_info("creator", &[]);
 
@@ -100,9 +100,9 @@ fn test_instantiation_duplicate_components() {
             },
         ],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
     let info = mock_info("creator", &[]);
 
@@ -118,9 +118,9 @@ fn test_add_process_component_unauthorized() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info, inst_msg).unwrap();
@@ -150,9 +150,9 @@ fn test_add_process_component_duplicate_name() {
             instantiate_msg: to_binary(&true).unwrap(),
         }],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -184,9 +184,9 @@ fn test_add_process_component() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -253,9 +253,9 @@ fn test_fire_condition_works() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition1".to_string(), "condition2".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -353,9 +353,9 @@ fn test_claim_ownership_unauth() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info, inst_msg).unwrap();
@@ -375,9 +375,9 @@ fn test_claim_ownership_not_found() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -403,9 +403,9 @@ fn test_claim_ownership_empty() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -424,9 +424,9 @@ fn test_claim_ownership_all() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -491,9 +491,9 @@ fn test_claim_ownership() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -547,9 +547,9 @@ fn test_proxy_message_unauth() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info, inst_msg).unwrap();
@@ -572,9 +572,9 @@ fn test_proxy_message_not_found() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -601,9 +601,9 @@ fn test_proxy_message() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
     ADO_ADDRESSES
         .save(
@@ -649,9 +649,9 @@ fn test_update_address_unauth() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     ADO_ADDRESSES
@@ -681,9 +681,9 @@ fn test_update_address_not_found() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps.as_mut(), env.clone(), info.clone(), inst_msg).unwrap();
@@ -710,9 +710,9 @@ fn test_update_address() {
     let inst_msg = InstantiateMsg {
         process: vec![],
         name: String::from("Some Process"),
-        primitive_contract: String::from("primitive_contract"),
+
         first_ados: vec!["condition_ado".to_string()],
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     ADO_ADDRESSES

--- a/contracts/ecosystem/andromeda-swapper/src/testing/tests.rs
+++ b/contracts/ecosystem/andromeda-swapper/src/testing/tests.rs
@@ -27,7 +27,7 @@ fn init(deps: DepsMut) -> Response {
             identifier: MOCK_ASTROPORT_WRAPPER_CONTRACT.to_owned(),
         }),
         primitive_contract: "primitive_contract".to_string(),
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     instantiate(deps, mock_env(), mock_info("sender", &[]), msg).unwrap()
@@ -65,7 +65,7 @@ fn test_instantiate_swapper_impl_new() {
             ado_type: "swapper_impl".to_string(),
         }),
         primitive_contract: "primitive_contract".to_string(),
-        kernel_address: None,
+        kernel_address: Some("kernel_contract".to_string()),
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), mock_info("sender", &[]), msg).unwrap();

--- a/contracts/ecosystem/andromeda-vault/src/mock.rs
+++ b/contracts/ecosystem/andromeda-vault/src/mock.rs
@@ -11,10 +11,8 @@ pub fn mock_andromeda_vault() -> Box<dyn Contract<Empty>> {
     Box::new(contract)
 }
 
-pub fn mock_vault_instantiate_msg() -> InstantiateMsg {
-    InstantiateMsg {
-        kernel_address: Some("contract3".to_string()),
-    }
+pub fn mock_vault_instantiate_msg(kernel_address: Option<String>) -> InstantiateMsg {
+    InstantiateMsg { kernel_address }
 }
 
 /// Used to generate a deposit message for a vault

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -170,7 +170,7 @@ fn execute_send(
     let mut msgs: Vec<SubMsg> = Vec::new();
     let mut amp_msgs: Vec<AMPMsg> = Vec::new();
     let mut kernel_funds: Vec<Coin> = Vec::new();
-    println!("1");
+
     let mut remainder_funds = info.funds.clone();
     // Looking at this nested for loop, we could find a way to reduce time/memory complexity to avoid DoS.
     // Would like to understand more about why we loop through funds and what it exactly stored in it.
@@ -191,11 +191,8 @@ fn execute_send(
         }
         // ADO receivers must use AndromedaMsg::Receive to execute their functionality
         // Others may just receive the funds
-        println!("12");
         let recipient = recipient_addr.recipient.get_addr()?;
-        println!("13");
         let message = recipient_addr.recipient.get_message()?.unwrap_or_default();
-        println!("14");
 
         match &recipient_addr.recipient {
             AMPRecipient::Addr(addr) => msgs.push(SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
@@ -210,12 +207,10 @@ fn execute_send(
                     Some(reply_gas.reply_on.clone().unwrap_or(ReplyOn::Always)),
                     reply_gas.gas_limit,
                 ));
-                println!("15");
                 // Add the coins intended for the kernel
                 for x in &vec_coin {
                     kernel_funds.push(x.to_owned())
                 }
-                println!("16");
             }
         }
     }
@@ -237,19 +232,15 @@ fn execute_send(
     // Check if any messages are intended for kernel in the first place
     if !amp_msgs.is_empty() {
         let contract = ADOContract::default();
-        println!("17");
         // The original sender of the message is the user in this case
         let origin = info.sender.to_string();
-        println!("17.1");
 
         // The previous sender of the message is the contract in this case since it will be the one sending the message to the kernel
         let previous_sender = env.contract.address;
-        println!("17.2");
 
         // The kernel address has been validated and saved during instantiation
         let kernel_address = contract.get_kernel_address(deps.storage)?;
 
-        println!("18");
         let msg = generate_msg_native_kernel(
             kernel_funds,
             origin,

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -291,8 +291,6 @@ fn execute_send(
         msgs.push(msg);
     }
 
-    println!("THE MESSAGES are: {msgs:?}");
-
     Ok(Response::new()
         .add_submessages(msgs)
         .add_attribute("action", "send")

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -732,7 +732,7 @@ mod tests {
                 ),
                 SubMsg::new(WasmMsg::Execute {
                     contract_addr: "kernel".to_string(),
-                    msg: to_binary(&KernelExecuteMsg::Receive(pkt)).unwrap(),
+                    msg: to_binary(&KernelExecuteMsg::AMPReceive(pkt)).unwrap(),
                     funds: vec![Coin::new(1000, "uluna"), Coin::new(2000, "uluna")],
                 }),
             ])

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -11,10 +11,13 @@ pub fn mock_andromeda_auction() -> Box<dyn Contract<Empty>> {
     Box::new(contract)
 }
 
-pub fn mock_auction_instantiate_msg(modules: Option<Vec<Module>>) -> InstantiateMsg {
+pub fn mock_auction_instantiate_msg(
+    modules: Option<Vec<Module>>,
+    kernel_address: Option<String>,
+) -> InstantiateMsg {
     InstantiateMsg {
         modules,
-        kernel_address: None,
+        kernel_address,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -545,7 +545,6 @@ fn execute_end_sale(
     if state.amount_sold < state.min_tokens_sold {
         issue_refunds_and_burn_tokens(deps, env, limit)
     } else {
-        println!("end sale in crowdfund");
         let origin = info.sender.into_string();
         let previous_sender = env.clone().contract.address.into_string();
         let kernel_address = ADOContract::default()
@@ -643,7 +642,6 @@ fn transfer_tokens_and_send_funds(
             STATE.save(deps.storage, &state)?;
 
             resp = resp.add_submessage(msg);
-            println!("transfer tokens resp {:?}", resp);
         }
         // Once all purchased tokens have been transferred, begin burning `limit` number of tokens
         // that were not purchased.
@@ -735,7 +733,6 @@ fn transfer_tokens_and_send_funds(
         )?;
     }
     STATE.save(deps.storage, &state)?;
-    println!("rate messages: {:?}", rate_messages);
 
     Ok(resp
         .add_attribute("action", "transfer_tokens_and_send_funds")

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
@@ -20,6 +20,7 @@ pub fn mock_crowdfund_instantiate_msg(
     token_address: String,
     can_mint_after_sale: bool,
     modules: Option<Vec<Module>>,
+    kernel_address: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         token_address: AndrAddress {
@@ -27,7 +28,7 @@ pub fn mock_crowdfund_instantiate_msg(
         },
         can_mint_after_sale,
         modules,
-        kernel_address: Some("contract3".to_string()),
+        kernel_address,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-cw721-staking/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721-staking/src/contract.rs
@@ -718,11 +718,8 @@ mod tests {
         let details = STAKED_NFTS
             .load(&deps.storage, "valid1".to_string())
             .unwrap();
-        println!("{:?}", details.time_of_staking.seconds());
-        println!("{:?}", env.block.time.clone().seconds());
         let time_spent = env.block.time.clone().seconds() - details.time_of_staking.seconds();
 
-        println!("{time_spent:?}");
         let set_reward = REWARD.load(&deps.storage).unwrap();
         let expected_reward = set_reward.amount * Uint128::from(time_spent);
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
@@ -19,13 +19,14 @@ pub fn mock_cw721_instantiate_msg(
     symbol: String,
     minter: String,
     modules: Option<Vec<Module>>,
+    kernel_address: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         name,
         symbol,
         minter: AndrAddress { identifier: minter },
         modules,
-        kernel_address: Some("contract3".to_string()),
+        kernel_address,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-wrapped-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-wrapped-cw721/src/contract.rs
@@ -63,7 +63,7 @@ pub fn instantiate(
                 minter: AndrAddress {
                     identifier: env.contract.address.to_string(),
                 },
-                kernel_address: None,
+                kernel_address: Some("kernel_contract".to_string()),
             };
             let msg = contract.generate_instantiate_msg(
                 deps.storage,
@@ -314,7 +314,7 @@ mod tests {
                 primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
                 cw721_instantiate_type: InstantiateType::Address(MOCK_CW721_CONTRACT.to_owned()),
                 can_unwrap: true,
-                kernel_address: None,
+                kernel_address: Some("kernel_contract".to_string()),
             },
         )
         .unwrap();
@@ -329,7 +329,7 @@ mod tests {
             primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
             can_unwrap: true,
             cw721_instantiate_type: InstantiateType::Address(MOCK_CW721_CONTRACT.to_owned()),
-            kernel_address: None,
+            kernel_address: Some("kernel_contract".to_string()),
         };
 
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -362,7 +362,7 @@ mod tests {
                 symbol: "symbol".to_string(),
                 modules: None,
             }),
-            kernel_address: None,
+            kernel_address: Some("kernel_contract".to_string()),
         };
 
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -373,7 +373,7 @@ mod tests {
             minter: AndrAddress {
                 identifier: mock_env().contract.address.to_string(),
             },
-            kernel_address: None,
+            kernel_address: Some("kernel_contract".to_string()),
         };
         let msg: SubMsg = SubMsg {
             id: 1,

--- a/contracts/non-fungible-tokens/andromeda-wrapped-cw721/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-wrapped-cw721/src/mock.rs
@@ -16,12 +16,13 @@ pub fn mock_wrapped_cw721_instantiate_msg(
     primitive_contract: String,
     cw721_instantiate_type: InstantiateType,
     can_unwrap: bool,
+    kernel_address: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         primitive_contract,
         cw721_instantiate_type,
         can_unwrap,
-        kernel_address: None,
+        kernel_address,
     }
 }
 

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -99,7 +99,6 @@ pub fn handle_amp_packet(
             &execute_env.deps.querier,
             vfs_address.clone(),
         )?;
-        print!("3 contract address from kernel {:?}", contract_addr);
         let msg = message.generate_sub_message(
             contract_addr,
             packet.get_origin(),

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -36,7 +36,7 @@ pub fn instantiate(
         deps.api,
         info,
         BaseInstantiateMsg {
-            ado_type: "adodb".to_string(),
+            ado_type: "kernel".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
             operators: None,
             modules: None,

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -73,7 +73,7 @@ pub fn execute(
     let execute_env = ExecuteEnv { deps, env, info };
 
     match msg {
-        ExecuteMsg::Receive(packet) => handle_amp_packet(execute_env, packet),
+        ExecuteMsg::AMPReceive(packet) => handle_amp_packet(execute_env, packet),
         ExecuteMsg::UpsertKeyAddress { key, value } => upsert_key_address(execute_env, key, value),
     }
 }

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -16,7 +16,7 @@ use cosmwasm_std::{
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;
 
-use crate::state::{ADO_DB_KEY, KERNEL_ADDRESSES};
+use crate::state::{ADO_DB_KEY, KERNEL_ADDRESSES, VFS_KEY};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-kernel";
@@ -90,37 +90,15 @@ pub fn handle_amp_packet(
         ContractError::Unauthorized {}
     );
     let mut res = Response::default();
-    // Batched message implementation
-    // let message_recipients = packet.get_unique_recipients();
-    // for recipient in message_recipients {
-    //     // Contract address is resolved here to reduce gas costs for repeated recipients
-    //     let contract_addr = recipient.clone(); //TODO: ADD NAMESPACING RESOLVER
-    //     let messages = packet.get_messages_for_recipient(recipient);
-    //     // for message in messages {
-    //     //     let sub_msg = message.generate_message(
-    //     //         contract_addr.clone(),
-    //     //         packet.get_origin(),
-    //     //         packet.get_previous_sender(),
-    //     //         1,
-    //     //     )?;
 
-    //     //     res = res.add_submessage(sub_msg);
-    //     // }
-    //     let amp_pkt = AMPPkt::new(packet.get_origin(), packet.get_previous_sender(), messages);
-    //     let sub_msg = SubMsg::reply_always(
-    //         CosmosMsg::Wasm::<Empty>(WasmMsg::Execute {
-    //             contract_addr,
-    //             msg: to_binary(&ExecuteMsg::Receive(amp_pkt))?,
-    //             funds: vec![], //TODO: CALCULATE FUNDS
-    //         }),
-    //         1,
-    //     );
-    // }
-
+    let vfs_address = KERNEL_ADDRESSES.may_load(execute_env.deps.storage, VFS_KEY)?;
     for message in packet.clone().messages {
-        let contract_addr =
-            message.get_recipient_address(execute_env.deps.api, &execute_env.deps.querier, None)?;
-        let msg = message.generate_message(
+        let contract_addr = message.get_recipient_address(
+            execute_env.deps.api,
+            &execute_env.deps.querier,
+            vfs_address.clone(),
+        )?;
+        let msg = message.generate_sub_message(
             contract_addr,
             packet.get_origin(),
             packet.get_previous_sender(),
@@ -129,6 +107,7 @@ pub fn handle_amp_packet(
 
         res = res.add_submessage(msg)
     }
+
     // TODO: GENERATE ATTRIBUTES FROM AMP PACKET
     Ok(res)
 }

--- a/contracts/os/andromeda-kernel/src/mock.rs
+++ b/contracts/os/andromeda-kernel/src/mock.rs
@@ -26,3 +26,7 @@ pub fn mock_verify_address(address: impl Into<String>) -> QueryMsg {
         address: address.into(),
     }
 }
+
+pub fn mock_get_key_address(key: impl Into<String>) -> QueryMsg {
+    QueryMsg::KeyAddress { key: key.into() }
+}

--- a/contracts/os/andromeda-vfs/.cargo/config
+++ b/contracts/os/andromeda-vfs/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 cw721 = "0.16.0"
 cw2 = "0.16.0"
 semver = "1"
+regex = "1"
 
 amp = { version = "0.1.0", path = "../../../packages/amp" }
 andromeda-os = { version = "0.1.0", path = "../../../packages/andromeda-os" }

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "andromeda-vfs"
+version = "0.1.0"
+authors = ["Connor Barr <crnbarr@gmail.com>"]
+edition = "2018"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+library = []
+testing = ["cw-multi-test"]
+
+[dependencies]
+cosmwasm-std = "1.1.6"
+cosmwasm-schema = "1.1.6"
+cw-storage-plus = "0.16.0"
+schemars = "0.8.10"
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
+cw721 = "0.16.0"
+cw2 = "0.16.0"
+semver = "1"
+
+amp = { version = "0.1.0", path = "../../../packages/amp" }
+andromeda-os = { version = "0.1.0", path = "../../../packages/andromeda-os" }
+ado-base = { path = "../../../packages/ado-base", version = "0.1.0" }
+common = { version = "0.1.0", path = "../../../packages/common" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cw-multi-test = { version = "0.16.0", optional = true }
+
+[dev-dependencies]
+andromeda-testing = { version = "0.1.0", path = "../../../packages/andromeda-testing" }
+

--- a/contracts/os/andromeda-vfs/Developing.md
+++ b/contracts/os/andromeda-vfs/Developing.md
@@ -1,0 +1,110 @@
+# Developing
+
+If you have recently created a contract with this template, you probably could use some
+help on how to build and test the contract, as well as prepare it for production. This
+file attempts to provide a brief overview, assuming you have installed a recent
+version of Rust already (eg. 1.44.1+).
+
+## Prerequisites
+
+Before starting, make sure you have [rustup](https://rustup.rs/) along with a
+recent `rustc` and `cargo` version installed. Currently, we are testing on 1.44.1+.
+
+And you need to have the `wasm32-unknown-unknown` target installed as well.
+
+You can check that via:
+
+```sh
+rustc --version
+cargo --version
+rustup target list --installed
+# if wasm32 is not listed above, run this
+rustup target add wasm32-unknown-unknown
+```
+
+## Compiling and running tests
+
+Now that you created your custom contract, make sure you can compile and run it before
+making any changes. Go into the repository and do:
+
+```sh
+# this will produce a wasm build in ./target/wasm32-unknown-unknown/release/YOUR_NAME_HERE.wasm
+cargo wasm
+
+# this runs unit tests with helpful backtraces
+RUST_BACKTRACE=1 cargo unit-test
+
+# auto-generate json schema
+cargo schema
+```
+
+### Understanding the tests
+
+The main code is in `src/contract.rs` and the unit tests there run in pure rust,
+which makes them very quick to execute and give nice output on failures, especially
+if you do `RUST_BACKTRACE=1 cargo unit-test`.
+
+We consider testing critical for anything on a blockchain, and recommend to always keep
+the tests up to date.
+
+## Generating JSON Schema
+
+While the Wasm calls (`init`, `handle`, `query`) accept JSON, this is not enough
+information to use it. We need to expose the schema for the expected messages to the
+clients. You can generate this schema by calling `cargo schema`, which will output
+4 files in `./schema`, corresponding to the 3 message types the contract accepts,
+as well as the internal `State`.
+
+These files are in standard json-schema format, which should be usable by various
+client side tools, either to auto-generate codecs, or just to validate incoming
+json wrt. the defined schema.
+
+## Preparing the Wasm bytecode for production
+
+Before we upload it to a chain, we need to ensure the smallest output size possible,
+as this will be included in the body of a transaction. We also want to have a
+reproducible build process, so third parties can verify that the uploaded Wasm
+code did indeed come from the claimed rust code.
+
+To solve both these issues, we have produced `rust-optimizer`, a docker image to
+produce an extremely small build output in a consistent manner. The suggest way
+to run it is this:
+
+```sh
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.10.3
+```
+
+We must mount the contract code to `/code`. You can use a absolute path instead
+of `$(pwd)` if you don't want to `cd` to the directory first. The other two
+volumes are nice for speedup. Mounting `/code/target` in particular is useful
+to avoid docker overwriting your local dev files with root permissions.
+Note the `/code/target` cache is unique for each contract being compiled to limit
+interference, while the registry cache is global.
+
+This is rather slow compared to local compilations, especially the first compile
+of a given contract. The use of the two volume caches is very useful to speed up
+following compiles of the same contract.
+
+This produces a `contract.wasm` file in the current directory (which must be the root
+directory of your rust project, the one with `Cargo.toml` inside). As well as
+`hash.txt` containing the Sha256 hash of `contract.wasm`, and it will rebuild
+your schema files as well.
+
+### Testing production build
+
+Once we have this compressed `contract.wasm`, we may want to ensure it is actually
+doing everything it is supposed to (as it is about 4% of the original size).
+If you update the "WASM" line in `tests/integration.rs`, it will run the integration
+steps on the optimized build, not just the normal build. I have never seen a different
+behavior, but it is nice to verify sometimes.
+
+```rust
+static WASM: &[u8] = include_bytes!("../contract.wasm");
+```
+
+Note that this is the same (deterministic) code you will be uploading to
+a blockchain to test it out, as we need to shrink the size and produce a
+clear mapping from wasm hash back to the source code.

--- a/contracts/os/andromeda-vfs/Importing.md
+++ b/contracts/os/andromeda-vfs/Importing.md
@@ -1,0 +1,62 @@
+# Importing
+
+In [Publishing](./Publishing.md), we discussed how you can publish your contract to the world.
+This looks at the flip-side, how can you use someone else's contract (which is the same
+question as how they will use your contract). Let's go through the various stages.
+
+## Verifying Artifacts
+
+Before using remote code, you most certainly want to verify it is honest.
+
+The simplest audit of the repo is to simply check that the artifacts in the repo
+are correct. This involves recompiling the claimed source with the claimed builder
+and validating that the locally compiled code (hash) matches the code hash that was
+uploaded. This will verify that the source code is the correct preimage. Which allows
+one to audit the original (Rust) source code, rather than looking at wasm bytecode.
+
+We have a script to do this automatic verification steps that can
+easily be run by many individuals. Please check out
+[`cosmwasm-verify`](https://github.com/CosmWasm/cosmwasm-verify/blob/master/README.md)
+to see a simple shell script that does all these steps and easily allows you to verify
+any uploaded contract.
+
+## Reviewing
+
+Once you have done the quick programatic checks, it is good to give at least a quick
+look through the code. A glance at `examples/schema.rs` to make sure it is outputing
+all relevant structs from `contract.rs`, and also ensure `src/lib.rs` is just the
+default wrapper (nothing funny going on there). After this point, we can dive into
+the contract code itself. Check the flows for the handle methods, any invariants and
+permission checks that should be there, and a reasonable data storage format.
+
+You can dig into the contract as far as you want, but it is important to make sure there
+are no obvious backdoors at least.
+
+## Decentralized Verification
+
+It's not very practical to do a deep code review on every dependency you want to use,
+which is a big reason for the popularity of code audits in the blockchain world. We trust
+some experts review in lieu of doing the work ourselves. But wouldn't it be nice to do this
+in a decentralized manner and peer-review each other's contracts? Bringing in deeper domain
+knowledge and saving fees.
+
+Luckily, there is an amazing project called [crev](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/README.md)
+that provides `A cryptographically verifiable code review system for the cargo (Rust) package manager`.
+
+I highly recommend that CosmWasm contract developers get set up with this. At minimum, we
+can all add a review on a package that programmatically checked out that the json schemas
+and wasm bytecode do match the code, and publish our claim, so we don't all rely on some
+central server to say it validated this. As we go on, we can add deeper reviews on standard
+packages.
+
+If you want to use `cargo-crev`, please follow their
+[getting started guide](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md)
+and once you have made your own *proof repository* with at least one *trust proof*,
+please make a PR to the [`cawesome-wasm`]() repo with a link to your repo and
+some public name or pseudonym that people know you by. This allows people who trust you
+to also reuse your proofs.
+
+There is a [standard list of proof repos](https://github.com/crev-dev/cargo-crev/wiki/List-of-Proof-Repositories)
+with some strong rust developers in there. This may cover dependencies like `serde` and `snafu`
+but will not hit any CosmWasm-related modules, so we look to bootstrap a very focused
+review community.

--- a/contracts/os/andromeda-vfs/LICENSE
+++ b/contracts/os/andromeda-vfs/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/contracts/os/andromeda-vfs/NOTICE
+++ b/contracts/os/andromeda-vfs/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2021 Connor Barr <crnbarr@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/contracts/os/andromeda-vfs/Publishing.md
+++ b/contracts/os/andromeda-vfs/Publishing.md
@@ -1,0 +1,115 @@
+# Publishing Contracts
+
+This is an overview of how to publish the contract's source code in this repo.
+We use Cargo's default registry [crates.io](https://crates.io/) for publishing contracts written in Rust.
+
+## Preparation
+
+Ensure the `Cargo.toml` file in the repo is properly configured. In particular, you want to
+choose a name starting with `cw-`, which will help a lot finding CosmWasm contracts when
+searching on crates.io. For the first publication, you will probably want version `0.1.0`.
+If you have tested this on a public net already and/or had an audit on the code,
+you can start with `1.0.0`, but that should imply some level of stability and confidence.
+You will want entries like the following in `Cargo.toml`:
+
+```toml
+name = "cw-escrow"
+version = "0.1.0"
+description = "Simple CosmWasm contract for an escrow with arbiter and timeout"
+repository = "https://github.com/confio/cosmwasm-examples"
+```
+
+You will also want to add a valid [SPDX license statement](https://spdx.org/licenses/),
+so others know the rules for using this crate. You can use any license you wish,
+even a commercial license, but we recommend choosing one of the following, unless you have
+specific requirements.
+
+* Permissive: [`Apache-2.0`](https://spdx.org/licenses/Apache-2.0.html#licenseText) or [`MIT`](https://spdx.org/licenses/MIT.html#licenseText)
+* Copyleft: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
+* Commercial license: `Commercial` (not sure if this works, I cannot find examples)
+
+It is also helpful to download the LICENSE text (linked to above) and store this
+in a LICENSE file in your repo. Now, you have properly configured your crate for use
+in a larger ecosystem.
+
+### Updating schema
+
+To allow easy use of the contract, we can publish the schema (`schema/*.json`) together
+with the source code.
+
+```sh
+cargo schema
+```
+
+Ensure you check in all the schema files, and make a git commit with the final state.
+This commit will be published and should be tagged. Generally, you will want to
+tag with the version (eg. `v0.1.0`), but in the `cosmwasm-examples` repo, we have
+multiple contracts and label it like `escrow-0.1.0`. Don't forget a
+`git push && git push --tags`
+
+### Note on build results
+
+Build results like Wasm bytecode or expected hash don't need to be updated since
+the don't belong to the source publication. However, they are excluded from packaging
+in `Cargo.toml` which allows you to commit them to your git repository if you like.
+
+```toml
+exclude = ["contract.wasm", "hash.txt"]
+```
+
+A single source code can be built with multiple different optimizers, so
+we should not make any strict assumptions on the tooling that will be used.
+
+## Publishing
+
+Now that your package is properly configured and all artifacts are committed, it
+is time to share it with the world.
+Please refer to the [complete instructions for any questions](https://rurust.github.io/cargo-docs-ru/crates-io.html),
+but I will try to give a quick overview of the happy path here.
+
+### Registry
+
+You will need an account on [crates.io](https://crates.io) to publish a rust crate.
+If you don't have one already, just click on "Log in with GitHub" in the top-right
+to quickly set up a free account. Once inside, click on your username (top-right),
+then "Account Settings". On the bottom, there is a section called "API Access".
+If you don't have this set up already, create a new token and use `cargo login`
+to set it up. This will now authenticate you with the `cargo` cli tool and allow
+you to publish.
+
+### Uploading
+
+Once this is set up, make sure you commit the current state you want to publish.
+Then try `cargo publish --dry-run`. If that works well, review the files that
+will be published via `cargo package --list`. If you are satisfied, you can now
+officially publish it via `cargo publish`.
+
+Congratulations, your package is public to the world.
+
+### Sharing
+
+Once you have published your package, people can now find it by
+[searching for "cw-" on crates.io](https://crates.io/search?q=cw).
+But that isn't exactly the simplest way. To make things easier and help
+keep the ecosystem together, we suggest making a PR to add your package
+to the [`cawesome-wasm`](https://github.com/cosmwasm/cawesome-wasm) list.
+
+### Organizations
+
+Many times you are writing a contract not as a solo developer, but rather as
+part of an organization. You will want to allow colleagues to upload new
+versions of the contract to crates.io when you are on holiday.
+[These instructions show how]() you can set up your crate to allow multiple maintainers.
+
+You can add another owner to the crate by specifying their github user. Note, you will
+now both have complete control of the crate, and they can remove you:
+
+`cargo owner --add ethanfrey`
+
+You can also add an existing github team inside your organization:
+
+`cargo owner --add github:confio:developers`
+
+The team will allow anyone who is currently in the team to publish new versions of the crate.
+And this is automatically updated when you make changes on github. However, it will not allow
+anyone in the team to add or remove other owners.

--- a/contracts/os/andromeda-vfs/README.md
+++ b/contracts/os/andromeda-vfs/README.md
@@ -1,0 +1,3 @@
+# Andromeda Factory
+
+A repository containing the NFT contract for Andromeda Protocol on Terra. This contract's primary purpose is to initialise and register ADO collections. Registration is done by a mapping between the ADO collection's symbol and the contract address for the given ADO collection. Documentation can be found [here](https://app.gitbook.com/@andromedaprotocol/s/andromeda/contracts/andromeda-factory).

--- a/contracts/os/andromeda-vfs/build.sh
+++ b/contracts/os/andromeda-vfs/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo wasm
+docker run --rm -v "$(pwd)":/code   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry   cosmwasm/rust-optimizer:0.10.3

--- a/contracts/os/andromeda-vfs/examples/schema.rs
+++ b/contracts/os/andromeda-vfs/examples/schema.rs
@@ -1,0 +1,11 @@
+use andromeda_os::kernel::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::write_api;
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+        execute: ExecuteMsg,
+
+    }
+}

--- a/contracts/os/andromeda-vfs/schema/andromeda-adodb.json
+++ b/contracts/os/andromeda-vfs/schema/andromeda-adodb.json
@@ -1,0 +1,841 @@
+{
+  "contract_name": "andromeda-adodb",
+  "contract_version": "0.1.1",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "andr_receive"
+        ],
+        "properties": {
+          "andr_receive": {
+            "$ref": "#/definitions/AndromedaMsg"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_code_id"
+        ],
+        "properties": {
+          "update_code_id": {
+            "type": "object",
+            "required": [
+              "code_id",
+              "code_id_key"
+            ],
+            "properties": {
+              "code_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "code_id_key": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "ADORecipient": {
+        "description": "ADOs use a default Receive message for handling funds, this struct states that the recipient is an ADO and may attach the data field to the Receive message",
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "description": "Addr can also be a human-readable identifier used in a app contract.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AndrAddress"
+              }
+            ]
+          },
+          "msg": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Binary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "AndrAddress": {
+        "type": "object",
+        "required": [
+          "identifier"
+        ],
+        "properties": {
+          "identifier": {
+            "description": "Can be either an address or identifier of an ADO in a app.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AndromedaMsg": {
+        "oneOf": [
+          {
+            "description": "Standard Messages",
+            "type": "object",
+            "required": [
+              "receive"
+            ],
+            "properties": {
+              "receive": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "update_owner"
+            ],
+            "properties": {
+              "update_owner": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "update_operators"
+            ],
+            "properties": {
+              "update_operators": {
+                "type": "object",
+                "required": [
+                  "operators"
+                ],
+                "properties": {
+                  "operators": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "update_app_contract"
+            ],
+            "properties": {
+              "update_app_contract": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "withdraw"
+            ],
+            "properties": {
+              "withdraw": {
+                "type": "object",
+                "properties": {
+                  "recipient": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Recipient"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "tokens_to_withdraw": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Withdrawal"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "register_module"
+            ],
+            "properties": {
+              "register_module": {
+                "type": "object",
+                "required": [
+                  "module"
+                ],
+                "properties": {
+                  "module": {
+                    "$ref": "#/definitions/Module"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "deregister_module"
+            ],
+            "properties": {
+              "deregister_module": {
+                "type": "object",
+                "required": [
+                  "module_idx"
+                ],
+                "properties": {
+                  "module_idx": {
+                    "$ref": "#/definitions/Uint64"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "alter_module"
+            ],
+            "properties": {
+              "alter_module": {
+                "type": "object",
+                "required": [
+                  "module",
+                  "module_idx"
+                ],
+                "properties": {
+                  "module": {
+                    "$ref": "#/definitions/Module"
+                  },
+                  "module_idx": {
+                    "$ref": "#/definitions/Uint64"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "refresh_address"
+            ],
+            "properties": {
+              "refresh_address": {
+                "type": "object",
+                "required": [
+                  "contract"
+                ],
+                "properties": {
+                  "contract": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "refresh_addresses"
+            ],
+            "properties": {
+              "refresh_addresses": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "start_after": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
+      "Module": {
+        "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+        "type": "object",
+        "required": [
+          "address",
+          "is_mutable",
+          "module_type"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/definitions/AndrAddress"
+          },
+          "is_mutable": {
+            "type": "boolean"
+          },
+          "module_type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Recipient": {
+        "oneOf": [
+          {
+            "description": "An address that is not another ADO. It is assumed that it is a valid address.",
+            "type": "object",
+            "required": [
+              "addr"
+            ],
+            "properties": {
+              "addr": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "a_d_o"
+            ],
+            "properties": {
+              "a_d_o": {
+                "$ref": "#/definitions/ADORecipient"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      },
+      "Withdrawal": {
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "withdrawal_type": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/WithdrawalType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "WithdrawalType": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "percentage"
+            ],
+            "properties": {
+              "percentage": {
+                "$ref": "#/definitions/Decimal"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "andr_query"
+        ],
+        "properties": {
+          "andr_query": {
+            "$ref": "#/definitions/AndromedaQuery"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "All code IDs for Andromeda contracts",
+        "type": "object",
+        "required": [
+          "code_id"
+        ],
+        "properties": {
+          "code_id": {
+            "type": "object",
+            "required": [
+              "key"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "AndromedaQuery": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "get"
+            ],
+            "properties": {
+              "get": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "owner"
+            ],
+            "properties": {
+              "owner": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "operators"
+            ],
+            "properties": {
+              "operators": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "original_publisher"
+            ],
+            "properties": {
+              "original_publisher": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "block_height_upon_creation"
+            ],
+            "properties": {
+              "block_height_upon_creation": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "is_operator"
+            ],
+            "properties": {
+              "is_operator": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "module"
+            ],
+            "properties": {
+              "module": {
+                "type": "object",
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "id": {
+                    "$ref": "#/definitions/Uint64"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "module_ids"
+            ],
+            "properties": {
+              "module_ids": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "version"
+            ],
+            "properties": {
+              "version": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "andr_query": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "AndromedaQuery",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "get"
+          ],
+          "properties": {
+            "get": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Binary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "owner"
+          ],
+          "properties": {
+            "owner": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "operators"
+          ],
+          "properties": {
+            "operators": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "original_publisher"
+          ],
+          "properties": {
+            "original_publisher": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "block_height_upon_creation"
+          ],
+          "properties": {
+            "block_height_upon_creation": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "is_operator"
+          ],
+          "properties": {
+            "is_operator": {
+              "type": "object",
+              "required": [
+                "address"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "module"
+          ],
+          "properties": {
+            "module": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/Uint64"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "module_ids"
+          ],
+          "properties": {
+            "module_ids": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "version"
+          ],
+          "properties": {
+            "version": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "definitions": {
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "code_id": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "uint64",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  }
+}

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -28,7 +28,7 @@ pub fn instantiate(
         deps.api,
         info,
         BaseInstantiateMsg {
-            ado_type: "adodb".to_string(),
+            ado_type: "vfs".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
             operators: None,
             modules: None,

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -167,7 +167,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 }
 
 fn from_semver(err: semver::Error) -> StdError {
-    StdError::generic_err(format!("Semver: {}", err))
+    StdError::generic_err(format!("Semver: {err}"))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -1,0 +1,114 @@
+use ado_base::state::ADOContract;
+use amp::messages::AMPPkt;
+use andromeda_os::vfs::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use common::{
+    ado_base::{AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
+    encode_binary,
+    error::ContractError,
+};
+use cosmwasm_std::{
+    attr, ensure, entry_point, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdError,
+};
+use cw2::{get_contract_version, set_contract_version};
+use semver::Version;
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:andromeda-vfs";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    ADOContract::default().instantiate(
+        deps.storage,
+        env,
+        deps.api,
+        info,
+        BaseInstantiateMsg {
+            ado_type: "adodb".to_string(),
+            ado_version: CONTRACT_VERSION.to_string(),
+            operators: None,
+            modules: None,
+            primitive_contract: None,
+            kernel_address: Some(msg.kernel_address),
+        },
+    )
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    if msg.result.is_err() {
+        return Err(ContractError::Std(StdError::generic_err(
+            msg.result.unwrap_err(),
+        )));
+    }
+
+    Ok(Response::default())
+}
+
+pub struct ExecuteEnv<'a> {
+    deps: DepsMut<'a>,
+    pub env: Env,
+    pub info: MessageInfo,
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    let execute_env = ExecuteEnv { deps, env, info };
+
+    match msg {}
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // New version
+    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
+
+    // Old version
+    let stored = get_contract_version(deps.storage)?;
+    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
+
+    let contract = ADOContract::default();
+
+    ensure!(
+        stored.contract == CONTRACT_NAME,
+        ContractError::CannotMigrate {
+            previous_contract: stored.contract,
+        }
+    );
+
+    // New version has to be newer/greater than the old version
+    ensure!(
+        storage_version < version,
+        ContractError::CannotMigrate {
+            previous_contract: stored.version,
+        }
+    );
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // Update the ADOContract's version
+    contract.execute_update_version(deps)?;
+
+    Ok(Response::default())
+}
+
+fn from_semver(err: semver::Error) -> StdError {
+    StdError::generic_err(format!("Semver: {}", err))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+    match msg {}
+}

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -1,13 +1,12 @@
 use ado_base::state::ADOContract;
-use amp::messages::AMPPkt;
+
 use andromeda_os::vfs::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use common::{
-    ado_base::{AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
-    encode_binary,
+    ado_base::{InstantiateMsg as BaseInstantiateMsg},
     error::ContractError,
 };
 use cosmwasm_std::{
-    attr, ensure, entry_point, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
     StdError,
 };
 use cw2::{get_contract_version, set_contract_version};
@@ -65,7 +64,7 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let execute_env = ExecuteEnv { deps, env, info };
+    let _execute_env = ExecuteEnv { deps, env, info };
 
     match msg {}
 }
@@ -109,6 +108,6 @@ fn from_semver(err: semver::Error) -> StdError {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {}
 }

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -8,9 +8,7 @@ use cosmwasm_std::{
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;
 
-use crate::state::{
-    add_pathname, paths, resolve_pathname, validate_pathname, validate_username, PathInfo, USERS,
-};
+use crate::state::{add_pathname, resolve_pathname, validate_pathname, validate_username, USERS};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-vfs";

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -157,5 +157,5 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
 
 fn query_resolve_path(deps: Deps, path: String) -> Result<Addr, ContractError> {
     validate_pathname(path.clone())?;
-    Ok(resolve_pathname(deps.storage, deps.api, path)?)
+    resolve_pathname(deps.storage, deps.api, path)
 }

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -1,13 +1,9 @@
 use ado_base::state::ADOContract;
 
 use andromeda_os::vfs::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use common::{
-    ado_base::{InstantiateMsg as BaseInstantiateMsg},
-    error::ContractError,
-};
+use common::{ado_base::InstantiateMsg as BaseInstantiateMsg, error::ContractError};
 use cosmwasm_std::{
-    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdError,
+    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
 };
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;

--- a/contracts/os/andromeda-vfs/src/lib.rs
+++ b/contracts/os/andromeda-vfs/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod contract;
+#[cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+pub mod mock;
+
+mod state;
+
+#[cfg(test)]
+mod testing;

--- a/contracts/os/andromeda-vfs/src/mock.rs
+++ b/contracts/os/andromeda-vfs/src/mock.rs
@@ -1,28 +1,35 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 
 use crate::contract::{execute, instantiate, query, reply};
-use andromeda_os::kernel::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use cosmwasm_std::Empty;
+use andromeda_os::vfs::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::{Addr, Empty};
 use cw_multi_test::{Contract, ContractWrapper};
 
-pub fn mock_andromeda_kernel() -> Box<dyn Contract<Empty>> {
+pub fn mock_andromeda_vfs() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new_with_empty(execute, instantiate, query).with_reply(reply);
     Box::new(contract)
 }
 
-pub fn mock_kernel_instantiate_message() -> InstantiateMsg {
-    InstantiateMsg {}
-}
-
-pub fn mock_upsert_key_address(key: impl Into<String>, value: impl Into<String>) -> ExecuteMsg {
-    ExecuteMsg::UpsertKeyAddress {
-        key: key.into(),
-        value: value.into(),
+pub fn mock_vfs_instantiate_message(kernel_address: impl Into<String>) -> InstantiateMsg {
+    InstantiateMsg {
+        kernel_address: kernel_address.into(),
     }
 }
 
-pub fn mock_verify_address(address: impl Into<String>) -> QueryMsg {
-    QueryMsg::VerifyAddress {
-        address: address.into(),
+pub fn mock_register_user(username: impl Into<String>, address: Option<Addr>) -> ExecuteMsg {
+    ExecuteMsg::RegisterUser {
+        username: username.into(),
+        address,
     }
+}
+
+pub fn mock_add_path(name: impl Into<String>, address: Addr) -> ExecuteMsg {
+    ExecuteMsg::AddPath {
+        name: name.into(),
+        address,
+    }
+}
+
+pub fn mock_resolve_path_query(path: impl Into<String>) -> QueryMsg {
+    QueryMsg::ResolvePath { path: path.into() }
 }

--- a/contracts/os/andromeda-vfs/src/mock.rs
+++ b/contracts/os/andromeda-vfs/src/mock.rs
@@ -1,0 +1,28 @@
+#![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+
+use crate::contract::{execute, instantiate, query, reply};
+use andromeda_os::kernel::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::Empty;
+use cw_multi_test::{Contract, ContractWrapper};
+
+pub fn mock_andromeda_kernel() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new_with_empty(execute, instantiate, query).with_reply(reply);
+    Box::new(contract)
+}
+
+pub fn mock_kernel_instantiate_message() -> InstantiateMsg {
+    InstantiateMsg {}
+}
+
+pub fn mock_upsert_key_address(key: impl Into<String>, value: impl Into<String>) -> ExecuteMsg {
+    ExecuteMsg::UpsertKeyAddress {
+        key: key.into(),
+        value: value.into(),
+    }
+}
+
+pub fn mock_verify_address(address: impl Into<String>) -> QueryMsg {
+    QueryMsg::VerifyAddress {
+        address: address.into(),
+    }
+}

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -1,0 +1,233 @@
+use common::error::ContractError;
+use cosmwasm_std::{ensure, Addr, Api, StdError, Storage};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Map, MultiIndex};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct PathInfo {
+    name: String,
+    addr: Addr,
+}
+
+pub struct PathIndices<'a> {
+    /// PK: parent_address + component_name
+    /// Secondary key: component_name
+    pub index: MultiIndex<'a, String, PathInfo, String>,
+}
+
+impl<'a> IndexList<PathInfo> for PathIndices<'a> {
+    fn get_indexes(
+        &'_ self,
+    ) -> Box<dyn Iterator<Item = &'_ dyn cw_storage_plus::Index<PathInfo>> + '_> {
+        let v: Vec<&dyn Index<PathInfo>> = vec![&self.index];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn paths<'a>() -> IndexedMap<'a, &'a str, PathInfo, PathIndices<'a>> {
+    let indexes = PathIndices {
+        index: MultiIndex::new(|_pk: &[u8], r| r.name.clone(), "path", "path_index"),
+    };
+    IndexedMap::new("path", indexes)
+}
+
+pub const USERS: Map<&str, Addr> = Map::new("users");
+
+pub fn split_pathname(path: String) -> Vec<String> {
+    path.split("/")
+        .filter(|string| string.len() > 0)
+        .map(|string| string.to_string())
+        .collect::<Vec<String>>()
+}
+
+pub const VALID_CHARACTERS: [&'static str; 4] = ["_", "-", "/", ":"];
+
+pub fn validate_pathname(path: String) -> Result<bool, ContractError> {
+    ensure!(
+        path.len() > 0,
+        ContractError::InvalidPathname {
+            error: Some("Empty path".to_string())
+        }
+    );
+    ensure!(
+        path.chars().any(|character| character.is_alphanumeric()),
+        ContractError::InvalidPathname {
+            error: Some("Path name does not include any valid characters".to_string())
+        }
+    );
+    // let valid_characters: Vec<&str> = vec!["_", "-"];
+
+    ensure!(
+        path.chars().all(|character| character.is_alphanumeric()
+            | VALID_CHARACTERS
+                .iter()
+                .any(|valid| valid.chars().next().eq(&Some(character)))),
+        ContractError::InvalidPathname {
+            error: Some("Pathname includes an invalid character".to_string())
+        }
+    );
+    Ok(true)
+}
+
+pub fn resolve_pathname(
+    storage: &dyn Storage,
+    api: &dyn Api,
+    pathname: String,
+) -> Result<Addr, ContractError> {
+    let parts = split_pathname(pathname);
+
+    let username_or_address = parts.first().unwrap();
+    let user_address = match api.addr_validate(username_or_address) {
+        Ok(addr) => addr,
+        Err(_e) => USERS.load(storage, &username_or_address.as_str())?,
+    };
+    let mut address = user_address;
+    for (idx, part) in parts.iter().enumerate() {
+        if idx == 0 {
+            continue;
+        }
+
+        address = paths()
+            .load(storage, &(address.to_string() + part.as_str()).as_str())?
+            .addr;
+    }
+
+    Ok(address)
+}
+
+pub fn add_pathname(
+    storage: &mut dyn Storage,
+    parent_addr: Addr,
+    name: String,
+    addr: Addr,
+) -> Result<(), StdError> {
+    paths().save(
+        storage,
+        &(parent_addr.to_string() + name.as_str()),
+        &PathInfo { name, addr },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use cosmwasm_std::testing::mock_dependencies;
+
+    use super::*;
+
+    #[test]
+    fn test_split_pathname() {
+        let pathname = "/username/dir1/dir2/file";
+
+        let res = split_pathname(pathname.to_string());
+        let expected = vec!["username", "dir1", "dir2", "file"];
+
+        assert_eq!(res, expected)
+    }
+
+    #[test]
+    fn test_validate_pathname() {
+        let valid_path = "/username/dir1/file";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let valid_path = "username/dir1/file";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let valid_path = "/username/dir1/file/";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let empty_path = "";
+        let res = validate_pathname(empty_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "///////";
+        let res = validate_pathname(invalid_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "/username/dir1/f!le";
+        let res = validate_pathname(invalid_path.to_string());
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn test_resolve_pathname() {
+        let mut deps = mock_dependencies();
+        let username = "u1";
+        let first_directory = "d1";
+        let second_directory = "d2";
+        let file = "f1";
+
+        let username_address = Addr::unchecked("useraddress");
+        let first_directory_address = Addr::unchecked("dir1address");
+        let second_directory_address = Addr::unchecked("dir2address");
+        let file_address = Addr::unchecked("fileaddress");
+
+        USERS
+            .save(deps.as_mut().storage, username, &username_address)
+            .unwrap();
+
+        let res = resolve_pathname(
+            deps.as_ref().storage,
+            deps.as_ref().api,
+            username.to_string(),
+        )
+        .unwrap();
+        assert_eq!(res, username_address);
+
+        paths()
+            .save(
+                deps.as_mut().storage,
+                (username_address.to_string() + first_directory).as_str(),
+                &PathInfo {
+                    name: first_directory.to_string(),
+                    addr: first_directory_address.clone(),
+                },
+            )
+            .unwrap();
+
+        let res = resolve_pathname(
+            deps.as_ref().storage,
+            deps.as_ref().api,
+            "/u1/d1".to_string(),
+        )
+        .unwrap();
+        assert_eq!(res, first_directory_address);
+
+        paths()
+            .save(
+                deps.as_mut().storage,
+                (first_directory_address.to_string() + second_directory).as_str(),
+                &PathInfo {
+                    name: second_directory.to_string(),
+                    addr: second_directory_address.clone(),
+                },
+            )
+            .unwrap();
+
+        let res = resolve_pathname(
+            deps.as_ref().storage,
+            deps.as_ref().api,
+            "/u1/d1/d2".to_string(),
+        )
+        .unwrap();
+        assert_eq!(res, second_directory_address);
+
+        paths()
+            .save(
+                deps.as_mut().storage,
+                (second_directory_address.to_string() + file).as_str(),
+                &PathInfo {
+                    name: file.to_string(),
+                    addr: file_address.clone(),
+                },
+            )
+            .unwrap();
+
+        let res = resolve_pathname(
+            deps.as_ref().storage,
+            deps.as_ref().api,
+            "/u1/d1/d2/f1".to_string(),
+        )
+        .unwrap();
+        assert_eq!(res, file_address)
+    }
+}

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -40,35 +40,6 @@ pub fn split_pathname(path: String) -> Vec<String> {
         .collect::<Vec<String>>()
 }
 
-pub const VALID_CHARACTERS: [&str; 4] = ["_", "-", "/", ":"];
-
-pub fn validate_pathname(path: String) -> Result<bool, ContractError> {
-    ensure!(
-        !path.is_empty(),
-        ContractError::InvalidPathname {
-            error: Some("Empty path".to_string())
-        }
-    );
-    ensure!(
-        path.chars().any(|character| character.is_alphanumeric()),
-        ContractError::InvalidPathname {
-            error: Some("Path name does not include any valid characters".to_string())
-        }
-    );
-    // let valid_characters: Vec<&str> = vec!["_", "-"];
-
-    ensure!(
-        path.chars().all(|character| character.is_alphanumeric()
-            | VALID_CHARACTERS
-                .iter()
-                .any(|valid| valid.chars().next().eq(&Some(character)))),
-        ContractError::InvalidPathname {
-            error: Some("Pathname includes an invalid character".to_string())
-        }
-    );
-    Ok(true)
-}
-
 pub fn resolve_pathname(
     storage: &dyn Storage,
     api: &dyn Api,
@@ -143,30 +114,6 @@ mod test {
         let expected = vec!["username", "dir1", "dir2", "file"];
 
         assert_eq!(res, expected)
-    }
-
-    #[test]
-    fn test_validate_pathname() {
-        let valid_path = "/username/dir1/file";
-        validate_pathname(valid_path.to_string()).unwrap();
-
-        let valid_path = "username/dir1/file";
-        validate_pathname(valid_path.to_string()).unwrap();
-
-        let valid_path = "/username/dir1/file/";
-        validate_pathname(valid_path.to_string()).unwrap();
-
-        let empty_path = "";
-        let res = validate_pathname(empty_path.to_string());
-        assert!(res.is_err());
-
-        let invalid_path = "///////";
-        let res = validate_pathname(invalid_path.to_string());
-        assert!(res.is_err());
-
-        let invalid_path = "/username/dir1/f!le";
-        let res = validate_pathname(invalid_path.to_string());
-        assert!(res.is_err())
     }
 
     #[test]

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -34,17 +34,17 @@ pub fn paths<'a>() -> IndexedMap<'a, &'a str, PathInfo, PathIndices<'a>> {
 pub const USERS: Map<&str, Addr> = Map::new("users");
 
 pub fn split_pathname(path: String) -> Vec<String> {
-    path.split("/")
-        .filter(|string| string.len() > 0)
+    path.split('/')
+        .filter(|string| !string.is_empty())
         .map(|string| string.to_string())
         .collect::<Vec<String>>()
 }
 
-pub const VALID_CHARACTERS: [&'static str; 4] = ["_", "-", "/", ":"];
+pub const VALID_CHARACTERS: [&str; 4] = ["_", "-", "/", ":"];
 
 pub fn validate_pathname(path: String) -> Result<bool, ContractError> {
     ensure!(
-        path.len() > 0,
+        !path.is_empty(),
         ContractError::InvalidPathname {
             error: Some("Empty path".to_string())
         }
@@ -79,7 +79,7 @@ pub fn resolve_pathname(
     let username_or_address = parts.first().unwrap();
     let user_address = match api.addr_validate(username_or_address) {
         Ok(addr) => addr,
-        Err(_e) => USERS.load(storage, &username_or_address.as_str())?,
+        Err(_e) => USERS.load(storage, username_or_address.as_str())?,
     };
     let mut address = user_address;
     for (idx, part) in parts.iter().enumerate() {
@@ -88,7 +88,7 @@ pub fn resolve_pathname(
         }
 
         address = paths()
-            .load(storage, &(address.to_string() + part.as_str()).as_str())?
+            .load(storage, (address.to_string() + part.as_str()).as_str())?
             .addr;
     }
 

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -111,7 +111,7 @@ pub fn add_pathname(
 
 pub fn validate_username(username: String) -> Result<bool, ContractError> {
     ensure!(
-        username.len() > 0,
+        !username.is_empty(),
         ContractError::InvalidUsername {
             error: Some("Username cannot be empty.".to_string())
         }

--- a/contracts/os/andromeda-vfs/src/testing/mod.rs
+++ b/contracts/os/andromeda-vfs/src/testing/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -1,7 +1,14 @@
-use crate::contract::instantiate;
+use crate::{
+    contract::{execute, instantiate},
+    state::{resolve_pathname, USERS},
+};
 
-use andromeda_os::vfs::InstantiateMsg;
-use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use andromeda_os::vfs::{ExecuteMsg, InstantiateMsg};
+use common::error::ContractError;
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, mock_info},
+    Addr,
+};
 
 #[test]
 fn proper_initialization() {
@@ -14,4 +21,96 @@ fn proper_initialization() {
 
     let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
     assert_eq!(0, res.messages.len());
+}
+
+#[test]
+fn test_register_user() {
+    let mut deps = mock_dependencies();
+    let username = "user1";
+    let sender = "sender";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
+
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(saved, sender)
+}
+
+#[test]
+fn test_register_user_unauthorized() {
+    let mut deps = mock_dependencies();
+    let username = "user1";
+    let sender = "sender";
+    let occupier = "occupier";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
+
+    USERS
+        .save(deps.as_mut().storage, username, &Addr::unchecked(occupier))
+        .unwrap();
+
+    let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(res, ContractError::Unauthorized {})
+}
+
+#[test]
+fn test_register_user_proxy() {
+    let mut deps = mock_dependencies();
+    let username = "user1";
+    let sender = "sender";
+    let new_occupier = "occupier";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: Some(Addr::unchecked(new_occupier)),
+    };
+
+    USERS
+        .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
+        .unwrap();
+
+    execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+
+    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(saved, new_occupier);
+
+    let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(res, ContractError::Unauthorized {})
+}
+
+#[test]
+fn test_add_path() {
+    let mut deps = mock_dependencies();
+    let username = "u1";
+    let component_name = "f1";
+    let sender = "sender";
+    let component_addr = Addr::unchecked("f1addr");
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::AddPath {
+        name: component_name.to_string(),
+        address: component_addr.clone(),
+    };
+
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    USERS
+        .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
+        .unwrap();
+
+    let path = format!("/{}/{}", username, component_name);
+
+    let resolved_addr = resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path).unwrap();
+
+    assert_eq!(resolved_addr, component_addr)
 }

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -1,0 +1,17 @@
+use crate::contract::instantiate;
+
+use andromeda_os::vfs::InstantiateMsg;
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+
+#[test]
+fn proper_initialization() {
+    let mut deps = mock_dependencies();
+    let info = mock_info("creator", &[]);
+    let msg = InstantiateMsg {
+        kernel_address: "kernel".to_string(),
+    };
+    let env = mock_env();
+
+    let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+    assert_eq!(0, res.messages.len());
+}

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -108,7 +108,7 @@ fn test_add_path() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
         .unwrap();
 
-    let path = format!("/{}/{}", username, component_name);
+    let path = format!("/{username}/{component_name}");
 
     let resolved_addr = resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path).unwrap();
 
@@ -135,7 +135,7 @@ fn test_add_parent_path() {
         .save(deps.as_mut().storage, username, &user_address)
         .unwrap();
 
-    let path = format!("/{}/{}", username, component_name);
+    let path = format!("/{username}/{component_name}");
 
     let resolved_addr = resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path).unwrap();
 

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -114,3 +114,30 @@ fn test_add_path() {
 
     assert_eq!(resolved_addr, component_addr)
 }
+
+#[test]
+fn test_add_parent_path() {
+    let mut deps = mock_dependencies();
+    let username = "u1";
+    let user_address = Addr::unchecked("useraddr");
+    let component_name = "f1";
+    let sender = "sender";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::AddParentPath {
+        name: component_name.to_string(),
+        parent_address: user_address.clone(),
+    };
+
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    USERS
+        .save(deps.as_mut().storage, username, &user_address)
+        .unwrap();
+
+    let path = format!("/{}/{}", username, component_name);
+
+    let resolved_addr = resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path).unwrap();
+
+    assert_eq!(resolved_addr, sender)
+}

--- a/packages/ado-base/Cargo.toml
+++ b/packages/ado-base/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 common = { version = "0.1.0", path = "../../packages/common" }
 cw2 = "0.16.0"
 semver = "1"
+andromeda-os = { version = "0.1.0", path = "../../packages/andromeda-os" }
 
 cw20 = { version = "0.16.0", optional = true}
 cw-asset = { version = "2.0.0", optional = true }

--- a/packages/ado-base/src/instantiate.rs
+++ b/packages/ado-base/src/instantiate.rs
@@ -40,8 +40,12 @@ impl<'a> ADOContract<'a> {
         name: &str,
     ) -> Result<u64, ContractError> {
         // Do we want to cache the factory address?
-        let factory_address = self.get_address_from_primitive(storage, querier, "adodb")?;
-        let code_id: u64 = query_get(Some(encode_binary(&name)?), factory_address, querier)?;
+        let factory_address = self.get_address_from_kernel(storage, querier, "adodb")?;
+        let code_id: u64 = query_get(
+            Some(encode_binary(&name)?),
+            factory_address.to_string(),
+            querier,
+        )?;
         Ok(code_id)
     }
 }

--- a/packages/ado-base/src/modules/hooks.rs
+++ b/packages/ado-base/src/modules/hooks.rs
@@ -21,7 +21,6 @@ impl<'a> ADOContract<'a> {
         hook_msg: AndromedaHook,
     ) -> Result<Vec<T>, ContractError> {
         let addresses: Vec<String> = self.load_module_addresses(storage, api, &querier)?;
-        println!("1 module hook {:?}", addresses);
         let mut resp: Vec<T> = Vec::new();
         for addr in addresses {
             let mod_resp = hook_query::<T>(&querier, hook_msg.clone(), addr)?;
@@ -118,7 +117,6 @@ fn hook_query<T: DeserializeOwned>(
     addr: String,
 ) -> Result<Option<T>, ContractError> {
     let msg = HookMsg::AndrHook(hook_msg);
-    println!("2 hook msg {:?}", msg);
     let mod_resp: Result<Option<T>, StdError> = querier.query_wasm_smart(addr, &msg);
     process_module_response(mod_resp)
 }

--- a/packages/ado-base/src/modules/hooks.rs
+++ b/packages/ado-base/src/modules/hooks.rs
@@ -1,6 +1,4 @@
-use cosmwasm_std::{
-    from_binary, to_binary, Api, Binary, Event, QuerierWrapper, StdError, Storage, SubMsg,
-};
+use cosmwasm_std::{to_binary, Api, Binary, Event, QuerierWrapper, StdError, Storage, SubMsg};
 use serde::de::DeserializeOwned;
 
 use crate::modules::ADOContract;

--- a/packages/ado-base/src/primitive.rs
+++ b/packages/ado-base/src/primitive.rs
@@ -1,9 +1,10 @@
 use crate::ADOContract;
 
+use andromeda_os::kernel::QueryMsg as KernelQueryMsg;
 use common::{
     ado_base::query_get, encode_binary, error::ContractError, primitive::GetValueResponse,
 };
-use cosmwasm_std::{DepsMut, Order, QuerierWrapper, Response, Storage};
+use cosmwasm_std::{Addr, DepsMut, Order, QuerierWrapper, Response, Storage};
 use cw_storage_plus::Bound;
 
 const DEFAULT_LIMIT: u32 = 10;
@@ -33,6 +34,7 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Gets the address for `contract` stored in the primitive contract.
+    /// TODO: REMOVE
     pub fn get_address_from_primitive(
         &self,
         storage: &dyn Storage,
@@ -43,6 +45,22 @@ impl<'a> ADOContract<'a> {
         let data = encode_binary(&contract)?;
         let res: GetValueResponse = query_get(Some(data), primitive_address.to_string(), querier)?;
         let address = res.value.try_get_string()?;
+
+        Ok(address)
+    }
+
+    /// Gets the address for `contract` stored in the primitive contract.
+    pub fn get_address_from_kernel(
+        &self,
+        storage: &dyn Storage,
+        querier: &QuerierWrapper,
+        contract: &str,
+    ) -> Result<Addr, ContractError> {
+        let kernel_address = self.kernel_address.load(storage)?;
+        let query = KernelQueryMsg::KeyAddress {
+            key: contract.to_string(),
+        };
+        let address: Addr = querier.query_wasm_smart(kernel_address, &query)?;
 
         Ok(address)
     }

--- a/packages/amp/src/messages.rs
+++ b/packages/amp/src/messages.rs
@@ -58,7 +58,7 @@ impl AMPMsg {
         querier: &QuerierWrapper,
         vfs_contract: Option<Addr>,
     ) -> Result<Addr, ContractError> {
-        if self.recipient.contains("/") {
+        if self.recipient.contains('/') {
             match vfs_contract {
                 Some(vfs_contract) => {
                     let query = VFSQueryMsg::ResolvePath {

--- a/packages/amp/src/messages.rs
+++ b/packages/amp/src/messages.rs
@@ -10,6 +10,11 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
+pub enum VFSQueryMsg {
+    ResolvePath { path: String },
+}
+
+#[cw_serde]
 /// This struct defines how the kernel parses and relays messages between ADOs
 /// It contains a simple recipient string which may use our namespacing implementation or a simple contract address
 /// If the desired recipient is via IBC then namespacing must be employed
@@ -50,22 +55,32 @@ impl AMPMsg {
     pub fn get_recipient_address(
         &self,
         api: &dyn Api,
-        _querier: &QuerierWrapper,
-        _namespacing_contract: Option<Addr>,
-    ) -> Result<String, ContractError> {
+        querier: &QuerierWrapper,
+        vfs_contract: Option<Addr>,
+    ) -> Result<Addr, ContractError> {
+        if self.recipient.contains("/") {
+            match vfs_contract {
+                Some(vfs_contract) => {
+                    let query = VFSQueryMsg::ResolvePath {
+                        path: self.recipient.clone(),
+                    };
+                    return Ok(querier.query_wasm_smart(vfs_contract, &query)?);
+                }
+                None => return Err(ContractError::InvalidAddress {}),
+            }
+        }
+
         let addr = api.addr_validate(&self.recipient);
         match addr {
-            Ok(addr) => Ok(addr.to_string()),
+            Ok(addr) => Ok(addr),
             Err(_) => Err(ContractError::InvalidAddress {}),
         }
     }
 
     /// Generates a sub message for the given AMP Message
-    pub fn generate_message(
+    pub fn generate_sub_message(
         &self,
-        // api: &dyn Api,
-        // querier: &QuerierWrapper,
-        contract_addr: String,
+        contract_addr: impl Into<String>,
         origin: String,
         previous_sender: String,
         id: u64,
@@ -77,7 +92,7 @@ impl AMPMsg {
             reply_on: self.reply_on.clone(),
             gas_limit: self.gas_limit,
             msg: CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr,
+                contract_addr: contract_addr.into(),
                 msg,
                 funds: self.funds.to_vec(),
             }),

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -27,8 +27,7 @@ impl AppComponent {
 pub struct InstantiateMsg {
     pub app_components: Vec<AppComponent>,
     pub name: String,
-    pub primitive_contract: String,
-    pub kernel_address: Option<String>,
+    pub kernel_address: String,
     // Used for automation
     pub target_ados: Option<Vec<String>>,
 }

--- a/packages/andromeda-automation/src/process.rs
+++ b/packages/andromeda-automation/src/process.rs
@@ -13,7 +13,6 @@ pub struct ProcessComponent {
 pub struct InstantiateMsg {
     pub process: Vec<ProcessComponent>,
     pub name: String,
-    pub primitive_contract: String,
     pub first_ados: Vec<String>,
     pub kernel_address: Option<String>,
 }

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -37,6 +37,17 @@ pub enum AMPRecipient {
     ADO(ADORecipient),
 }
 
+impl AMPRecipient {
+    pub fn ado(address: impl Into<String>, msg: Option<Binary>) -> AMPRecipient {
+        let ado_recipient = ADORecipient {
+            address: address.into(),
+            msg,
+        };
+
+        AMPRecipient::ADO(ado_recipient)
+    }
+}
+
 pub fn generate_msg_native_kernel(
     funds: Vec<Coin>,
     origin: String,

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -99,18 +99,15 @@ impl AMPRecipient {
         _kernel_address: String,
     ) -> Result<SubMsg, ContractError> {
         Ok(match &self {
-            AMPRecipient::ADO(recip) => {
-                println!("Generate message native ADO");
-                SubMsg::new(WasmMsg::Execute {
-                    contract_addr: recip.address.to_owned(),
-                    msg: encode_binary(&AMPExecuteMsg::AMPReceive(AMPPkt::new(
-                        origin,
-                        previous_sender,
-                        messages,
-                    )))?,
-                    funds,
-                })
-            }
+            AMPRecipient::ADO(recip) => SubMsg::new(WasmMsg::Execute {
+                contract_addr: recip.address.to_owned(),
+                msg: encode_binary(&AMPExecuteMsg::AMPReceive(AMPPkt::new(
+                    origin,
+                    previous_sender,
+                    messages,
+                )))?,
+                funds,
+            }),
             AMPRecipient::Addr(addr) => SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
                 to_address: addr.clone(),
                 amount: funds,

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -58,7 +58,7 @@ pub fn generate_msg_native_kernel(
 ) -> Result<SubMsg, ContractError> {
     Ok(SubMsg::new(WasmMsg::Execute {
         contract_addr: kernel_address,
-        msg: encode_binary(&KernelExecuteMsg::Receive(AMPPkt::new(
+        msg: encode_binary(&KernelExecuteMsg::AMPReceive(AMPPkt::new(
             origin,
             previous_sender,
             messages,

--- a/packages/andromeda-os/Cargo.toml
+++ b/packages/andromeda-os/Cargo.toml
@@ -20,6 +20,7 @@ semver = "1"
 amp = { version = "0.1.0", path = "../amp" }
 cw20 = { version = "0.16.0", optional = true}
 cw-asset = { version = "2.0.0", optional = true }
+regex = "1"
 
 [dev-dependencies]
 cw20 = "0.16.0"

--- a/packages/andromeda-os/src/kernel.rs
+++ b/packages/andromeda-os/src/kernel.rs
@@ -10,7 +10,7 @@ pub struct InstantiateMsg {}
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Receives an AMP Packet for relaying
-    Receive(AMPPkt),
+    AMPReceive(AMPPkt),
     /// Upserts a key address to the kernel, restricted to the owner of the kernel
     UpsertKeyAddress { key: String, value: String },
 }

--- a/packages/andromeda-os/src/lib.rs
+++ b/packages/andromeda-os/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod adodb;
 pub mod kernel;
+pub mod vfs;

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -1,5 +1,34 @@
+use common::error::ContractError;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
+use cosmwasm_std::{ensure, Addr};
+use regex::Regex;
+
+pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([^/:\s]+(/)?)+$";
+pub const COMPONENT_NAME_REGEX: &str = r"^([^/^:\s]+)+$";
+
+pub fn validate_component_name(path: String) -> Result<bool, ContractError> {
+    let re = Regex::new(COMPONENT_NAME_REGEX).unwrap();
+
+    ensure!(
+        re.is_match(&path),
+        ContractError::InvalidPathname {
+            error: Some("Pathname includes an invalid character".to_string())
+        }
+    );
+    Ok(true)
+}
+
+pub fn validate_pathname(path: String) -> Result<bool, ContractError> {
+    let re = Regex::new(PATH_REGEX).unwrap();
+
+    ensure!(
+        re.is_match(&path),
+        ContractError::InvalidPathname {
+            error: Some("Pathname includes an invalid character".to_string())
+        }
+    );
+    Ok(true)
+}
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -30,9 +59,10 @@ pub enum ExecuteMsg {
         name: String,
         address: Addr,
     },
-    // AddPathMulti {
-    //     paths: Vec<PathDetails>,
-    // },
+    AddParentPath {
+        name: String,
+        parent_address: Addr,
+    },
     RegisterUser {
         username: String,
         address: Option<Addr>,
@@ -47,4 +77,56 @@ pub struct MigrateMsg {}
 pub enum QueryMsg {
     #[returns(Addr)]
     ResolvePath { path: String },
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_validate_component_name() {
+        let valid_name = "component1";
+        validate_component_name(valid_name.to_string()).unwrap();
+
+        let valid_name = "component-1";
+        validate_component_name(valid_name.to_string()).unwrap();
+
+        let empty_name = "";
+        let res = validate_component_name(empty_name.to_string());
+        assert!(res.is_err());
+
+        let invalid_name = "/ /";
+        let res = validate_component_name(invalid_name.to_string());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_validate_pathname() {
+        let valid_path = "/username";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let valid_path = "username/dir1/file";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let valid_path = "/username/dir1/file/";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let valid_path = "vfs://home/username/dir1/file/";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let valid_path = "vfs://chain/username/dir1/file/";
+        validate_pathname(valid_path.to_string()).unwrap();
+
+        let empty_path = "";
+        let res = validate_pathname(empty_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "//// ///";
+        let res = validate_pathname(invalid_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "vfs:/username/dir1/f!le";
+        let res = validate_pathname(invalid_path.to_string());
+        assert!(res.is_err())
+    }
 }

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -1,8 +1,4 @@
-
 use cosmwasm_schema::{cw_serde, QueryResponses};
-
-
-
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -1,8 +1,8 @@
-use common::ado_base::AndromedaQuery;
-use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
 
-use amp::messages::AMPPkt;
+use cosmwasm_schema::{cw_serde, QueryResponses};
+
+
+
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -1,0 +1,24 @@
+use common::ado_base::AndromedaQuery;
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Addr;
+
+use amp::messages::AMPPkt;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    /// Address of the Kernel contract on chain
+    pub kernel_address: String,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    // Receives an AMP Packet for relaying
+    // AMPReceive(AMPPkt),
+}
+
+#[cw_serde]
+pub struct MigrateMsg {}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {}

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -8,6 +8,21 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+pub struct PathDetails {
+    name: String,
+    address: Addr,
+}
+
+impl PathDetails {
+    pub fn new(name: impl Into<String>, address: Addr) -> PathDetails {
+        PathDetails {
+            name: name.into(),
+            address,
+        }
+    }
+}
+
+#[cw_serde]
 pub enum ExecuteMsg {
     // Receives an AMP Packet for relaying
     // AMPReceive(AMPPkt),
@@ -15,6 +30,9 @@ pub enum ExecuteMsg {
         name: String,
         address: Addr,
     },
+    // AddPathMulti {
+    //     paths: Vec<PathDetails>,
+    // },
     RegisterUser {
         username: String,
         address: Option<Addr>,

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -3,8 +3,8 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{ensure, Addr};
 use regex::Regex;
 
-pub const COMPONENT_NAME_REGEX: &str = r"^[^/^:\s]{1,40}$";
-pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([^/:\s]{1,40}(/)?)+$";
+pub const COMPONENT_NAME_REGEX: &str = r"^[A-Za-z0-9\.\-_]{1,40}$";
+pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([A-Za-z0-9\.]{1,40}(/)?)+$";
 
 pub fn convert_component_name(path: String) -> String {
     path.replace(' ', "_")
@@ -93,6 +93,12 @@ mod test {
         validate_component_name(valid_name.to_string()).unwrap();
 
         let valid_name = "component-1";
+        validate_component_name(valid_name.to_string()).unwrap();
+
+        let valid_name = "component_1";
+        validate_component_name(valid_name.to_string()).unwrap();
+
+        let valid_name = ".component-1";
         validate_component_name(valid_name.to_string()).unwrap();
 
         let empty_name = "";

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -3,8 +3,12 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{ensure, Addr};
 use regex::Regex;
 
-pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([^/:\s]+(/)?)+$";
-pub const COMPONENT_NAME_REGEX: &str = r"^([^/^:\s]+)+$";
+pub const COMPONENT_NAME_REGEX: &str = r"^([^/^:\s]{1,40})+$";
+pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([^/:\s]{1,40}(/)?)+$";
+
+pub fn convert_component_name(path: String) -> String {
+    path.replace(" ", "_")
+}
 
 pub fn validate_component_name(path: String) -> Result<bool, ContractError> {
     let re = Regex::new(COMPONENT_NAME_REGEX).unwrap();
@@ -98,6 +102,14 @@ mod test {
         let invalid_name = "/ /";
         let res = validate_component_name(invalid_name.to_string());
         assert!(res.is_err());
+
+        let invalid_name = " ";
+        let res = validate_component_name(invalid_name.to_string());
+        assert!(res.is_err());
+
+        let invalid_name = "somereallyreallyreallyreallyreallyreallyreallyreallylongname";
+        let res = validate_component_name(invalid_name.to_string());
+        assert!(res.is_err());
     }
 
     #[test]
@@ -128,5 +140,13 @@ mod test {
         let invalid_path = "vfs:/username/dir1/f!le";
         let res = validate_pathname(invalid_path.to_string());
         assert!(res.is_err())
+    }
+
+    #[test]
+    fn test_convert_component_name() {
+        let pre_convert = "Some Component Name";
+        let converted = convert_component_name(pre_convert.to_string());
+
+        assert_eq!("Some_Component_Name", converted)
     }
 }

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -3,11 +3,11 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{ensure, Addr};
 use regex::Regex;
 
-pub const COMPONENT_NAME_REGEX: &str = r"^([^/^:\s]{1,40})+$";
+pub const COMPONENT_NAME_REGEX: &str = r"^[^/^:\s]{1,40}$";
 pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([^/:\s]{1,40}(/)?)+$";
 
 pub fn convert_component_name(path: String) -> String {
-    path.replace(" ", "_")
+    path.replace(' ', "_")
 }
 
 pub fn validate_component_name(path: String) -> Result<bool, ContractError> {
@@ -107,7 +107,8 @@ mod test {
         let res = validate_component_name(invalid_name.to_string());
         assert!(res.is_err());
 
-        let invalid_name = "somereallyreallyreallyreallyreallyreallyreallyreallylongname";
+        let invalid_name =
+            "somereallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongname";
         let res = validate_component_name(invalid_name.to_string());
         assert!(res.is_err());
     }

--- a/packages/andromeda-os/src/vfs.rs
+++ b/packages/andromeda-os/src/vfs.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Addr;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -10,6 +11,14 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     // Receives an AMP Packet for relaying
     // AMPReceive(AMPPkt),
+    AddPath {
+        name: String,
+        address: Addr,
+    },
+    RegisterUser {
+        username: String,
+        address: Option<Addr>,
+    },
 }
 
 #[cw_serde]
@@ -17,4 +26,7 @@ pub struct MigrateMsg {}
 
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum QueryMsg {}
+pub enum QueryMsg {
+    #[returns(Addr)]
+    ResolvePath { path: String },
+}

--- a/packages/andromeda-testing/Cargo.toml
+++ b/packages/andromeda-testing/Cargo.toml
@@ -27,6 +27,7 @@ andromeda-modules = { version = "0.1.0", path = "../andromeda-modules" }
 andromeda-adodb = { path = "../../contracts/os/andromeda-adodb", features = ["testing"] }
 andromeda-primitive = { path = "../../contracts/data-storage/andromeda-primitive", features = ["testing"] }
 andromeda-kernel = { path = "../../contracts/os/andromeda-kernel", features = ["testing"] }
+andromeda-vfs = { path = "../../contracts/os/andromeda-vfs", features = ["testing"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { version = "0.16.0", optional = true }

--- a/packages/andromeda-testing/src/mock.rs
+++ b/packages/andromeda-testing/src/mock.rs
@@ -11,7 +11,8 @@ use andromeda_primitive::mock::{
     mock_andromeda_primitive, mock_primitive_instantiate_msg, mock_store_address_msgs,
 };
 use andromeda_vfs::mock::{
-    mock_add_path, mock_andromeda_vfs, mock_register_user, mock_vfs_instantiate_message,
+    mock_add_path, mock_andromeda_vfs, mock_register_user, mock_resolve_path_query,
+    mock_vfs_instantiate_message,
 };
 use cosmwasm_std::Addr;
 use cw_multi_test::{App, Executor};
@@ -213,5 +214,16 @@ impl MockAndromeda {
         let register_msg = mock_add_path(name, address);
         app.execute_contract(sender, vfs_address, &register_msg, &[])
             .unwrap();
+    }
+
+    pub fn vfs_resolve_path(&self, app: &mut App, path: impl Into<String>) -> Addr {
+        let vfs_address_query = mock_get_key_address("vfs");
+        let vfs_address: Addr = app
+            .wrap()
+            .query_wasm_smart(self.kernel_address.clone(), &vfs_address_query)
+            .unwrap();
+
+        let query = mock_resolve_path_query(path);
+        app.wrap().query_wasm_smart(vfs_address, &query).unwrap()
     }
 }

--- a/packages/andromeda-testing/src/testing/mock_querier.rs
+++ b/packages/andromeda-testing/src/testing/mock_querier.rs
@@ -19,10 +19,11 @@ use andromeda_non_fungible_tokens::{
     cw721_bid::{BidResponse, ExecuteMsg as BidsExecuteMsg, QueryMsg as BidsQueryMsg},
 };
 use andromeda_os::adodb::QueryMsg as FactoryQueryMsg;
+use andromeda_os::kernel::QueryMsg as KernelQueryMsg;
 use cosmwasm_std::{
     coin, coins, from_binary, from_slice,
     testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
-    to_binary, BankMsg, Binary, Coin, ContractResult, CosmosMsg, Decimal, Event, OwnedDeps,
+    to_binary, Addr, BankMsg, Binary, Coin, ContractResult, CosmosMsg, Decimal, Event, OwnedDeps,
     Querier, QuerierResult, QueryRequest, Response, SubMsg, SystemError, SystemResult, Uint128,
     WasmMsg, WasmQuery,
 };
@@ -34,6 +35,8 @@ pub const MOCK_FACTORY_CONTRACT: &str = "factory_contract";
 pub const MOCK_CW721_CONTRACT: &str = "cw721_contract";
 pub const MOCK_AUCTION_CONTRACT: &str = "auction_contract";
 pub const MOCK_PRIMITIVE_CONTRACT: &str = "primitive_contract";
+pub const MOCK_KERNEL_CONTRACT: &str = "kernel_contract";
+pub const MOCK_VFS_CONTRACT: &str = "vfs_contract";
 pub const MOCK_CW20_CONTRACT: &str = "cw20_contract";
 pub const MOCK_CW20_CONTRACT2: &str = "cw20_contract2";
 pub const MOCK_RATES_CONTRACT: &str = "rates_contract";
@@ -106,6 +109,7 @@ impl WasmMockQuerier {
                     MOCK_CW20_CONTRACT2 => self.handle_cw20_query(msg),
                     MOCK_CW721_CONTRACT => self.handle_cw721_query(msg),
                     MOCK_PRIMITIVE_CONTRACT => self.handle_primitive_query(msg),
+                    MOCK_KERNEL_CONTRACT => self.handle_kernel_query(msg),
                     MOCK_RATES_CONTRACT => self.handle_rates_query(msg),
                     MOCK_ADDRESSLIST_CONTRACT => self.handle_addresslist_query(msg),
                     MOCK_BIDS_CONTRACT => self.handle_bids_query(msg),
@@ -412,6 +416,20 @@ impl WasmMockQuerier {
                         value: Primitive::String(MOCK_FACTORY_CONTRACT.to_owned()),
                     },
                     _ => panic!("Unsupported primitive key"),
+                };
+                SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
+            }
+            _ => panic!("Unsupported Query"),
+        }
+    }
+
+    fn handle_kernel_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            KernelQueryMsg::KeyAddress { key } => {
+                let msg_response = match key.as_str() {
+                    "adodb" => Addr::unchecked(MOCK_FACTORY_CONTRACT),
+                    "vfs" => Addr::unchecked(MOCK_VFS_CONTRACT),
+                    _ => panic!("Unsupported key address"),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -522,6 +522,9 @@ pub enum ContractError {
 
     #[error("Invalid Pathname, {error:?}")]
     InvalidPathname { error: Option<String> },
+
+    #[error("Invalid Username, {error:?}")]
+    InvalidUsername { error: Option<String> },
 }
 
 impl From<Cw20ContractError> for ContractError {

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -519,6 +519,9 @@ pub enum ContractError {
 
     #[error("Invalid Expiration Time")]
     InvalidExpirationTime {},
+
+    #[error("Invalid Pathname, {error:?}")]
+    InvalidPathname { error: Option<String> },
 }
 
 impl From<Cw20ContractError> for ContractError {

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -39,6 +39,7 @@ andromeda-splitter = { path = "../contracts/finance/andromeda-splitter", feature
 andromeda-os = { path = "../packages/andromeda-os"}
 andromeda-kernel = { path = "../contracts/os/andromeda-kernel", features = ["testing"] }
 andromeda-adodb = { path = "../contracts/os/andromeda-adodb", features = ["testing"] }
+andromeda-vfs = { path = "../contracts/os/andromeda-vfs", features = ["testing"]}
 
 
 #Other Crates

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -67,3 +67,6 @@ name = "cw20_staking_app"
 
 [[test]]
 name = "wrapped_cw721_app"
+
+[[test]]
+name = "kernel"

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -77,6 +77,7 @@ fn test_auction_app() {
         "TT".to_string(),
         owner.to_string(),
         None,
+        Some(andr.kernel_address.to_string()),
     );
     let cw721_component = AppComponent::new(
         "1".to_string(),
@@ -84,7 +85,8 @@ fn test_auction_app() {
         to_binary(&cw721_init_msg).unwrap(),
     );
 
-    let auction_init_msg = mock_auction_instantiate_msg(None);
+    let auction_init_msg =
+        mock_auction_instantiate_msg(None, Some(andr.kernel_address.to_string()));
     let auction_component = AppComponent::new(
         "2".to_string(),
         "auction".to_string(),

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -96,7 +96,7 @@ fn test_auction_app() {
     let app_init_msg = mock_app_instantiate_msg(
         "Auction App".to_string(),
         app_components.clone(),
-        andr.registry_address.to_string(),
+        andr.registry_address,
     );
 
     let app_addr = router

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -94,9 +94,9 @@ fn test_auction_app() {
     // Create App
     let app_components = vec![cw721_component.clone(), auction_component];
     let app_init_msg = mock_app_instantiate_msg(
-        "Auction App".to_string(),
+        "AuctionApp".to_string(),
         app_components.clone(),
-        andr.registry_address,
+        andr.kernel_address,
     );
 
     let app_addr = router

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -1,6 +1,3 @@
-use andromeda_adodb::mock::{
-    mock_adodb_instantiate_msg, mock_andromeda_adodb, mock_store_code_id_msg,
-};
 use andromeda_app::app::AppComponent;
 use andromeda_app_contract::mock::{
     mock_andromeda_app, mock_app_instantiate_msg, mock_claim_ownership_msg, mock_get_address_msg,
@@ -14,9 +11,7 @@ use andromeda_cw721::mock::{
     mock_andromeda_cw721, mock_cw721_instantiate_msg, mock_cw721_owner_of,
 };
 use andromeda_finance::splitter::{ADORecipient, AMPRecipient, AddressPercent};
-use andromeda_kernel::mock::{
-    mock_andromeda_kernel, mock_kernel_instantiate_message, mock_upsert_key_address,
-};
+
 use andromeda_modules::rates::{Rate, RateInfo};
 use andromeda_rates::mock::{mock_andromeda_rates, mock_rates_instantiate_msg};
 use andromeda_splitter::mock::{

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -179,7 +179,7 @@ fn test_crowdfund_app() {
     let app_init_msg = mock_app_instantiate_msg(
         "Crowdfund App".to_string(),
         app_components.clone(),
-        andr.registry_address.to_string(),
+        andr.kernel_address,
     );
 
     let app_addr = router

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -251,7 +251,6 @@ fn test_crowdfund_app() {
             &mock_get_address_msg(vault_one_app_component.name),
         )
         .unwrap();
-    println!("Vault one address: {vault_one_addr:?}");
 
     let vault_two_addr: String = router
         .wrap()
@@ -260,7 +259,6 @@ fn test_crowdfund_app() {
             &mock_get_address_msg(vault_two_app_component.name),
         )
         .unwrap();
-    println!("Vault two address: {vault_two_addr:?}");
 
     router
         .execute_contract(
@@ -279,8 +277,6 @@ fn test_crowdfund_app() {
         )
         .unwrap();
 
-    println!("crowdfund address {:?}", crowdfund_addr);
-
     let splitter_addr: String = router
         .wrap()
         .query_wasm_smart(
@@ -288,7 +284,6 @@ fn test_crowdfund_app() {
             &mock_get_address_msg(splitter_app_component.name),
         )
         .unwrap();
-    println!("Splitter address is: {splitter_addr:?}");
 
     // Mint Tokens
     let mint_msg = mock_crowdfund_quick_mint_msg(5, owner.to_string());
@@ -364,10 +359,9 @@ fn test_crowdfund_app() {
             &[],
         )
         .unwrap();
-    let result = router
+    router
         .execute_contract(owner, Addr::unchecked(crowdfund_addr), &end_sale_msg, &[])
         .unwrap();
-    println!("{result:?}");
 
     // Check final state
     //Check token transfers

--- a/tests-integration/tests/cw20_staking_app.rs
+++ b/tests-integration/tests/cw20_staking_app.rs
@@ -110,7 +110,7 @@ fn test_cw20_staking_app() {
     let app_init_msg = mock_app_instantiate_msg(
         "Staking App".to_string(),
         app_components.clone(),
-        andr.registry_address.to_string(),
+        andr.kernel_address,
     );
 
     let app_addr = router

--- a/tests-integration/tests/kernel.rs
+++ b/tests-integration/tests/kernel.rs
@@ -108,8 +108,6 @@ fn kernel() {
 
     assert_eq!(components, app_components);
 
-    andr.vfs_add_path(&mut router, owner.clone(), "app1", app_addr);
-
     let splitter_addr = andr.vfs_resolve_path(&mut router, "/am/app1/splitter");
     let vault_addr = andr.vfs_resolve_path(&mut router, "/am/app1/vault");
 

--- a/tests-integration/tests/kernel.rs
+++ b/tests-integration/tests/kernel.rs
@@ -103,7 +103,7 @@ fn kernel() {
 
     let components: Vec<AppComponent> = router
         .wrap()
-        .query_wasm_smart(app_addr.clone(), &mock_get_components_msg())
+        .query_wasm_smart(app_addr, &mock_get_components_msg())
         .unwrap();
 
     assert_eq!(components, app_components);

--- a/tests-integration/tests/kernel.rs
+++ b/tests-integration/tests/kernel.rs
@@ -4,6 +4,7 @@ use andromeda_app_contract::mock::{
 };
 use andromeda_finance::splitter::{AMPRecipient, AddressPercent};
 
+use andromeda_kernel::mock::mock_get_key_address;
 use andromeda_splitter::mock::{
     mock_andromeda_splitter, mock_splitter_instantiate_msg, mock_splitter_send_msg,
 };
@@ -12,6 +13,7 @@ use andromeda_vault::mock::{
     mock_andromeda_vault, mock_vault_deposit_msg, mock_vault_get_balance,
     mock_vault_instantiate_msg,
 };
+use andromeda_vfs::mock::mock_resolve_path_query;
 
 use cosmwasm_std::{coin, coins, to_binary, Addr, Coin, Decimal, Uint128};
 
@@ -63,6 +65,11 @@ fn kernel() {
     let vault_init_msg = mock_vault_instantiate_msg();
     let vault_app_component =
         AppComponent::new("vault", "vault", to_binary(&vault_init_msg).unwrap());
+    let hidden_vault_app_component = AppComponent::new(
+        ".hidden_vault",
+        "vault",
+        to_binary(&vault_init_msg).unwrap(),
+    );
 
     // Generate Splitter Contract
     let vault_deposit_message =
@@ -83,7 +90,11 @@ fn kernel() {
         to_binary(&splitter_init_msg).unwrap(),
     );
 
-    let app_components: Vec<AppComponent> = vec![vault_app_component, splitter_app_component];
+    let app_components: Vec<AppComponent> = vec![
+        vault_app_component,
+        splitter_app_component,
+        hidden_vault_app_component,
+    ];
     let app_init_msg = mock_app_instantiate_msg(
         "app1",
         app_components.clone(),
@@ -110,6 +121,19 @@ fn kernel() {
 
     let splitter_addr = andr.vfs_resolve_path(&mut router, "/am/app1/splitter");
     let vault_addr = andr.vfs_resolve_path(&mut router, "/am/app1/vault");
+
+    // Ensure hidden component is not added to VFS
+    let vfs_address_query = mock_get_key_address("vfs");
+    let vfs_address: Addr = router
+        .wrap()
+        .query_wasm_smart(andr.kernel_address.clone(), &vfs_address_query)
+        .unwrap();
+
+    let query = mock_resolve_path_query("/am/app1/.hidden_vault");
+    assert!(router
+        .wrap()
+        .query_wasm_smart::<Addr>(vfs_address, &query)
+        .is_err());
 
     let send_msg = mock_splitter_send_msg();
     router

--- a/tests-integration/tests/kernel.rs
+++ b/tests-integration/tests/kernel.rs
@@ -62,7 +62,7 @@ fn kernel() {
     andr.store_code_id(&mut router, "app", app_code_id);
 
     // Generate Vault Contract
-    let vault_init_msg = mock_vault_instantiate_msg();
+    let vault_init_msg = mock_vault_instantiate_msg(Some(andr.kernel_address.to_string()));
     let vault_app_component =
         AppComponent::new("vault", "vault", to_binary(&vault_init_msg).unwrap());
     let hidden_vault_app_component = AppComponent::new(

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -50,7 +50,7 @@ fn mock_andromeda(app: &mut App, admin_address: Addr) -> MockAndromeda {
 }
 
 #[test]
-fn test_auction_app() {
+fn test_marketplace_app() {
     let owner = Addr::unchecked("owner");
     let buyer = Addr::unchecked("buyer");
     let rates_receiver = Addr::unchecked("receiver");
@@ -77,6 +77,7 @@ fn test_auction_app() {
         "TT".to_string(),
         owner.to_string(),
         None,
+        Some(andr.kernel_address.to_string()),
     );
     let cw721_component = AppComponent::new(
         "1".to_string(),
@@ -121,7 +122,7 @@ fn test_auction_app() {
     let app_init_msg = mock_app_instantiate_msg(
         "Auction App".to_string(),
         app_components.clone(),
-        andr.registry_address.to_string(),
+        andr.kernel_address.to_string(),
     );
 
     let app_addr = router

--- a/tests-integration/tests/wrapped_cw721_app.rs
+++ b/tests-integration/tests/wrapped_cw721_app.rs
@@ -91,7 +91,7 @@ fn test_wrapped_cw721_app() {
     let app_init_msg = mock_app_instantiate_msg(
         "Wrapped CW721 App".to_string(),
         app_components.clone(),
-        andr.registry_address.to_string(),
+        andr.kernel_address.to_string(),
     );
     let app_addr = router
         .instantiate_contract(

--- a/tests-integration/tests/wrapped_cw721_app.rs
+++ b/tests-integration/tests/wrapped_cw721_app.rs
@@ -65,6 +65,7 @@ fn test_wrapped_cw721_app() {
         "TT".to_string(),
         owner.to_string(), // Crowdfund must be minter
         None,
+        Some(andr.kernel_address.to_string()),
     );
     let cw721_component = AppComponent::new(
         "1".to_string(),
@@ -80,6 +81,7 @@ fn test_wrapped_cw721_app() {
             modules: None,
         }),
         true,
+        Some(andr.kernel_address.to_string()),
     );
     let wrapped_cw721_component = AppComponent::new(
         "2".to_string(),


### PR DESCRIPTION
# Motivation
These changes reflect the Virtual File System component of our messaging protocol. The aim of the VFS is to take a path similar to a Unix file path and resolve this to an address.

# Implementation
The VFS is implemented as an independent contract registered with the Kernel for use in resolving paths within an AMP message. A path is resolved by recursively resolving parent address and child name tuple keys within the VFS contract (`"{parent_address}{child_name}"` maps to `"someaddress"`). 

Addresses may only be registered by the child or parent, i.e. a child can register its name relative to its parent or a parent may register its child. For example, when an application is made it will register all paths for its child components and also register itself as a child of the instantiating address.

An AMP message can then use a path as a recipient for a message and this is resolved by the kernel. The VFS is also accessed outside of the kernel when necessary.

# Testing

## Unit/Integration tests
All integration tests were updated to use VFS instead of their previous app name references. The `kernel.rs` integration test is a good example of the entire process.

## On-chain tests
TODO

# Future work
Update all references to use the VFS, for example the `minter` field for the `cw721` contract should use VFS.

Consider adding the ability for a path owner to register a path outside of the contract itself.
