### PR TITLE
Cross-chain User Registration

### DIFF
--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -420,7 +420,7 @@ fn test_get_code_id() {
         version: ado_version.get_version(),
         code_id,
         action_fees: None,
-        publisher: Some(owner.clone()),
+        publisher: Some(owner),
     };
     execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
@@ -439,9 +439,9 @@ fn test_get_code_id() {
     assert_eq!(value, code_id);
 
     let query_msg = QueryMsg::CodeId {
-        key: format!("{}@latest", ado_version.get_type()).to_string(),
+        key: format!("{}@latest", ado_version.get_type()),
     };
-    let res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let res = query(deps.as_ref(), env, query_msg).unwrap();
     let value: u64 = from_binary(&res).unwrap();
     assert_eq!(value, code_id);
 }

--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 use andromeda_std::testing::mock_querier::{mock_dependencies_custom, MOCK_KERNEL_CONTRACT};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{from_binary, Uint128};
 
-use crate::contract::{execute, instantiate};
+use crate::contract::{execute, instantiate, query};
 use crate::state::{ACTION_FEES, CODE_ID, LATEST_VERSION, PUBLISHER};
 
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::error::ContractError;
-use andromeda_std::os::adodb::{ADOVersion, ActionFee, ExecuteMsg, InstantiateMsg};
+use andromeda_std::os::adodb::{ADOVersion, ActionFee, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 use cosmwasm_std::{
     attr,
@@ -393,4 +393,55 @@ fn test_update_publisher() {
     let unauth_info = mock_info("not_owner", &[]);
     let resp = execute(deps.as_mut(), env, unauth_info, msg).unwrap_err();
     assert_eq!(resp, ContractError::Unauthorized {});
+}
+
+#[test]
+fn test_get_code_id() {
+    let owner = String::from("owner");
+    let mut deps = mock_dependencies_custom(&[]);
+    let env = mock_env();
+    let info = mock_info(owner.as_str(), &[]);
+    let ado_version = ADOVersion::from_type("ado_type").with_version("0.1.0");
+    let code_id = 1;
+
+    instantiate(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(&owner, &[]),
+        InstantiateMsg {
+            kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+            owner: None,
+        },
+    )
+    .unwrap();
+
+    let msg = ExecuteMsg::Publish {
+        ado_type: ado_version.get_type(),
+        version: ado_version.get_version(),
+        code_id,
+        action_fees: None,
+        publisher: Some(owner.clone()),
+    };
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    let query_msg = QueryMsg::CodeId {
+        key: ado_version.clone().into_string(),
+    };
+    let res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let value: u64 = from_binary(&res).unwrap();
+    assert_eq!(value, code_id);
+
+    let query_msg = QueryMsg::CodeId {
+        key: ado_version.get_type(),
+    };
+    let res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let value: u64 = from_binary(&res).unwrap();
+    assert_eq!(value, code_id);
+
+    let query_msg = QueryMsg::CodeId {
+        key: format!("{}@latest", ado_version.get_type()).to_string(),
+    };
+    let res = query(deps.as_ref(), env.clone(), query_msg).unwrap();
+    let value: u64 = from_binary(&res).unwrap();
+    assert_eq!(value, code_id);
 }

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -108,6 +108,7 @@ pub fn execute(
             kernel_address,
         ),
         ExecuteMsg::Recover {} => execute::recover(execute_env),
+        ExecuteMsg::Internal(msg) => execute::internal(execute_env, msg),
     }
 }
 

--- a/contracts/os/andromeda-kernel/src/mock.rs
+++ b/contracts/os/andromeda-kernel/src/mock.rs
@@ -13,7 +13,7 @@ pub fn mock_andromeda_kernel() -> Box<dyn Contract<Empty>> {
 pub fn mock_kernel_instantiate_message(owner: Option<String>) -> InstantiateMsg {
     InstantiateMsg {
         owner,
-        chain_name: "test".to_string(),
+        chain_name: "andromeda".to_string(),
     }
 }
 

--- a/contracts/os/andromeda-kernel/src/reply.rs
+++ b/contracts/os/andromeda-kernel/src/reply.rs
@@ -22,6 +22,7 @@ pub enum ReplyId {
     UpdateOwnership = 3,
     IBCHooksPacketSend = 4,
     Recovery = 5,
+    RegisterUsername = 6,
 }
 
 /// Handles the reply from an ADO creation

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -109,15 +109,15 @@ fn test_register_user_cross_chain() {
         address: address.to_string(),
         chain: chain.to_string(),
     });
