### PR TITLE
VFS Root Directories

### DIFF
--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -57,7 +57,7 @@ pub fn instantiate(
             deps.storage,
             env,
             deps.api,
-            info.clone(),
+            info,
             BaseInstantiateMsg {
                 ado_type: "app-contract".to_string(),
                 ado_version: CONTRACT_VERSION.to_string(),

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -79,7 +79,7 @@ pub fn instantiate(
 
     let add_path_msg = VFSExecuteMsg::AddParentPath {
         name: convert_component_name(msg.name),
-        parent_address: AndrAddr::from_string(info.sender),
+        parent_address: AndrAddr::from_string(format!("~{sender}")),
     };
     let cosmos_msg: CosmosMsg<Empty> = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: vfs_address.to_string(),
@@ -156,6 +156,7 @@ pub fn register_component_path(
     let add_path_msg = VFSExecuteMsg::AddPath {
         name: name.into(),
         address,
+        parent_address: None,
     };
     let cosmos_msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: vfs_address.to_string(),

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -58,7 +58,7 @@ fn test_instantiation() {
         reply_on: ReplyOn::Always,
         gas_limit: None,
     };
-    let sender = info.sender.clone();
+    let sender = info.sender;
     let register_submsg: SubMsg<Empty> = SubMsg {
         id: 1002,
         msg: CosmosMsg::Wasm(WasmMsg::Execute {

--- a/contracts/app/andromeda-app-contract/src/testing/mod.rs
+++ b/contracts/app/andromeda-app-contract/src/testing/mod.rs
@@ -58,13 +58,14 @@ fn test_instantiation() {
         reply_on: ReplyOn::Always,
         gas_limit: None,
     };
+    let sender = info.sender.clone();
     let register_submsg: SubMsg<Empty> = SubMsg {
         id: 1002,
         msg: CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: "vfs_contract".to_string(),
             msg: to_binary(&VFSExecuteMsg::AddParentPath {
                 name: convert_component_name("Some App".to_string()),
-                parent_address: AndrAddr::from_string(info.sender),
+                parent_address: AndrAddr::from_string(format!("~{sender}")),
             })
             .unwrap(),
             funds: vec![],

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -1,23 +1,16 @@
 use andromeda_std::ado_contract::ADOContract;
 
-use andromeda_std::amp::AndrAddr;
-use andromeda_std::os::vfs::{
-    validate_component_name, validate_path_name, validate_username, ExecuteMsg, InstantiateMsg,
-    MigrateMsg, QueryMsg,
-};
+use andromeda_std::os::vfs::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary, error::ContractError,
 };
 use cosmwasm_std::{
-    attr, ensure, entry_point, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdError,
+    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
 };
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;
 
-use crate::state::{
-    add_pathname, get_paths, get_subdir, paths, resolve_pathname, PathInfo, ADDRESS_USERNAME, USERS,
-};
+use crate::{execute, query};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-vfs";
@@ -57,12 +50,6 @@ pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, Contract
     Ok(Response::default())
 }
 
-pub struct ExecuteEnv<'a> {
-    deps: DepsMut<'a>,
-    pub env: Env,
-    pub info: MessageInfo,
-}
-
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -70,104 +57,24 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let execute_env = ExecuteEnv { deps, env, info };
+    let execute_env = execute::ExecuteEnv { deps, env, info };
 
     match msg {
-        ExecuteMsg::AddPath { name, address } => execute_add_path(execute_env, name, address),
-        ExecuteMsg::RegisterUser { username } => execute_register_user(execute_env, username),
+        ExecuteMsg::AddPath {
+            name,
+            address,
+            parent_address,
+        } => execute::add_path(execute_env, name, address, parent_address),
+        ExecuteMsg::RegisterUser { username } => execute::register_user(execute_env, username),
         ExecuteMsg::AddParentPath {
             name,
             parent_address,
-        } => execute_add_parent_path(execute_env, name, parent_address),
+        } => execute::add_parent_path(execute_env, name, parent_address),
+        ExecuteMsg::RegisterLibrary {
+            lib_name,
+            lib_address,
+        } => execute::register_library(execute_env, lib_name, lib_address),
     }
-}
-
-fn execute_add_path(
-    execute_env: ExecuteEnv,
-    name: String,
-    address: Addr,
-) -> Result<Response, ContractError> {
-    validate_component_name(name.clone())?;
-    add_pathname(
-        execute_env.deps.storage,
-        execute_env.info.sender,
-        name,
-        address,
-    )?;
-    Ok(Response::default())
-}
-
-fn execute_add_parent_path(
-    execute_env: ExecuteEnv,
-    name: String,
-    parent_address: AndrAddr,
-) -> Result<Response, ContractError> {
-    validate_component_name(name.clone())?;
-    let parent_address = resolve_pathname(
-        execute_env.deps.storage,
-        execute_env.deps.api,
-        parent_address.into_string(),
-    )?;
-    let existing = paths()
-        .load(
-            execute_env.deps.storage,
-            &(parent_address.clone(), name.clone()),
-        )
-        .ok();
-    // Ensure that this path is not already added or if already added it should point to same address as above. This prevent external users to override existing paths.
-    // Only add path method can override existing paths as its safe because only owner of the path can execute it
-    match existing {
-        None => {
-            add_pathname(
-                execute_env.deps.storage,
-                parent_address,
-                name,
-                execute_env.info.sender,
-            )?;
-        }
-        Some(path) => {
-            ensure!(
-                path.address == execute_env.info.sender,
-                ContractError::Unauthorized {}
-            )
-        }
-    };
-    Ok(Response::default())
-}
-
-fn execute_register_user(
-    execute_env: ExecuteEnv,
-    username: String,
-) -> Result<Response, ContractError> {
-    let current_user_address = USERS.may_load(execute_env.deps.storage, username.as_str())?;
-    if current_user_address.is_some() {
-        ensure!(
-            current_user_address.unwrap() == execute_env.info.sender,
-            ContractError::Unauthorized {}
-        );
-    }
-
-    //Remove username registration from previous username
-    USERS.remove(execute_env.deps.storage, username.as_str());
-
-    validate_username(username.clone())?;
-    USERS.save(
-        execute_env.deps.storage,
-        username.as_str(),
-        &execute_env.info.sender,
-    )?;
-    //Update current address' username
-    ADDRESS_USERNAME.save(
-        execute_env.deps.storage,
-        execute_env.info.sender.as_ref(),
-        &username,
-    )?;
-
-    Ok(Response::default().add_attributes(vec![
-        attr("action", "register_username"),
-        attr("addr", execute_env.info.sender),
-        attr("username", username),
-    ]))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -211,29 +118,10 @@ fn from_semver(err: semver::Error) -> StdError {
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
-        QueryMsg::ResolvePath { path } => encode_binary(&query_resolve_path(deps, path)?),
-        QueryMsg::SubDir { path } => encode_binary(&query_subdir(deps, path)?),
-        QueryMsg::Paths { addr } => encode_binary(&query_paths(deps, addr)?),
-        QueryMsg::GetUsername { address } => encode_binary(&query_get_username(deps, address)?),
+        QueryMsg::ResolvePath { path } => encode_binary(&query::resolve_path(deps, path)?),
+        QueryMsg::SubDir { path } => encode_binary(&query::subdir(deps, path)?),
+        QueryMsg::Paths { addr } => encode_binary(&query::paths(deps, addr)?),
+        QueryMsg::GetUsername { address } => encode_binary(&query::get_username(deps, address)?),
+        QueryMsg::GetLibrary { address } => encode_binary(&query::get_library_name(deps, address)?),
     }
-}
-
-fn query_resolve_path(deps: Deps, path: String) -> Result<Addr, ContractError> {
-    validate_path_name(path.clone())?;
-    resolve_pathname(deps.storage, deps.api, path)
-}
-fn query_subdir(deps: Deps, path: String) -> Result<Vec<PathInfo>, ContractError> {
-    validate_path_name(path.clone())?;
-    get_subdir(deps.storage, deps.api, path)
-}
-
-fn query_paths(deps: Deps, addr: Addr) -> Result<Vec<String>, ContractError> {
-    get_paths(deps.storage, addr)
-}
-
-fn query_get_username(deps: Deps, addr: Addr) -> Result<String, ContractError> {
-    let username = ADDRESS_USERNAME
-        .may_load(deps.storage, addr.to_string().as_str())?
-        .unwrap_or(addr.to_string());
-    Ok(username)
 }

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -18,7 +18,7 @@ pub fn add_path(
     env: ExecuteEnv,
     name: String,
     address: Addr,
-    parent_address: Option<Addr>,
+    parent_address: Option<AndrAddr>,
 ) -> Result<Response, ContractError> {
     let kernel_address = ADOContract::default().get_kernel_address(env.deps.storage)?;
     ensure!(
@@ -28,13 +28,10 @@ pub fn add_path(
                 .is_contract_owner(env.deps.storage, env.info.sender.as_str())?,
         ContractError::Unauthorized {}
     );
+    let parent_andr_addr = parent_address.unwrap_or(AndrAddr::from_string(env.info.sender));
+    let parent_addr = resolve_pathname(env.deps.storage, env.deps.api, parent_andr_addr)?;
     validate_component_name(name.clone())?;
-    add_pathname(
-        env.deps.storage,
-        parent_address.unwrap_or(env.info.sender),
-        name,
-        address,
-    )?;
+    add_pathname(env.deps.storage, parent_addr, name, address)?;
     Ok(Response::default())
 }
 

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -1,0 +1,114 @@
+use andromeda_std::ado_contract::ADOContract;
+use andromeda_std::amp::AndrAddr;
+use andromeda_std::error::ContractError;
+use andromeda_std::os::vfs::{validate_component_name, validate_username};
+use cosmwasm_std::{attr, ensure, Addr, DepsMut, Env, MessageInfo, Response};
+
+use crate::state::{
+    add_pathname, paths, resolve_pathname, ADDRESS_LIBRARY, ADDRESS_USERNAME, LIBRARIES, USERS,
+};
+
+pub struct ExecuteEnv<'a> {
+    pub deps: DepsMut<'a>,
+    pub env: Env,
+    pub info: MessageInfo,
+}
+
+pub fn add_path(
+    env: ExecuteEnv,
+    name: String,
+    address: Addr,
+    parent_address: Option<Addr>,
+) -> Result<Response, ContractError> {
+    let kernel_address = ADOContract::default().get_kernel_address(env.deps.storage)?;
+    ensure!(
+        parent_address.is_none()
+            || env.info.sender == kernel_address
+            || ADOContract::default()
+                .is_contract_owner(env.deps.storage, env.info.sender.as_str())?,
+        ContractError::Unauthorized {}
+    );
+    validate_component_name(name.clone())?;
+    add_pathname(
+        env.deps.storage,
+        parent_address.unwrap_or(env.info.sender),
+        name,
+        address,
+    )?;
+    Ok(Response::default())
+}
+
+pub fn add_parent_path(
+    env: ExecuteEnv,
+    name: String,
+    parent_address: AndrAddr,
+) -> Result<Response, ContractError> {
+    validate_component_name(name.clone())?;
+    let parent_address = resolve_pathname(env.deps.storage, env.deps.api, parent_address)?;
+    let existing = paths()
+        .load(env.deps.storage, &(parent_address.clone(), name.clone()))
+        .ok();
+    // Ensure that this path is not already added or if already added it should point to same address as above. This prevent external users to override existing paths.
+    // Only add path method can override existing paths as its safe because only owner of the path can execute it
+    match existing {
+        None => {
+            add_pathname(env.deps.storage, parent_address, name, env.info.sender)?;
+        }
+        Some(path) => {
+            ensure!(
+                path.address == env.info.sender,
+                ContractError::Unauthorized {}
+            )
+        }
+    };
+    Ok(Response::default())
+}
+
+pub fn register_user(env: ExecuteEnv, username: String) -> Result<Response, ContractError> {
+    let current_user_address = USERS.may_load(env.deps.storage, username.as_str())?;
+    if current_user_address.is_some() {
+        ensure!(
+            current_user_address.unwrap() == env.info.sender,
+            ContractError::Unauthorized {}
+        );
+    }
+
+    //Remove username registration from previous username
+    USERS.remove(env.deps.storage, username.as_str());
+
+    validate_username(username.clone())?;
+    USERS.save(env.deps.storage, username.as_str(), &env.info.sender)?;
+    //Update current address' username
+    ADDRESS_USERNAME.save(env.deps.storage, env.info.sender.as_ref(), &username)?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "register_username"),
+        attr("addr", env.info.sender),
+        attr("username", username),
+    ]))
+}
+
+pub fn register_library(
+    env: ExecuteEnv,
+    lib_name: String,
+    lib_address: Addr,
+) -> Result<Response, ContractError> {
+    let kernel_address = ADOContract::default().get_kernel_address(env.deps.storage)?;
+    ensure!(
+        env.info.sender == kernel_address
+            || ADOContract::default()
+                .is_contract_owner(env.deps.storage, env.info.sender.as_str())?,
+        ContractError::Unauthorized {}
+    );
+
+    validate_username(lib_name.clone())?;
+    LIBRARIES.save(env.deps.storage, lib_name.as_str(), &lib_address)?;
+    //Update current address' username
+    ADDRESS_LIBRARY.save(env.deps.storage, lib_address.as_str(), &lib_name)?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "register_library"),
+        attr("addr", lib_address),
+        attr("library_name", lib_name),
+    ]))
+}

