### PR TITLE
Fix/minter query bug

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -519,9 +519,7 @@ pub fn query_transfer_agreement(
 }
 
 pub fn query_minter(deps: Deps) -> Result<String, ContractError> {
-    let minter = ANDR_MINTER
-        .load(deps.storage)?
-        .get_raw_address(&deps)?;
+    let minter = ANDR_MINTER.load(deps.storage)?.get_raw_address(&deps)?;
     Ok(minter.to_string())
 }
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -519,8 +519,10 @@ pub fn query_transfer_agreement(
 }
 
 pub fn query_minter(deps: Deps) -> Result<String, ContractError> {
-    let owner = ADOContract::default().query_contract_owner(deps)?;
-    Ok(owner.owner)
+    let minter = ANDR_MINTER
+        .load(deps.storage)?
+        .get_raw_address(&deps)?;
+    Ok(minter.to_string())
 }
 
 #[cfg_attr(not(feature = "imported"), entry_point)]

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
@@ -38,6 +38,10 @@ pub fn mock_cw721_owner_of(token_id: String, include_expired: Option<bool>) -> Q
     }
 }
 
+pub fn mock_cw721_minter_query() -> QueryMsg {
+    QueryMsg::Minter {}
+}
+
 pub fn mock_mint_msg(
     token_id: String,
     extension: TokenExtension,

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -8,7 +8,7 @@ use andromeda_crowdfund::mock::{
     mock_end_crowdfund_msg, mock_purchase_msg, mock_start_crowdfund_msg,
 };
 use andromeda_cw721::mock::{
-    mock_andromeda_cw721, mock_cw721_instantiate_msg, mock_cw721_owner_of,
+    mock_andromeda_cw721, mock_cw721_instantiate_msg, mock_cw721_minter_query, mock_cw721_owner_of,
 };
 use andromeda_finance::splitter::AddressPercent;
 use andromeda_std::amp::{AndrAddr, Recipient};
@@ -263,6 +263,21 @@ fn test_crowdfund_app() {
         )
         .unwrap();
 
+    let cw721_addr: String = router
+        .wrap()
+        .query_wasm_smart(
+            app_addr,
+            &mock_get_address_msg(cw721_component.name),
+        )
+        .unwrap();
+
+    let minter: String = router
+        .wrap()
+        .query_wasm_smart(cw721_addr.clone(), &mock_cw721_minter_query())
+        .unwrap();
+
+    assert_eq!(minter, crowdfund_addr);
+
     // Mint Tokens
     let mint_msg = mock_crowdfund_quick_mint_msg(5, owner.to_string());
     router
@@ -336,10 +351,6 @@ fn test_crowdfund_app() {
 
     // Check final state
     //Check token transfers
-    let cw721_addr: String = router
-        .wrap()
-        .query_wasm_smart(app_addr, &mock_get_address_msg(cw721_component.name))
-        .unwrap();
     for (i, buyer) in buyers.iter().enumerate() {
         let query_msg = mock_cw721_owner_of(i.to_string(), None);
         let owner: OwnerOfResponse = router

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -265,10 +265,7 @@ fn test_crowdfund_app() {
 
     let cw721_addr: String = router
         .wrap()
-        .query_wasm_smart(
-            app_addr,
-            &mock_get_address_msg(cw721_component.name),
-        )
+        .query_wasm_smart(app_addr, &mock_get_address_msg(cw721_component.name))
         .unwrap();
 
     let minter: String = router


### PR DESCRIPTION
# Motivation

The minter query for cw721 was returning the owner app address, not the minter address. 

# Implementation
Updated andromeda-cw721 contract's `query_minter` function to return the minter address.

# Testing
It is tested by updating the crowdfund integration test.
For that `mock_cw721_minter_query` is added to andromeda-cw721 contract's mock and `test_crowdfund_app` test is updated to check the minter of the cw721 contract.