-    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap_err();
+    let res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap_err();
     assert_eq!(res, ContractError::Unauthorized {});
 
     let info = mock_info(MOCK_VFS_CONTRACT, &[]);
-    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
     assert_eq!(res.messages.len(), 1);
 
     let expected = IbcMsg::SendPacket {
-        channel_id: channel_info.direct_channel_id.clone().unwrap(),
+        channel_id: channel_info.direct_channel_id.unwrap(),
         data: to_binary(&IbcExecuteMsg::RegisterUsername {
             username: username.to_string(),
             address: address.to_string(),

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -1,15 +1,19 @@
 use crate::{
     contract::{execute, instantiate},
-    state::ADO_OWNER,
+    ibc::PACKET_LIFETIME,
+    state::{ADO_OWNER, CHANNELS, KERNEL_ADDRESSES},
 };
 use andromeda_std::{
     amp::{ADO_DB_KEY, VFS_KEY},
-    os::kernel::{ExecuteMsg, InstantiateMsg},
-    testing::mock_querier::{mock_dependencies_custom, MOCK_ADODB_CONTRACT, MOCK_VFS_CONTRACT},
+    error::ContractError,
+    os::kernel::{ChannelInfo, ExecuteMsg, IbcExecuteMsg, InstantiateMsg, InternalMsg},
+    testing::mock_querier::{
+        mock_dependencies_custom, MOCK_ADODB_CONTRACT, MOCK_FAKE_KERNEL_CONTRACT, MOCK_VFS_CONTRACT,
+    },
 };
 use cosmwasm_std::{
     testing::{mock_dependencies, mock_env, mock_info},
-    Binary,
+    to_binary, Addr, Binary, CosmosMsg, IbcMsg,
 };
 
 #[test]
@@ -62,4 +66,65 @@ fn test_create_ado() {
     let res = execute(deps.as_mut(), env, info.clone(), create_msg).unwrap();
     assert_eq!(1, res.messages.len());
     assert_eq!(ADO_OWNER.load(deps.as_ref().storage).unwrap(), info.sender);
+}
+
+#[test]
+fn test_register_user_cross_chain() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let info = mock_info("creator", &[]);
+    let env = mock_env();
+    let chain = "chain";
+    instantiate(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        InstantiateMsg {
+            owner: None,
+            chain_name: "andromeda".to_string(),
+        },
+    )
+    .unwrap();
+
+    KERNEL_ADDRESSES
+        .save(
+            deps.as_mut().storage,
+            VFS_KEY,
+            &Addr::unchecked(MOCK_VFS_CONTRACT),
+        )
+        .unwrap();
+    let channel_info = ChannelInfo {
+        kernel_address: MOCK_FAKE_KERNEL_CONTRACT.to_string(),
+        ics20_channel_id: Some("1".to_string()),
+        direct_channel_id: Some("2".to_string()),
+        supported_modules: vec![],
+    };
+    CHANNELS
+        .save(deps.as_mut().storage, chain, &channel_info)
+        .unwrap();
+
+    let username = "username";
+    let address = "address";
+    let msg = ExecuteMsg::Internal(InternalMsg::RegisterUserCrossChain {
+        username: username.to_string(),
+        address: address.to_string(),
+        chain: chain.to_string(),
+    });
+    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap_err();
+    assert_eq!(res, ContractError::Unauthorized {});
+
+    let info = mock_info(MOCK_VFS_CONTRACT, &[]);
+    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    assert_eq!(res.messages.len(), 1);
+
+    let expected = IbcMsg::SendPacket {
+        channel_id: channel_info.direct_channel_id.clone().unwrap(),
+        data: to_binary(&IbcExecuteMsg::RegisterUsername {
+            username: username.to_string(),
+            address: address.to_string(),
+        })
+        .unwrap(),
+        timeout: env.block.time.plus_seconds(PACKET_LIFETIME).into(),
+    };
+
+    assert_eq!(res.messages.first().unwrap().msg, CosmosMsg::Ibc(expected));
 }

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -70,7 +70,9 @@ pub fn execute(
             symlink,
             parent_address,
         } => execute::add_symlink(execute_env, name, symlink, parent_address),
-        ExecuteMsg::RegisterUser { username } => execute::register_user(execute_env, username),
+        ExecuteMsg::RegisterUser { username, address } => {
+            execute::register_user(execute_env, username, address)
+        }
         ExecuteMsg::AddParentPath {
             name,
             parent_address,
@@ -79,6 +81,9 @@ pub fn execute(
             lib_name,
             lib_address,
         } => execute::register_library(execute_env, lib_name, lib_address),
+        ExecuteMsg::RegisterUserCrossChain { chain, address } => {
+            execute::register_user_cross_chain(execute_env, chain, address)
+        }
     }
 }
 

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -2,8 +2,14 @@ use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::amp::AndrAddr;
 use andromeda_std::error::ContractError;
 use andromeda_std::os::aos_querier::AOSQuerier;
-use andromeda_std::os::vfs::{validate_component_name, validate_username};
-use cosmwasm_std::{attr, ensure, Addr, DepsMut, Env, MessageInfo, Response};
+use andromeda_std::os::kernel::InternalMsg;
+use andromeda_std::os::{
+    kernel::ExecuteMsg as KernelExecuteMsg,
+    vfs::{validate_component_name, validate_username},
+};
+use cosmwasm_std::{
+    attr, ensure, to_binary, Addr, DepsMut, Env, MessageInfo, Response, SubMsg, WasmMsg,
+};
 
 use crate::state::{
     add_path_symlink, add_pathname, paths, resolve_pathname, ADDRESS_LIBRARY, ADDRESS_USERNAME,
@@ -104,17 +110,33 @@ pub fn add_parent_path(
     Ok(Response::default())
 }
 
-pub fn register_user(env: ExecuteEnv, username: String) -> Result<Response, ContractError> {
+pub fn register_user(
+    env: ExecuteEnv,
+    username: String,
+    address: Option<Addr>,
+) -> Result<Response, ContractError> {
     let kernel = &ADOContract::default().get_kernel_address(env.deps.storage)?;
     let curr_chain = AOSQuerier::get_current_chain(&env.deps.querier, &kernel)?;
+    // Can only register username directly on Andromeda chain
     ensure!(
         curr_chain == "andromeda" || env.info.sender == kernel,
         ContractError::Unauthorized {}
     );
+    // If address is provided sender must be Kernel
+    ensure!(
+        address.is_none() || env.info.sender == kernel,
+        ContractError::Unauthorized {}
+    );
+    // Kernel must provide an address
+    ensure!(
+        env.info.sender != kernel || address.is_some(),
+        ContractError::Unauthorized {}
+    );
+    let sender = address.unwrap_or(env.info.sender.clone());
     let current_user_address = USERS.may_load(env.deps.storage, username.as_str())?;
     if current_user_address.is_some() {
         ensure!(
-            current_user_address.unwrap() == env.info.sender,
+            current_user_address.unwrap() == sender,
             ContractError::Unauthorized {}
         );
     }
@@ -123,13 +145,13 @@ pub fn register_user(env: ExecuteEnv, username: String) -> Result<Response, Cont
     USERS.remove(env.deps.storage, username.as_str());
 
     validate_username(username.clone())?;
-    USERS.save(env.deps.storage, username.as_str(), &env.info.sender)?;
+    USERS.save(env.deps.storage, username.as_str(), &sender)?;
     //Update current address' username
-    ADDRESS_USERNAME.save(env.deps.storage, env.info.sender.as_ref(), &username)?;
+    ADDRESS_USERNAME.save(env.deps.storage, sender.as_ref(), &username)?;
 
     Ok(Response::default().add_attributes(vec![
         attr("action", "register_username"),
-        attr("addr", env.info.sender),
+        attr("addr", sender),
         attr("username", username),
     ]))
 }
@@ -157,4 +179,35 @@ pub fn register_library(
         attr("addr", lib_address),
         attr("library_name", lib_name),
     ]))
+}
+
+pub fn register_user_cross_chain(
+    env: ExecuteEnv,
+    chain: String,
+    address: String,
+) -> Result<Response, ContractError> {
+    let kernel = ADOContract::default().get_kernel_address(env.deps.storage)?;
+    let username = ADDRESS_USERNAME.load(env.deps.storage, env.info.sender.as_str())?;
+    let msg = KernelExecuteMsg::Internal(InternalMsg::RegisterUserCrossChain {
+        username: username.clone(),
+        address: address.clone(),
+        chain: chain.clone(),
+    });
+    let sub_msg = SubMsg::reply_on_error(
+        WasmMsg::Execute {
+            contract_addr: kernel.to_string(),
+            msg: to_binary(&msg)?,
+            funds: vec![],
+        },
+        1,
+    );
+
+    Ok(Response::default()
+        .add_attributes(vec![
+            attr("action", "register_user_cross_chain"),
+            attr("addr", address),
+            attr("username", username),
+            attr("chain", chain),
+        ])
+        .add_submessage(sub_msg))
 }

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -116,7 +116,7 @@ pub fn register_user(
     address: Option<Addr>,
 ) -> Result<Response, ContractError> {
     let kernel = &ADOContract::default().get_kernel_address(env.deps.storage)?;
-    let curr_chain = AOSQuerier::get_current_chain(&env.deps.querier, &kernel)?;
+    let curr_chain = AOSQuerier::get_current_chain(&env.deps.querier, kernel)?;
     // Can only register username directly on Andromeda chain
     ensure!(
         curr_chain == "andromeda" || env.info.sender == kernel,

--- a/contracts/os/andromeda-vfs/src/mock.rs
+++ b/contracts/os/andromeda-vfs/src/mock.rs
@@ -26,6 +26,7 @@ pub fn mock_vfs_instantiate_message(
 pub fn mock_register_user(username: impl Into<String>) -> ExecuteMsg {
     ExecuteMsg::RegisterUser {
         username: username.into(),
+        address: None,
     }
 }
 

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -131,7 +131,7 @@ fn test_register_user_foreign_chain() {
         address: Some(Addr::unchecked(sender)),
     };
     let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
-    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
     let addr = USERS.load(deps.as_ref().storage, username).unwrap();
     assert_eq!(addr, sender);
 
@@ -166,7 +166,7 @@ fn test_register_user_cross_chain() {
         .save(deps.as_mut().storage, sender, &username.to_string())
         .unwrap();
 
-    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
     assert_eq!(res.messages.len(), 1);
 
     let expected = KernelExecuteMsg::Internal(InternalMsg::RegisterUserCrossChain {

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -5,18 +5,24 @@ use crate::{
 
 use andromeda_std::{
     amp::AndrAddr,
-    os::vfs::{ExecuteMsg, InstantiateMsg},
+    os::{
+        kernel::{ExecuteMsg as KernelExecuteMsg, InternalMsg},
+        vfs::{ExecuteMsg, InstantiateMsg},
+    },
+    testing::mock_querier::{
+        mock_dependencies_custom, MOCK_FAKE_KERNEL_CONTRACT, MOCK_KERNEL_CONTRACT,
+    },
 };
 use andromeda_std::{error::ContractError, os::vfs::QueryMsg};
 use cosmwasm_std::{
     from_binary,
     testing::{mock_dependencies, mock_env, mock_info},
-    Addr, DepsMut, Env, MessageInfo,
+    to_binary, Addr, CosmosMsg, DepsMut, Env, MessageInfo, WasmMsg,
 };
 
 fn instantiate_contract(deps: DepsMut, env: Env, info: MessageInfo) {
     let msg = InstantiateMsg {
-        kernel_address: "kernel".to_string(),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
     };
 
@@ -34,15 +40,16 @@ fn proper_initialization() {
 
 #[test]
 fn test_register_user() {
-    let mut deps = mock_dependencies();
+    let mut deps = mock_dependencies_custom(&[]);
     let username = "user1";
     let sender = "sender";
     let info = mock_info(sender, &[]);
     let env = mock_env();
     let msg = ExecuteMsg::RegisterUser {
         username: username.to_string(),
+        address: None,
     };
-
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
     execute(deps.as_mut(), env, info, msg).unwrap();
 
     let saved = USERS.load(deps.as_ref().storage, username).unwrap();
@@ -51,7 +58,7 @@ fn test_register_user() {
 
 #[test]
 fn test_register_user_unauthorized() {
-    let mut deps = mock_dependencies();
+    let mut deps = mock_dependencies_custom(&[]);
     let username = "user1";
     let sender = "sender";
     let occupier = "occupier";
@@ -59,8 +66,9 @@ fn test_register_user_unauthorized() {
     let env = mock_env();
     let msg = ExecuteMsg::RegisterUser {
         username: username.to_string(),
+        address: None,
     };
-
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
     USERS
         .save(deps.as_mut().storage, username, &Addr::unchecked(occupier))
         .unwrap();
@@ -71,7 +79,7 @@ fn test_register_user_unauthorized() {
 
 #[test]
 fn test_register_user_already_registered() {
-    let mut deps = mock_dependencies();
+    let mut deps = mock_dependencies_custom(&[]);
     let username = "user1";
     let new_username = "user2";
     let sender = "sender";
@@ -79,7 +87,9 @@ fn test_register_user_already_registered() {
     let env = mock_env();
     let msg = ExecuteMsg::RegisterUser {
         username: new_username.to_string(),
+        address: None,
     };
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
 
     USERS
         .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
@@ -92,6 +102,87 @@ fn test_register_user_already_registered() {
         .load(deps.as_ref().storage, sender)
         .unwrap();
     assert_eq!(username, new_username)
+}
+
+#[test]
+fn test_register_user_foreign_chain() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let username = "user1";
+    let sender = "sender";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = InstantiateMsg {
+        kernel_address: MOCK_FAKE_KERNEL_CONTRACT.to_string(),
+        owner: None,
+    };
+
+    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    assert_eq!(0, res.messages.len());
+
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
+    let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: Some(Addr::unchecked(sender)),
+    };
+    let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
+    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    let addr = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(addr, sender);
+
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
+    let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+}
+
+#[test]
+fn test_register_user_cross_chain() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let username = "user1";
+    let sender = "sender";
+    let foreign_address = "address";
+    let chain = "chain";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    instantiate_contract(deps.as_mut(), env.clone(), info.clone());
+
+    let msg = ExecuteMsg::RegisterUserCrossChain {
+        chain: chain.to_string(),
+        address: foreign_address.to_string(),
+    };
+    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
+    assert!(res.is_err());
+
+    ADDRESS_USERNAME
+        .save(deps.as_mut().storage, sender, &username.to_string())
+        .unwrap();
+
+    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    assert_eq!(res.messages.len(), 1);
+
+    let expected = KernelExecuteMsg::Internal(InternalMsg::RegisterUserCrossChain {
+        username: username.to_string(),
+        address: foreign_address.to_string(),
+        chain: chain.to_string(),
+    });
+
+    assert_eq!(
+        res.messages[0].msg,
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: MOCK_KERNEL_CONTRACT.to_string(),
+            msg: to_binary(&expected).unwrap(),
+            funds: vec![],
+        })
+    );
 }
 
 #[test]

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -1,7 +1,4 @@
-use andromeda_std::{
-    ado_contract::ADOContract, amp::AndrAddr, andr_exec, andr_instantiate, andr_query,
-    error::ContractError,
-};
+use andromeda_std::{amp::AndrAddr, andr_exec, andr_instantiate, andr_query, error::ContractError};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{to_binary, Addr, Binary, Deps};
 use serde::Serialize;
@@ -71,7 +68,7 @@ impl AppComponent {
         }
     }
 
-    pub fn verify(&self, deps: &Deps) -> Result<(), ContractError> {
+    pub fn verify(&self, _deps: &Deps) -> Result<(), ContractError> {
         if self.name.is_empty() {
             panic!("name cannot be empty");
         }

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{
     ado_contract::ADOContract, amp::AndrAddr, andr_exec, andr_instantiate, andr_query,
-    error::ContractError, os::aos_querier::AOSQuerier,
+    error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{to_binary, Addr, Binary, Deps};
@@ -79,10 +79,6 @@ impl AppComponent {
             panic!("ado_type cannot be empty");
         }
         self.component_type.verify()?;
-        let adodb_addr = ADOContract::default()
-            .get_adodb_address(deps.storage, &deps.querier)
-            .unwrap();
-        AOSQuerier::code_id_getter(&deps.querier, &adodb_addr, &self.ado_type).unwrap();
         Ok(())
     }
 }

--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -53,10 +53,6 @@ pub fn andr_exec(_args: TokenStream, input: TokenStream) -> TokenStream {
                 UpdateAppContract {
                     address: String,
                 },
-                Deposit {
-                    recipient: Option<::andromeda_std::amp::AndrAddr>,
-                    msg: Option<::cosmwasm_std::Binary>,
-                },
                 SetPermission {
                     actor: ::andromeda_std::amp::AndrAddr,
                     action: String,
@@ -101,6 +97,10 @@ pub fn andr_exec(_args: TokenStream, input: TokenStream) -> TokenStream {
             merged,
             quote! {
                 enum Right {
+                    Deposit {
+                        recipient: Option<::andromeda_std::amp::AndrAddr>,
+                        msg: Option<::cosmwasm_std::Binary>,
+                    },
                     Withdraw {
                         recipient: Option<::andromeda_std::amp::Recipient>,
                         tokens_to_withdraw: Option<Vec<::andromeda_std::common::withdraw::Withdrawal>>,

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -99,7 +99,7 @@ impl AOSQuerier {
         }
     }
 
-    pub fn code_id_getter(
+    pub fn code_id_getter_raw(
         querier: &QuerierWrapper,
         adodb_addr: &Addr,
         ado_type: &str,
@@ -111,6 +111,18 @@ impl AOSQuerier {
             Some(code_id) => Ok(code_id),
             None => Err(ContractError::InvalidAddress {}),
         }
+    }
+
+    pub fn code_id_getter(
+        querier: &QuerierWrapper,
+        adodb_addr: &Addr,
+        ado_type: &str,
+    ) -> Result<u64, ContractError> {
+        let query = ADODBQueryMsg::CodeId {
+            key: ado_type.to_string(),
+        };
+        let code_id: u64 = querier.query_wasm_smart(adodb_addr, &query)?;
+        Ok(code_id)
     }
 
     /// Queries the kernel's raw storage for the VFS's address

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -25,9 +25,14 @@ pub enum ExecuteMsg {
     #[serde(rename = "amp_receive")]
     AMPReceive(AMPPkt),
     /// Constructs an AMPPkt with a given AMPMsg and sends it to the recipient
-    Send { message: AMPMsg },
+    Send {
+        message: AMPMsg,
+    },
     /// Upserts a key address to the kernel, restricted to the owner of the kernel
-    UpsertKeyAddress { key: String, value: String },
+    UpsertKeyAddress {
+        key: String,
+        value: String,
+    },
     /// Creates an ADO with the given type and message
     Create {
         ado_type: String,
@@ -44,6 +49,18 @@ pub enum ExecuteMsg {
     },
     /// Recovers funds from failed IBC messages
     Recover {},
+    // Only accessible to key contracts
+    Internal(InternalMsg),
+}
+
+#[cw_serde]
+pub enum InternalMsg {
+    // Restricted to VFS
+    RegisterUserCrossChain {
+        username: String,
+        address: String,
+        chain: String,
+    },
 }
 
 #[cw_serde]
@@ -80,5 +97,9 @@ pub enum IbcExecuteMsg {
         instantiation_msg: Binary,
         owner: AndrAddr,
         ado_type: String,
+    },
+    RegisterUsername {
+        username: String,
+        address: String,
     },
 }

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -95,11 +95,16 @@ pub enum ExecuteMsg {
     },
     RegisterUser {
         username: String,
+        address: Option<Addr>,
     },
     // Restricted to VFS owner/Kernel
     RegisterLibrary {
         lib_name: String,
         lib_address: Addr,
+    },
+    RegisterUserCrossChain {
+        chain: String,
+        address: String,
     },
 }
 

--- a/packages/std/src/testing/mock_querier.rs
+++ b/packages/std/src/testing/mock_querier.rs
@@ -26,6 +26,8 @@ pub const MOCK_APP_CONTRACT: &str = "app_contract";
 pub const MOCK_PRIMITIVE_CONTRACT: &str = "primitive_contract";
 /// Mock Kernel Contract Address
 pub const MOCK_KERNEL_CONTRACT: &str = "kernel_contract";
+/// Mock Kernel Contract Address on foreign chain
+pub const MOCK_FAKE_KERNEL_CONTRACT: &str = "fake_kernel_contract";
 /// Mock VFS Contract Address
 pub const MOCK_VFS_CONTRACT: &str = "vfs_contract";
 /// Mock ADODB Contract Address
@@ -145,8 +147,8 @@ impl MockAndromedaQuerier {
             QueryRequest::Wasm(WasmQuery::Raw { contract_addr, key }) => {
                 match contract_addr.as_str() {
                     // MOCK_APP_CONTRACT => self.handle_app_raw_query(key),
-                    MOCK_KERNEL_CONTRACT => self.handle_kernel_raw_query(key),
-                    MOCK_VFS_CONTRACT => self.handle_kernel_raw_query(key),
+                    MOCK_KERNEL_CONTRACT => self.handle_kernel_raw_query(key, false),
+                    MOCK_FAKE_KERNEL_CONTRACT => self.handle_kernel_raw_query(key, true),
                     MOCK_ADODB_CONTRACT => self.handle_adodb_raw_query(key),
                     _ => panic!("Unsupported query for contract: {contract_addr}"),
                 }
@@ -375,7 +377,7 @@ impl MockAndromedaQuerier {
         }
     }
 
-    pub fn handle_kernel_raw_query(&self, key: &Binary) -> QuerierResult {
+    pub fn handle_kernel_raw_query(&self, key: &Binary, fake: bool) -> QuerierResult {
         let key_vec = key.as_slice();
         let key_str = String::from_utf8(key_vec.to_vec()).unwrap();
 
@@ -401,6 +403,13 @@ impl MockAndromedaQuerier {
             } else {
                 panic!("Invalid Kernel Address Raw Query")
             }
+        } else if key_str.contains("curr_chain") {
+            let res = if fake {
+                "fake_chain".to_string()
+            } else {
+                "andromeda".to_string()
+            };
+            SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
         } else {
             panic!("Invalid Kernel Raw Query")
         }


### PR DESCRIPTION
# Motivation

To allow users to maintain their username across every chain aOS is installed on the Andromeda chain will be used as a sovereign chain to propagate username registration. Users can register their username on Andromeda and then spread this to other connected chains. Once a username is registered on another chain that chain can also be used to register the username on another chain.

# Implementation

- Added an `Internal` message type to the Kernel for registered aOS components
- Added the `RegisterUserCrossChain` message to both the VFS and Kernel (restricted to VFS)
- Made use of the `curr_chain` state variable of the kernel to determine if the current chain is `"andromeda"`

# Testing

End-to-end and unit tests were added appropriately.

# Notes

N/A

# Future work

Integrate ICA ADOs to potentially circumvent the kernel propagation