--- a/contracts/os/andromeda-vfs/src/lib.rs
+++ b/contracts/os/andromeda-vfs/src/lib.rs
@@ -6,3 +6,6 @@ mod state;
 
 #[cfg(test)]
 mod testing;
+
+mod execute;
+mod query;

--- a/contracts/os/andromeda-vfs/src/mock.rs
+++ b/contracts/os/andromeda-vfs/src/mock.rs
@@ -1,7 +1,10 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 
 use crate::contract::{execute, instantiate, query, reply};
-use andromeda_std::os::vfs::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::{
+    amp::AndrAddr,
+    os::vfs::{ExecuteMsg, InstantiateMsg, QueryMsg},
+};
 use cosmwasm_std::{Addr, Empty};
 use cw_multi_test::{Contract, ContractWrapper};
 
@@ -30,9 +33,12 @@ pub fn mock_add_path(name: impl Into<String>, address: Addr) -> ExecuteMsg {
     ExecuteMsg::AddPath {
         name: name.into(),
         address,
+        parent_address: None,
     }
 }
 
 pub fn mock_resolve_path_query(path: impl Into<String>) -> QueryMsg {
-    QueryMsg::ResolvePath { path: path.into() }
+    QueryMsg::ResolvePath {
+        path: AndrAddr::from_string(path.into()),
+    }
 }

