### PR TITLE
Fix/splitter bug

### DIFF
--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -58,16 +58,28 @@ pub fn amp_receive(
             error: Some("No messages supplied".to_string())
         }
     );
+
+    let mut res_messages = Vec::new();
+    let mut res_attributes = Vec::new();
+    let mut res_events = Vec::new();
+    
     for (idx, message) in packet.messages.iter().enumerate() {
         let mut handler = MsgHandler::new(message.clone());
-        res = handler.handle(
+        let msg_res = handler.handle(
             deps.branch(),
             info.clone(),
             env.clone(),
             Some(packet.clone()),
             idx as u64,
         )?;
+        res_messages.extend_from_slice(&msg_res.messages);
+        res_attributes.extend_from_slice(&msg_res.attributes);
+        res_events.extend_from_slice(&msg_res.events);
     }
+
+    res.messages.extend_from_slice(&res_messages);
+    res.attributes.extend_from_slice(&res_attributes);
+    res.events.extend_from_slice(&res_events);
     Ok(res.add_attribute("action", "handle_amp_packet"))
 }
 

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -62,7 +62,7 @@ pub fn amp_receive(
     let mut res_messages = Vec::new();
     let mut res_attributes = Vec::new();
     let mut res_events = Vec::new();
-    
+
     for (idx, message) in packet.messages.iter().enumerate() {
         let mut handler = MsgHandler::new(message.clone());
         let msg_res = handler.handle(

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -59,10 +59,6 @@ pub fn amp_receive(
         }
     );
 
-    let mut res_messages = Vec::new();
-    let mut res_attributes = Vec::new();
-    let mut res_events = Vec::new();
-
     for (idx, message) in packet.messages.iter().enumerate() {
         let mut handler = MsgHandler::new(message.clone());
         let msg_res = handler.handle(
@@ -72,14 +68,11 @@ pub fn amp_receive(
             Some(packet.clone()),
             idx as u64,
         )?;
-        res_messages.extend_from_slice(&msg_res.messages);
-        res_attributes.extend_from_slice(&msg_res.attributes);
-        res_events.extend_from_slice(&msg_res.events);
+        res.messages.extend_from_slice(&msg_res.messages);
+        res.attributes.extend_from_slice(&msg_res.attributes);
+        res.events.extend_from_slice(&msg_res.events);
     }
 
-    res.messages.extend_from_slice(&res_messages);
-    res.attributes.extend_from_slice(&res_attributes);
-    res.events.extend_from_slice(&res_events);
     Ok(res.add_attribute("action", "handle_amp_packet"))
 }
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -112,6 +112,9 @@ name = "auction_app"
 [[test]]
 name = "marketplace_app"
 
+[[test]]
+name = "splitter"
+
 # [[test]]
 # name = "cw20_staking_app"
 

--- a/tests-integration/tests/splitter.rs
+++ b/tests-integration/tests/splitter.rs
@@ -1,0 +1,119 @@
+use andromeda_app::app::{AppComponent, ComponentType};
+use andromeda_app_contract::mock::{
+    mock_andromeda_app, mock_app_instantiate_msg, mock_get_address_msg
+};
+
+use andromeda_testing::mock::MockAndromeda;
+
+use andromeda_std::amp::{Recipient};
+use cosmwasm_std::{coin, Addr, Decimal, Uint128};
+
+use andromeda_finance::splitter::{AddressPercent, ExecuteMsg as SplitterExecuteMsg};
+use andromeda_splitter::mock::{
+    mock_andromeda_splitter, mock_splitter_instantiate_msg
+};
+
+use std::str::FromStr;
+
+use cw_multi_test::{App, Executor};
+fn mock_app() -> App {
+    App::new(|router, _api, storage| {
+        router
+            .bank
+            .init_balance(
+                storage,
+                &Addr::unchecked("owner"),
+                [coin(10000000, "uandr")].to_vec(),
+            )
+            .unwrap();
+    })
+}
+
+fn mock_andromeda(app: &mut App, admin_address: Addr) -> MockAndromeda {
+    MockAndromeda::new(app, &admin_address)
+}
+
+#[test]
+fn test_splitter() {
+    let owner = Addr::unchecked("owner");
+    let recipient_1 = Addr::unchecked("recipient_1");
+    let recipient_2 = Addr::unchecked("recipient_2");
+    
+    let mut router = mock_app();
+    let andr = mock_andromeda(&mut router, owner.clone());
+
+    let app_code_id = router.store_code(mock_andromeda_app());
+    andr.store_code_id(&mut router, "app", app_code_id);
+    let splitter_code_id = router.store_code(mock_andromeda_splitter());
+    andr.store_code_id(&mut router, "splitter", splitter_code_id);
+
+    let splitter_recipients = vec![
+        AddressPercent {
+            recipient: Recipient::from_string(recipient_1.to_string()),
+            percent: Decimal::from_str("0.2").unwrap(),
+        },
+        AddressPercent {
+            recipient: Recipient::from_string(recipient_2.to_string()),
+            percent: Decimal::from_str("0.8").unwrap(),
+        },
+    ];
+
+    let splitter_init_msg = mock_splitter_instantiate_msg(splitter_recipients, andr.kernel_address.clone(), None, None);
+    let splitter_app_component = AppComponent {
+        name: "1".to_string(),
+        component_type: ComponentType::new(&splitter_init_msg),
+        ado_type: "splitter".to_string(),
+    };
+
+    let app_components = vec![splitter_app_component.clone()];
+
+    let app_init_msg = mock_app_instantiate_msg(
+        "app".to_string(),
+        app_components.clone(),
+        andr.kernel_address.clone(),
+        None,
+    );
+
+    let app_addr = router
+        .instantiate_contract(
+            app_code_id,
+            owner.clone(),
+            &app_init_msg,
+            &[],
+            "Splitter App",
+            Some(owner.to_string()),
+        )
+        .unwrap();
+
+    let splitter_addr: String = router
+        .wrap()
+        .query_wasm_smart(
+            app_addr.clone(),
+            &mock_get_address_msg(splitter_app_component.name),
+        )
+        .unwrap();
+
+    let token = coin(1000, "uandr");
+    router
+        .execute_contract(
+            owner,
+            Addr::unchecked(splitter_addr.clone()),
+            & SplitterExecuteMsg::Send {},
+            &[token.clone()],
+        )
+        .unwrap();
+    
+    let balance_1 = router
+        .wrap()
+        .query_balance(recipient_1, "uandr")
+        .unwrap();
+    let balance_2 = router
+        .wrap()
+        .query_balance(recipient_2, "uandr")
+        .unwrap();
+    
+
+    assert_eq!(balance_1.amount, Uint128::from(200u128));
+    assert_eq!(balance_2.amount, Uint128::from(800u128));
+
+}

--- a/tests-integration/tests/splitter.rs
+++ b/tests-integration/tests/splitter.rs
@@ -1,17 +1,15 @@
 use andromeda_app::app::{AppComponent, ComponentType};
 use andromeda_app_contract::mock::{
-    mock_andromeda_app, mock_app_instantiate_msg, mock_get_address_msg
+    mock_andromeda_app, mock_app_instantiate_msg, mock_get_address_msg,
 };
 
 use andromeda_testing::mock::MockAndromeda;
 
-use andromeda_std::amp::{Recipient};
+use andromeda_std::amp::Recipient;
 use cosmwasm_std::{coin, Addr, Decimal, Uint128};
 
 use andromeda_finance::splitter::{AddressPercent, ExecuteMsg as SplitterExecuteMsg};
-use andromeda_splitter::mock::{
-    mock_andromeda_splitter, mock_splitter_instantiate_msg
-};
+use andromeda_splitter::mock::{mock_andromeda_splitter, mock_splitter_instantiate_msg};
 
 use std::str::FromStr;
 
@@ -38,7 +36,7 @@ fn test_splitter() {
     let owner = Addr::unchecked("owner");
     let recipient_1 = Addr::unchecked("recipient_1");
     let recipient_2 = Addr::unchecked("recipient_2");
-    
+
     let mut router = mock_app();
     let andr = mock_andromeda(&mut router, owner.clone());
 
@@ -58,7 +56,8 @@ fn test_splitter() {
         },
     ];
 
-    let splitter_init_msg = mock_splitter_instantiate_msg(splitter_recipients, andr.kernel_address.clone(), None, None);
+    let splitter_init_msg =
+        mock_splitter_instantiate_msg(splitter_recipients, andr.kernel_address.clone(), None, None);
     let splitter_app_component = AppComponent {
         name: "1".to_string(),
         component_type: ComponentType::new(splitter_init_msg),
@@ -87,10 +86,7 @@ fn test_splitter() {
 
     let splitter_addr: String = router
         .wrap()
-        .query_wasm_smart(
-            app_addr,
-            &mock_get_address_msg(splitter_app_component.name),
-        )
+        .query_wasm_smart(app_addr, &mock_get_address_msg(splitter_app_component.name))
         .unwrap();
 
     let token = coin(1000, "uandr");
@@ -98,22 +94,14 @@ fn test_splitter() {
         .execute_contract(
             owner,
             Addr::unchecked(splitter_addr),
-            & SplitterExecuteMsg::Send {},
+            &SplitterExecuteMsg::Send {},
             &[token],
         )
         .unwrap();
-    
-    let balance_1 = router
-        .wrap()
-        .query_balance(recipient_1, "uandr")
-        .unwrap();
-    let balance_2 = router
-        .wrap()
-        .query_balance(recipient_2, "uandr")
-        .unwrap();
-    
+
+    let balance_1 = router.wrap().query_balance(recipient_1, "uandr").unwrap();
+    let balance_2 = router.wrap().query_balance(recipient_2, "uandr").unwrap();
 
     assert_eq!(balance_1.amount, Uint128::from(200u128));
     assert_eq!(balance_2.amount, Uint128::from(800u128));
-
 }

--- a/tests-integration/tests/splitter.rs
+++ b/tests-integration/tests/splitter.rs
@@ -61,7 +61,7 @@ fn test_splitter() {
     let splitter_init_msg = mock_splitter_instantiate_msg(splitter_recipients, andr.kernel_address.clone(), None, None);
     let splitter_app_component = AppComponent {
         name: "1".to_string(),
-        component_type: ComponentType::new(&splitter_init_msg),
+        component_type: ComponentType::new(splitter_init_msg),
         ado_type: "splitter".to_string(),
     };
 
@@ -69,7 +69,7 @@ fn test_splitter() {
 
     let app_init_msg = mock_app_instantiate_msg(
         "app".to_string(),
-        app_components.clone(),
+        app_components,
         andr.kernel_address.clone(),
         None,
     );
@@ -88,7 +88,7 @@ fn test_splitter() {
     let splitter_addr: String = router
         .wrap()
         .query_wasm_smart(
-            app_addr.clone(),
+            app_addr,
             &mock_get_address_msg(splitter_app_component.name),
         )
         .unwrap();
@@ -97,9 +97,9 @@ fn test_splitter() {
     router
         .execute_contract(
             owner,
-            Addr::unchecked(splitter_addr.clone()),
+            Addr::unchecked(splitter_addr),
             & SplitterExecuteMsg::Send {},
-            &[token.clone()],
+            &[token],
         )
         .unwrap();
     


### PR DESCRIPTION
# Motivation
Only last recipient was receiving the fund when splitter component was used.

# Implementation

1. Updated kernel's entry point which was handling amp packet. 
2. Added integration test as well

# Notes
1. When using frontend, it is displaying the hint to ensure that the sum of percentage of recipients should be 1. Currently it is working even if they are not summed to 1. But when updating recipients, it is checking if percentages are summed to 1
2.  ado_contract's amp handler was also implemented similar to kernel's handler. When new packet is received, it just pops a message from the packet's messages. Might need to check again and update if similar problem occurs