--- a/contracts/os/andromeda-vfs/src/query.rs
+++ b/contracts/os/andromeda-vfs/src/query.rs
@@ -1,0 +1,34 @@
+use andromeda_std::os::vfs::validate_path_name;
+use andromeda_std::{amp::AndrAddr, error::ContractError};
+use cosmwasm_std::{Addr, Deps};
+
+use crate::state::{
+    get_paths, get_subdir, resolve_pathname, PathInfo, ADDRESS_LIBRARY, ADDRESS_USERNAME,
+};
+
+pub fn resolve_path(deps: Deps, path: AndrAddr) -> Result<Addr, ContractError> {
+    validate_path_name(path.to_string())?;
+    resolve_pathname(deps.storage, deps.api, path)
+}
+pub fn subdir(deps: Deps, path: AndrAddr) -> Result<Vec<PathInfo>, ContractError> {
+    validate_path_name(path.to_string())?;
+    get_subdir(deps.storage, deps.api, path)
+}
+
+pub fn paths(deps: Deps, addr: Addr) -> Result<Vec<String>, ContractError> {
+    get_paths(deps.storage, addr)
+}
+
+pub fn get_username(deps: Deps, addr: Addr) -> Result<String, ContractError> {
+    let username = ADDRESS_USERNAME
+        .may_load(deps.storage, addr.to_string().as_str())?
+        .unwrap_or(addr.to_string());
+    Ok(username)
+}
+
+pub fn get_library_name(deps: Deps, addr: Addr) -> Result<String, ContractError> {
+    let lib_name = ADDRESS_LIBRARY
+        .may_load(deps.storage, addr.to_string().as_str())?
+        .unwrap_or(addr.to_string());
+    Ok(lib_name)
+}

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -78,7 +78,7 @@ pub fn resolve_path(
 ) -> Result<Addr, ContractError> {
     let mut parts = split_pathname(pathname.to_string());
 
-    let username_or_address = if parts[0].starts_with("~") && parts.len() == 1 {
+    let username_or_address = if parts[0].starts_with('~') && parts.len() == 1 {
         parts[0].remove(0);
         parts[0].as_str()
     } else {
@@ -212,7 +212,7 @@ mod test {
         let res = resolve_path(
             deps.as_ref().storage,
             deps.as_ref().api,
-            AndrAddr::from_string(format!("/home/{username}").to_string()),
+            AndrAddr::from_string(format!("/home/{username}")),
         )
         .unwrap();
         assert_eq!(res, username_address);
@@ -220,7 +220,7 @@ mod test {
         let res = resolve_path(
             deps.as_ref().storage,
             deps.as_ref().api,
-            AndrAddr::from_string(format!("~{username}").to_string()),
+            AndrAddr::from_string(format!("~{username}")),
         )
         .unwrap();
         assert_eq!(res, username_address);
@@ -228,7 +228,7 @@ mod test {
         let res = resolve_path(
             deps.as_ref().storage,
             deps.as_ref().api,
-            AndrAddr::from_string(format!("~/{username}").to_string()),
+            AndrAddr::from_string(format!("~/{username}")),
         )
         .unwrap();
         assert_eq!(res, username_address);
@@ -248,7 +248,7 @@ mod test {
         let res = resolve_path(
             deps.as_ref().storage,
             deps.as_ref().api,
-            AndrAddr::from_string(format!("/home/{username}/{first_directory}").to_string()),
+            AndrAddr::from_string(format!("/home/{username}/{first_directory}")),
         )
         .unwrap();
         assert_eq!(res, first_directory_address);
@@ -271,9 +271,9 @@ mod test {
         let res = resolve_path(
             deps.as_ref().storage,
             deps.as_ref().api,
-            AndrAddr::from_string(
-                format!("/home/{username}/{first_directory}/{second_directory}").to_string(),
-            ),
+            AndrAddr::from_string(format!(
+                "/home/{username}/{first_directory}/{second_directory}"
+            )),
         )
         .unwrap();
         assert_eq!(res, second_directory_address);
@@ -293,9 +293,9 @@ mod test {
         let res = resolve_path(
             deps.as_ref().storage,
             deps.as_ref().api,
-            AndrAddr::from_string(
-                format!("/home/{username}/{first_directory}/{second_directory}/{file}").to_string(),
-            ),
+            AndrAddr::from_string(format!(
+                "/home/{username}/{first_directory}/{second_directory}/{file}"
+            )),
         )
         .unwrap();
         assert_eq!(res, file_address)

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -133,7 +133,7 @@ fn test_add_path() {
     let msg = ExecuteMsg::AddPath {
         name: component_name_two.to_string(),
         address: component_addr_two.clone(),
-        parent_address: Some(component_addr.clone()),
+        parent_address: Some(AndrAddr::from_string(component_addr.clone())),
     };
 
     execute(deps.as_mut(), env.clone(), info, msg).unwrap();
@@ -155,7 +155,7 @@ fn test_add_path() {
     let msg = ExecuteMsg::AddPath {
         name: component_name_two.to_string(),
         address: component_addr_two,
-        parent_address: Some(component_addr),
+        parent_address: Some(AndrAddr::from_string(component_addr)),
     };
 
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     contract::{execute, instantiate, query},
-    state::{add_pathname, resolve_pathname, PathInfo, ADDRESS_USERNAME, USERS},
+    state::{add_pathname, resolve_pathname, PathInfo, ADDRESS_LIBRARY, ADDRESS_USERNAME, USERS},
 };
 
 use andromeda_std::{
@@ -11,21 +11,25 @@ use andromeda_std::{error::ContractError, os::vfs::QueryMsg};
 use cosmwasm_std::{
     from_binary,
     testing::{mock_dependencies, mock_env, mock_info},
-    Addr,
+    Addr, DepsMut, Env, MessageInfo,
 };
+
+fn instantiate_contract(deps: DepsMut, env: Env, info: MessageInfo) {
+    let msg = InstantiateMsg {
+        kernel_address: "kernel".to_string(),
+        owner: None,
+    };
+
+    let res = instantiate(deps, env, info, msg).unwrap();
+    assert_eq!(0, res.messages.len());
+}
 
 #[test]
 fn proper_initialization() {
     let mut deps = mock_dependencies();
     let info = mock_info("creator", &[]);
-    let msg = InstantiateMsg {
-        kernel_address: "kernel".to_string(),
-        owner: None,
-    };
     let env = mock_env();
-
-    let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
-    assert_eq!(0, res.messages.len());
+    instantiate_contract(deps.as_mut(), env, info)
 }
 
 #[test]
@@ -99,22 +103,63 @@ fn test_add_path() {
     let component_addr = Addr::unchecked("f1addr");
     let info = mock_info(sender, &[]);
     let env = mock_env();
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
     let msg = ExecuteMsg::AddPath {
         name: component_name.to_string(),
         address: component_addr.clone(),
+        parent_address: None,
     };
 
-    execute(deps.as_mut(), env, info, msg).unwrap();
+    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
     USERS
         .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
         .unwrap();
 
-    let path = format!("/{username}/{component_name}");
+    let path = format!("/home/{username}/{component_name}");
 
-    let resolved_addr = resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path).unwrap();
+    let resolved_addr = resolve_pathname(
+        deps.as_ref().storage,
+        deps.as_ref().api,
+        AndrAddr::from_string(path),
+    )
+    .unwrap();
 
-    assert_eq!(resolved_addr, component_addr)
+    assert_eq!(resolved_addr, component_addr.clone());
+
+    let component_name_two = "component_two";
+    let component_addr_two = Addr::unchecked("component_two_addr");
+    let msg = ExecuteMsg::AddPath {
+        name: component_name_two.to_string(),
+        address: component_addr_two.clone(),
+        parent_address: Some(component_addr.clone()),
+    };
+
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    let path = format!("/home/{username}/{component_name}/{component_name_two}");
+
+    let resolved_addr = resolve_pathname(
+        deps.as_ref().storage,
+        deps.as_ref().api,
+        AndrAddr::from_string(path),
+    )
+    .unwrap();
+
+    assert_eq!(resolved_addr, component_addr_two);
+
+    let info = mock_info("not_the_owner", &[]);
+    let component_name_two = "component_two";
+    let component_addr_two = Addr::unchecked("component_two_addr");
+    let msg = ExecuteMsg::AddPath {
+        name: component_name_two.to_string(),
+        address: component_addr_two.clone(),
+        parent_address: Some(component_addr),
+    };
+
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {})
 }
 
 #[test]
@@ -128,7 +173,7 @@ fn test_add_parent_path() {
     let env = mock_env();
     let msg = ExecuteMsg::AddParentPath {
         name: component_name.to_string(),
-        parent_address: AndrAddr::from_string(user_address.clone()),
+        parent_address: AndrAddr::from_string(format!("/home/{user_address}").clone()),
     };
 
     execute(deps.as_mut(), env, info, msg).unwrap();
@@ -137,9 +182,14 @@ fn test_add_parent_path() {
         .save(deps.as_mut().storage, username, &user_address)
         .unwrap();
 
-    let path = format!("/{username}/{component_name}");
+    let path = format!("/home/{username}/{component_name}");
 
-    let resolved_addr = resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path).unwrap();
+    let resolved_addr = resolve_pathname(
+        deps.as_ref().storage,
+        deps.as_ref().api,
+        AndrAddr::from_string(path),
+    )
+    .unwrap();
 
     assert_eq!(resolved_addr, sender)
 }
@@ -162,7 +212,7 @@ fn test_override_add_parent_path() {
     let info = mock_info(user_address.as_str(), &[]);
     let msg = ExecuteMsg::AddParentPath {
         name: component_name.to_string(),
-        parent_address: AndrAddr::from_string(user_address.clone()),
+        parent_address: AndrAddr::from_string(format!("/home/{user_address}").clone()),
     };
 
     execute(deps.as_mut(), env.clone(), info, msg).unwrap();
@@ -171,7 +221,7 @@ fn test_override_add_parent_path() {
     let info = mock_info("user_two", &[]);
     let msg = ExecuteMsg::AddParentPath {
         name: component_name.to_string(),
-        parent_address: AndrAddr::from_string(user_address),
+        parent_address: AndrAddr::from_string(format!("/home/{user_address}")),
     };
 
     // This will error, user_two is trying to add his address as identifier for /user_one/identifier vfs path
@@ -201,6 +251,37 @@ fn test_get_username() {
 
     let unregistered_addr = "notregistered";
     let query_msg = QueryMsg::GetUsername {
+        address: Addr::unchecked(unregistered_addr),
+    };
+
+    let res = query(deps.as_ref(), env, query_msg).unwrap();
+    let val: String = from_binary(&res).unwrap();
+
+    assert_eq!(val, unregistered_addr);
+}
+
+#[test]
+fn test_get_library() {
+    let mut deps = mock_dependencies();
+    let env = mock_env();
+    let lib_name = "l1";
+    let sender = "sender";
+
+    ADDRESS_LIBRARY
+        .save(deps.as_mut().storage, sender, &lib_name.to_string())
+        .unwrap();
+
+    let query_msg = QueryMsg::GetLibrary {
+        address: Addr::unchecked(sender),
+    };
+
+    let res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let val: String = from_binary(&res).unwrap();
+
+    assert_eq!(val, lib_name);
+
+    let unregistered_addr = "notregistered";
+    let query_msg = QueryMsg::GetLibrary {
         address: Addr::unchecked(unregistered_addr),
     };
 
@@ -265,15 +346,18 @@ fn test_get_subdir() {
     }
 
     for path in root_paths.clone() {
-        let path_name = format!("/{username}/{name}", name = path.name);
-        let resolved_addr =
-            resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path_name.clone());
+        let path_name = format!("/home/{username}/{name}", name = path.name);
+        let resolved_addr = resolve_pathname(
+            deps.as_ref().storage,
+            deps.as_ref().api,
+            AndrAddr::from_string(path_name.clone()),
+        );
         assert!(resolved_addr.is_ok(), "{path_name} not found");
         assert_eq!(resolved_addr.unwrap(), path.address)
     }
 
     let query_msg = QueryMsg::SubDir {
-        path: format!("/{username}"),
+        path: AndrAddr::from_string(format!("/home/{username}")),
     };
     let res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
     let val: Vec<PathInfo> = from_binary(&res).unwrap();
@@ -281,7 +365,7 @@ fn test_get_subdir() {
 
     let subdir = &root_paths[0].name;
     let query_msg = QueryMsg::SubDir {
-        path: format!("/{username}/{subdir}"),
+        path: AndrAddr::from_string(format!("/home/{username}/{subdir}")),
     };
     let res = query(deps.as_ref(), env, query_msg).unwrap();
     let val: Vec<PathInfo> = from_binary(&res).unwrap();
@@ -349,9 +433,12 @@ fn test_get_paths() {
     }
 
     for path in root_paths {
-        let path_name = format!("/{username}/{name}", name = path.name);
-        let resolved_addr =
-            resolve_pathname(deps.as_ref().storage, deps.as_ref().api, path_name.clone());
+        let path_name = format!("/home/{username}/{name}", name = path.name);
+        let resolved_addr = resolve_pathname(
+            deps.as_ref().storage,
+            deps.as_ref().api,
+            AndrAddr::from_string(path_name.clone()),
+        );
         assert!(resolved_addr.is_ok(), "{path_name} not found");
         assert_eq!(resolved_addr.unwrap(), path.address)
     }

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -126,7 +126,7 @@ fn test_add_path() {
     )
     .unwrap();
 
-    assert_eq!(resolved_addr, component_addr.clone());
+    assert_eq!(resolved_addr, component_addr);
 
     let component_name_two = "component_two";
     let component_addr_two = Addr::unchecked("component_two_addr");
@@ -154,7 +154,7 @@ fn test_add_path() {
     let component_addr_two = Addr::unchecked("component_two_addr");
     let msg = ExecuteMsg::AddPath {
         name: component_name_two.to_string(),
-        address: component_addr_two.clone(),
+        address: component_addr_two,
         parent_address: Some(component_addr),
     };
 
@@ -173,7 +173,7 @@ fn test_add_parent_path() {
     let env = mock_env();
     let msg = ExecuteMsg::AddParentPath {
         name: component_name.to_string(),
-        parent_address: AndrAddr::from_string(format!("/home/{user_address}").clone()),
+        parent_address: AndrAddr::from_string(format!("/home/{user_address}")),
     };
 
     execute(deps.as_mut(), env, info, msg).unwrap();
@@ -212,7 +212,7 @@ fn test_override_add_parent_path() {
     let info = mock_info(user_address.as_str(), &[]);
     let msg = ExecuteMsg::AddParentPath {
         name: component_name.to_string(),
-        parent_address: AndrAddr::from_string(format!("/home/{user_address}").clone()),
+        parent_address: AndrAddr::from_string(format!("/home/{user_address}")),
     };
 
     execute(deps.as_mut(), env.clone(), info, msg).unwrap();

--- a/ibc-tests/test/ibc.spec.ts
+++ b/ibc-tests/test/ibc.spec.ts
@@ -303,7 +303,7 @@ describe("Basic IBC Token Transfers", async () => {
     const { chainA } = state;
     const receiver = randomAddress(chainA.definition.prefix);
     const transferAmount = { amount: "100", denom: chainA.denom };
-    const msg = createAMPMsg(`/${receiver}`, undefined, [transferAmount]);
+    const msg = createAMPMsg(`${receiver}`, undefined, [transferAmount]);
     const kernelMsg = { send: { message: msg } };
     const res = await chainA.os.kernel!.execute(kernelMsg, chainA.client!, [
       transferAmount,
@@ -321,7 +321,7 @@ describe("Basic IBC Token Transfers", async () => {
     const { chainB } = state;
     const receiver = randomAddress(chainB.definition.prefix);
     const transferAmount = { amount: "100", denom: chainB.denom };
-    const msg = createAMPMsg(`/${receiver}`, undefined, [transferAmount]);
+    const msg = createAMPMsg(`${receiver}`, undefined, [transferAmount]);
     const kernelMsg = { send: { message: msg } };
     const res = await chainB.os.kernel!.execute(kernelMsg, chainB.client!, [
       transferAmount,
@@ -339,9 +339,11 @@ describe("Basic IBC Token Transfers", async () => {
     const { link, chainA, chainB } = state;
     const receiver = randomAddress(chainB.definition.prefix);
     const transferAmount = { amount: "105", denom: chainA.denom };
-    const msg = createAMPMsg(`ibc://${chainB.name}/${receiver}`, undefined, [
-      transferAmount,
-    ]);
+    const msg = createAMPMsg(
+      `ibc://${chainB.name}/home/${receiver}`,
+      undefined,
+      [transferAmount]
+    );
     const kernelMsg = { send: { message: msg } };
     const res = await chainA.os.kernel!.execute(kernelMsg, chainA.client!, [
       transferAmount,
@@ -363,9 +365,11 @@ describe("Basic IBC Token Transfers", async () => {
     const { link, chainA, chainB } = state;
     const receiver = randomAddress(chainA.definition.prefix);
     const transferAmount = { amount: "105", denom: chainB.denom };
-    const msg = createAMPMsg(`ibc://${chainA.name}/${receiver}`, undefined, [
-      transferAmount,
-    ]);
+    const msg = createAMPMsg(
+      `ibc://${chainA.name}/home/${receiver}`,
+      undefined,
+      [transferAmount]
+    );
     const kernelMsg = { send: { message: msg } };
     const res = await chainB.os.kernel!.execute(kernelMsg, chainB.client!, [
       transferAmount,
@@ -397,7 +401,7 @@ describe("Basic IBC Token Transfers", async () => {
         recipients: [
           {
             recipient: {
-              address: `ibc://${chainB.name}/${receiver}`,
+              address: `ibc://${chainB.name}/home/${receiver}`,
             },
             percent: "1",
           },
@@ -455,7 +459,7 @@ describe("Basic IBC Token Transfers", async () => {
         recipients: [
           {
             recipient: {
-              address: `ibc://${chainB.name}/${receiver}`,
+              address: `ibc://${chainB.name}/home/${receiver}`,
             },
             percent: "1",
           },
@@ -478,7 +482,7 @@ describe("Basic IBC Token Transfers", async () => {
 
       const transferAmount = { amount: "100", denom: chainB.denom };
       const transferMsg = createAMPMsg(
-        `ibc://${chainA.name}/${chainA.client!.senderAddress}`,
+        `ibc://${chainA.name}/home/${chainA.client!.senderAddress}`,
         undefined,
         [transferAmount]
       );
@@ -530,7 +534,7 @@ describe("Basic IBC Token Transfers", async () => {
         recipients: [
           {
             recipient: {
-              address: `ibc://${chainA.name}/${receiver}`,
+              address: `ibc://${chainA.name}/home/${receiver}`,
             },
             percent: "1",
           },
@@ -550,7 +554,7 @@ describe("Basic IBC Token Transfers", async () => {
 
       const transferAmount = { amount: "100", denom: chainA.denom };
       const msg = createAMPMsg(
-        `ibc://${chainB.name}/${splitter.address}`,
+        `ibc://${chainB.name}/home/${splitter.address}`,
         { send: {} },
         [transferAmount]
       );
@@ -593,7 +597,7 @@ describe("IBC Fund Recovery", async () => {
         recipients: [
           {
             recipient: {
-              address: `ibc://${chainA.name}/${receiver}`,
+              address: `ibc://${chainA.name}/home/${receiver}`,
             },
             percent: "1",
           },
@@ -617,7 +621,7 @@ describe("IBC Fund Recovery", async () => {
       const transferAmount = { amount: "100", denom: chainA.denom };
       // ERROR HERE
       const msg = createAMPMsg(
-        `ibc://${chainB.name}/${splitter.address}`,
+        `ibc://${chainB.name}/home/${splitter.address}`,
         { not_a_valid_message: {} },
         [transferAmount],
         {
@@ -665,7 +669,7 @@ describe("IBC Fund Recovery", async () => {
         recipients: [
           {
             recipient: {
-              address: `ibc://${chainA.name}/${receiver}`,
+              address: `ibc://${chainA.name}/home/${receiver}`,
               msg: "eyJzZW5kIjp7fX0=", // { send: {} } encoded
               ibc_recovery_address: recoveryAddr,
             },
@@ -690,7 +694,7 @@ describe("IBC Fund Recovery", async () => {
 
       const transferAmount = { amount: "100", denom: chainA.denom };
       const msg = createAMPMsg(
-        `ibc://${chainB.name}/${splitter.address}`,
+        `ibc://${chainB.name}/home/${splitter.address}`,
         { send: {} },
         [transferAmount]
       );
@@ -737,7 +741,7 @@ describe("IBC Fund Recovery", async () => {
         recipients: [
           {
             recipient: {
-              address: `ibc://${chainA.name}/${receiver}`,
+              address: `ibc://${chainA.name}/home/${receiver}`,
               msg: "eyJzZW5kIjp7fX0=", // { send: {} } encoded
             },
             percent: "1",

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -117,7 +117,7 @@ impl AndrAddr {
             || self.0.starts_with('/')
             || self.0.split("://").count() > 1
             || self.0.split('/').count() > 1
-            || self.0.starts_with("~")
+            || self.0.starts_with('~')
     }
 
     /// Whether the provided address is a valid human readable address
@@ -195,7 +195,7 @@ impl AndrAddr {
                 true => self.0.as_str(),
                 false => {
                     let raw_path = self.get_raw_path();
-                    if raw_path.starts_with("~") {
+                    if raw_path.starts_with('~') {
                         return "home";
                     }
                     raw_path.split('/').nth(1).unwrap()

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -82,7 +82,7 @@ pub enum ExecuteMsg {
     AddPath {
         name: String,
         address: Addr,
-        parent_address: Option<Addr>,
+        parent_address: Option<AndrAddr>,
     },
     AddParentPath {
         name: String,

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 pub const COMPONENT_NAME_REGEX: &str = r"^[A-Za-z0-9\.\-_]{1,40}$";
 pub const USERNAME_REGEX: &str = r"^[a-z0-9]+$";
-pub const PATH_REGEX: &str = r"^([A-Za-z0-9]+://)?(/)?([A-Za-z0-9\.\-_]{1,40}(/)?)+$";
+pub const PATH_REGEX: &str = r"^((([A-Za-z0-9]+://)?([A-Za-z0-9\.\-_]{1,40})?(/)?(home|lib)/)|(~(/)?))([A-Za-z0-9\.\-_]{1,40}(/)?)+$";
 
 pub fn convert_component_name(path: String) -> String {
     path.replace(' ', "_")
@@ -82,6 +82,7 @@ pub enum ExecuteMsg {
     AddPath {
         name: String,
         address: Addr,
+        parent_address: Option<Addr>,
     },
     AddParentPath {
         name: String,
@@ -89,6 +90,11 @@ pub enum ExecuteMsg {
     },
     RegisterUser {
         username: String,
+    },
+    // Restricted to VFS owner/Kernel
+    RegisterLibrary {
+        lib_name: String,
+        lib_address: Addr,
     },
 }
 
@@ -99,13 +105,15 @@ pub struct MigrateMsg {}
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(Addr)]
-    ResolvePath { path: String },
+    ResolvePath { path: AndrAddr },
     #[returns(Vec<PathDetails>)]
-    SubDir { path: String },
+    SubDir { path: AndrAddr },
     #[returns(Vec<String>)]
     Paths { addr: Addr },
     #[returns(String)]
     GetUsername { address: Addr },
+    #[returns(String)]
+    GetLibrary { address: Addr },
 }
 
 /// Queries the provided VFS contract address to resolve the given path
@@ -114,7 +122,9 @@ pub fn vfs_resolve_path(
     vfs_contract: impl Into<String>,
     querier: &QuerierWrapper,
 ) -> Result<Addr, ContractError> {
-    let query = QueryMsg::ResolvePath { path: path.into() };
+    let query = QueryMsg::ResolvePath {
+        path: AndrAddr::from_string(path.into()),
+    };
     let addr = querier.query_wasm_smart::<Addr>(vfs_contract, &query)?;
     Ok(addr)
 }
@@ -157,19 +167,22 @@ mod test {
 
     #[test]
     fn test_validate_path_name() {
-        let valid_path = "/username";
+        let valid_path = "/home/username";
         validate_path_name(valid_path.to_string()).unwrap();
 
-        let valid_path = "username/dir1/file";
+        let valid_path = "~username";
         validate_path_name(valid_path.to_string()).unwrap();
 
-        let valid_path = "/username/dir1/file/";
+        let valid_path = "~/username";
         validate_path_name(valid_path.to_string()).unwrap();
 
-        let valid_path = "vfs://home/username/dir1/file/";
+        let valid_path = "/home/username/dir1/file";
         validate_path_name(valid_path.to_string()).unwrap();
 
-        let valid_path = "vfs://chain/username/dir1/file/";
+        let valid_path = "/home/username/dir1/file/";
+        validate_path_name(valid_path.to_string()).unwrap();
+
+        let valid_path = "vfs://chain/home/username/dir1/file/";
         validate_path_name(valid_path.to_string()).unwrap();
 
         let empty_path = "";
@@ -182,7 +195,27 @@ mod test {
 
         let invalid_path = "vfs:/username/dir1/f!le";
         let res = validate_path_name(invalid_path.to_string());
-        assert!(res.is_err())
+        assert!(res.is_err());
+
+        let invalid_path = "vfs://home/username/dir1/f!le";
+        let res = validate_path_name(invalid_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "vfs://chain1//username/dir1/f!le";
+        let res = validate_path_name(invalid_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "vfs://username/dir1/f!le";
+        let res = validate_path_name(invalid_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "vfs://~username/dir1/f!le";
+        let res = validate_path_name(invalid_path.to_string());
+        assert!(res.is_err());
+
+        let invalid_path = "vfs://~/username/dir1/f!le";
+        let res = validate_path_name(invalid_path.to_string());
+        assert!(res.is_err());
     }
 
     #[test]

--- a/packages/std/src/testing/mock_querier.rs
+++ b/packages/std/src/testing/mock_querier.rs
@@ -209,6 +209,9 @@ impl MockAndromedaQuerier {
             VFSQueryMsg::GetUsername { address } => {
                 SystemResult::Ok(ContractResult::Ok(to_binary(&address).unwrap()))
             }
+            VFSQueryMsg::GetLibrary { address } => {
+                SystemResult::Ok(ContractResult::Ok(to_binary(&address).unwrap()))
+            }
         }
     }
 

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -165,14 +165,14 @@ fn test_crowdfund_app() {
 
     // Create splitter recipient structures
     let vault_one_recipient =
-        Recipient::from_string(format!("/am/app/{}", vault_one_app_component.name)).with_msg(
+        Recipient::from_string(format!("~/am/app/{}", vault_one_app_component.name)).with_msg(
             mock_vault_deposit_msg(
                 Some(AndrAddr::from_string(vault_one_recipient_addr.to_string())),
                 None,
             ),
         );
     let vault_two_recipient =
-        Recipient::from_string(format!("/am/app/{}", vault_two_app_component.name)).with_msg(
+        Recipient::from_string(format!("~/am/app/{}", vault_two_app_component.name)).with_msg(
             mock_vault_deposit_msg(
                 Some(AndrAddr::from_string(vault_two_recipient_addr.to_string())),
                 None,
@@ -277,8 +277,9 @@ fn test_crowdfund_app() {
     // Start Sale
     let token_price = coin(100, "uandr");
 
-    let sale_recipient = Recipient::from_string(format!("/am/app/{}", splitter_app_component.name))
-        .with_msg(mock_splitter_send_msg());
+    let sale_recipient =
+        Recipient::from_string(format!("~/am/app/{}", splitter_app_component.name))
+            .with_msg(mock_splitter_send_msg());
     let start_msg = mock_start_crowdfund_msg(
         Expiration::AtHeight(router.block_info().height + 5),
         token_price.clone(),

--- a/tests-integration/tests/kernel.rs
+++ b/tests-integration/tests/kernel.rs
@@ -68,7 +68,7 @@ fn kernel() {
         KernelExecuteMsg::Create {
             ado_type: "splitter".to_string(),
             msg: to_binary(&splitter_msg).unwrap(),
-            owner: Some(AndrAddr::from_string("/am".to_string())),
+            owner: Some(AndrAddr::from_string("~/am".to_string())),
         },
         owner.clone(),
         &[],
@@ -85,7 +85,7 @@ fn kernel() {
         &mut router,
         KernelExecuteMsg::Send {
             message: AMPMsg::new(
-                format!("/{}", splitter.addr()),
+                format!("~/{}", splitter.addr()),
                 to_binary(&mock_splitter_send_msg()).unwrap(),
                 Some(vec![coin(100, "uandr")]),
             ),


### PR DESCRIPTION
# Motivation

In a standard unix filesystem there are root directories such as `/home` or `/dev`. To replicate this within our VFS root directories have been added to all Andromeda addresses. Currently there is support for two root directories:
- `/home` or `~/` or `~`
- `/lib`

The `/home` directory is used to reference all publicly registerable usernames. So for example if you wanted to send to user `user1` then you would send to `/home/user1`, `~/user1` or `~user1` in similar fashion to the `cd` command in a terminal.

The `/lib` directory is used for public use addresses that can only be registered via the kernel or contract owner (eventually run by a DAO). These could be things such as a protocol's address.

# Implementation

- Updated VFS valid path regex to include the above variations
- Updated path resolution to include root directories
- Updated all affected tests

# Testing

All unit tests, integration tests and e2e tests were updated

# Notes

Design space left for other root directories

# Future work

N/A
