### PR TITLE
268 cw20 exchange extended options in startsale struct

### DIFF
--- a/contracts/app/andromeda-app-contract/schema/andromeda-app-contract.json
+++ b/contracts/app/andromeda-app-contract/schema/andromeda-app-contract.json
@@ -187,7 +187,7 @@
               "new_owner": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Addr"
+                    "$ref": "#/definitions/AndrAddr"
                   },
                   {
                     "type": "null"
@@ -415,6 +415,73 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "register_module"
+        ],
+        "properties": {
+          "register_module": {
+            "type": "object",
+            "required": [
+              "module"
+            ],
+            "properties": {
+              "module": {
+                "$ref": "#/definitions/Module"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "deregister_module"
+        ],
+        "properties": {
+          "deregister_module": {
+            "type": "object",
+            "required": [
+              "module_idx"
+            ],
+            "properties": {
+              "module_idx": {
+                "$ref": "#/definitions/Uint64"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "alter_module"
+        ],
+        "properties": {
+          "alter_module": {
+            "type": "object",
+            "required": [
+              "module",
+              "module_idx"
+            ],
+            "properties": {
+              "module": {
+                "$ref": "#/definitions/Module"
+              },
+              "module_idx": {
+                "$ref": "#/definitions/Uint64"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
@@ -561,10 +628,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
       },
       "AndrAddr": {
         "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
@@ -723,6 +786,29 @@
               {
                 "type": "null"
               }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Module": {
+        "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+        "type": "object",
+        "required": [
+          "address",
+          "is_mutable"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/definitions/AndrAddr"
+          },
+          "is_mutable": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -1120,11 +1206,215 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "module"
+        ],
+        "properties": {
+          "module": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/Uint64"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "module_ids"
+        ],
+        "properties": {
+          "module_ids": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "andr_hook"
+        ],
+        "properties": {
+          "andr_hook": {
+            "$ref": "#/definitions/AndromedaHook"
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
       "AndrAddr": {
         "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+        "type": "string"
+      },
+      "AndromedaHook": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "on_execute"
+            ],
+            "properties": {
+              "on_execute": {
+                "type": "object",
+                "required": [
+                  "payload",
+                  "sender"
+                ],
+                "properties": {
+                  "payload": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "sender": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "on_funds_transfer"
+            ],
+            "properties": {
+              "on_funds_transfer": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "payload",
+                  "sender"
+                ],
+                "properties": {
+                  "amount": {
+                    "$ref": "#/definitions/Funds"
+                  },
+                  "payload": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "sender": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "on_token_transfer"
+            ],
+            "properties": {
+              "on_token_transfer": {
+                "type": "object",
+                "required": [
+                  "recipient",
+                  "sender",
+                  "token_id"
+                ],
+                "properties": {
+                  "recipient": {
+                    "type": "string"
+                  },
+                  "sender": {
+                    "type": "string"
+                  },
+                  "token_id": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
+      "Cw20Coin": {
+        "type": "object",
+        "required": [
+          "address",
+          "amount"
+        ],
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Funds": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "$ref": "#/definitions/Cw20Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
       }
     }
@@ -1132,6 +1422,12 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "andr_hook": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Binary",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
     "balance": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "BalanceResponse",
@@ -1429,6 +1725,45 @@
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
           "type": "string"
         }
+      }
+    },
+    "module": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Module",
+      "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+      "type": "object",
+      "required": [
+        "address",
+        "is_mutable"
+      ],
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/AndrAddr"
+        },
+        "is_mutable": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "AndrAddr": {
+          "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+          "type": "string"
+        }
+      }
+    },
+    "module_ids": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_String",
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     },
     "operators": {

--- a/contracts/app/andromeda-app-contract/schema/raw/execute.json
+++ b/contracts/app/andromeda-app-contract/schema/raw/execute.json
@@ -41,7 +41,7 @@
             "new_owner": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Addr"
+                  "$ref": "#/definitions/AndrAddr"
                 },
                 {
                   "type": "null"
@@ -269,6 +269,73 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "register_module"
+      ],
+      "properties": {
+        "register_module": {
+          "type": "object",
+          "required": [
+            "module"
+          ],
+          "properties": {
+            "module": {
+              "$ref": "#/definitions/Module"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "deregister_module"
+      ],
+      "properties": {
+        "deregister_module": {
+          "type": "object",
+          "required": [
+            "module_idx"
+          ],
+          "properties": {
+            "module_idx": {
+              "$ref": "#/definitions/Uint64"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "alter_module"
+      ],
+      "properties": {
+        "alter_module": {
+          "type": "object",
+          "required": [
+            "module",
+            "module_idx"
+          ],
+          "properties": {
+            "module": {
+              "$ref": "#/definitions/Module"
+            },
+            "module_idx": {
+              "$ref": "#/definitions/Uint64"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
@@ -415,10 +482,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
     },
     "AndrAddr": {
       "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
@@ -577,6 +640,29 @@
             {
               "type": "null"
             }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Module": {
+      "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+      "type": "object",
+      "required": [
+        "address",
+        "is_mutable"
+      ],
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/AndrAddr"
+        },
+        "is_mutable": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
           ]
         }
       },

--- a/contracts/app/andromeda-app-contract/schema/raw/query.json
+++ b/contracts/app/andromeda-app-contract/schema/raw/query.json
@@ -263,11 +263,215 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "module"
+      ],
+      "properties": {
+        "module": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/Uint64"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "module_ids"
+      ],
+      "properties": {
+        "module_ids": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "andr_hook"
+      ],
+      "properties": {
+        "andr_hook": {
+          "$ref": "#/definitions/AndromedaHook"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
     "AndrAddr": {
       "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+      "type": "string"
+    },
+    "AndromedaHook": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "on_execute"
+          ],
+          "properties": {
+            "on_execute": {
+              "type": "object",
+              "required": [
+                "payload",
+                "sender"
+              ],
+              "properties": {
+                "payload": {
+                  "$ref": "#/definitions/Binary"
+                },
+                "sender": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "on_funds_transfer"
+          ],
+          "properties": {
+            "on_funds_transfer": {
+              "type": "object",
+              "required": [
+                "amount",
+                "payload",
+                "sender"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Funds"
+                },
+                "payload": {
+                  "$ref": "#/definitions/Binary"
+                },
+                "sender": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "on_token_transfer"
+          ],
+          "properties": {
+            "on_token_transfer": {
+              "type": "object",
+              "required": [
+                "recipient",
+                "sender",
+                "token_id"
+              ],
+              "properties": {
+                "recipient": {
+                  "type": "string"
+                },
+                "sender": {
+                  "type": "string"
+                },
+                "token_id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Cw20Coin": {
+      "type": "object",
+      "required": [
+        "address",
+        "amount"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Funds": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "native"
+          ],
+          "properties": {
+            "native": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "cw20"
+          ],
+          "properties": {
+            "cw20": {
+              "$ref": "#/definitions/Cw20Coin"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     }
   }

--- a/contracts/app/andromeda-app-contract/schema/raw/response_to_andr_hook.json
+++ b/contracts/app/andromeda-app-contract/schema/raw/response_to_andr_hook.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Binary",
+  "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+  "type": "string"
+}

--- a/contracts/app/andromeda-app-contract/schema/raw/response_to_module.json
+++ b/contracts/app/andromeda-app-contract/schema/raw/response_to_module.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Module",
+  "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+  "type": "object",
+  "required": [
+    "address",
+    "is_mutable"
+  ],
+  "properties": {
+    "address": {
+      "$ref": "#/definitions/AndrAddr"
+    },
+    "is_mutable": {
+      "type": "boolean"
+    },
+    "name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "AndrAddr": {
+      "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/app/andromeda-app-contract/schema/raw/response_to_module_ids.json
+++ b/contracts/app/andromeda-app-contract/schema/raw/response_to_module_ids.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Array_of_String",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/contracts/app/andromeda-app-contract/src/execute.rs
+++ b/contracts/app/andromeda-app-contract/src/execute.rs
@@ -3,11 +3,11 @@ use crate::state::{
     load_component_addresses, ADO_ADDRESSES,
 };
 use andromeda_app::app::{AppComponent, ComponentType};
-use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::common::context::ExecuteContext;
 use andromeda_std::error::ContractError;
 use andromeda_std::os::aos_querier::AOSQuerier;
 use andromeda_std::os::vfs::ExecuteMsg as VFSExecuteMsg;
+use andromeda_std::{ado_contract::ADOContract, amp::AndrAddr};
 
 use crate::reply::ReplyId;
 use cosmwasm_std::{
@@ -77,7 +77,7 @@ pub fn handle_add_app_component(
 pub fn claim_ownership(
     ctx: ExecuteContext,
     name_opt: Option<String>,
-    new_owner: Option<Addr>,
+    new_owner: Option<AndrAddr>,
 ) -> Result<Response, ContractError> {
     ensure!(
         ADOContract::default().is_contract_owner(ctx.deps.storage, ctx.info.sender.as_str())?
@@ -94,16 +94,17 @@ pub fn claim_ownership(
         )?);
     } else {
         let addresses = load_component_addresses(ctx.deps.storage, None)?;
+
         for address in addresses {
             let curr_owner = AOSQuerier::ado_owner_getter(&ctx.deps.querier, &address)?;
+            // Get the AndrAddr's raw address if available, else get the message sender's address.
             if curr_owner == ctx.env.contract.address {
-                msgs.push(generate_ownership_message(
-                    address,
-                    new_owner
-                        .clone()
-                        .unwrap_or(ctx.info.sender.clone())
-                        .as_str(),
-                )?);
+                let new_owner = if let Some(new_owner) = new_owner.clone() {
+                    new_owner.get_raw_address(&ctx.deps.as_ref())?
+                } else {
+                    ctx.info.sender.clone()
+                };
+                msgs.push(generate_ownership_message(address, new_owner.as_str())?);
             }
         }
     }

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/schema/andromeda-cw20-exchange.json
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/schema/andromeda-cw20-exchange.json
@@ -1316,13 +1316,62 @@
       },
       "additionalProperties": false,
       "definitions": {
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "Sale": {
           "description": "Struct used to define a token sale. The asset used for the sale is defined as the key for the storage map.",
           "type": "object",
           "required": [
             "amount",
+            "end_time",
             "exchange_rate",
-            "recipient"
+            "recipient",
+            "start_time"
           ],
           "properties": {
             "amount": {
@@ -1330,6 +1379,14 @@
               "allOf": [
                 {
                   "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "end_time": {
+              "description": "The time when the sale ends",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
                 }
               ]
             },
@@ -1344,12 +1401,32 @@
             "recipient": {
               "description": "The recipient of the sale proceeds",
               "type": "string"
+            },
+            "start_time": {
+              "description": "The time when the sale starts",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                }
+              ]
             }
           },
           "additionalProperties": false
         },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
         }
       }

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/schema/andromeda-cw20-exchange.json
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/schema/andromeda-cw20-exchange.json
@@ -1371,6 +1371,7 @@
             "end_time",
             "exchange_rate",
             "recipient",
+            "start_amount",
             "start_time"
           ],
           "properties": {
@@ -1401,6 +1402,14 @@
             "recipient": {
               "description": "The recipient of the sale proceeds",
               "type": "string"
+            },
+            "start_amount": {
+              "description": "The amount for sale at the given rate at the start of the sale",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
             },
             "start_time": {
               "description": "The time when the sale starts",

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/schema/raw/response_to_sale.json
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/schema/raw/response_to_sale.json
@@ -17,13 +17,62 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "Sale": {
       "description": "Struct used to define a token sale. The asset used for the sale is defined as the key for the storage map.",
       "type": "object",
       "required": [
         "amount",
+        "end_time",
         "exchange_rate",
-        "recipient"
+        "recipient",
+        "start_time"
       ],
       "properties": {
         "amount": {
@@ -31,6 +80,14 @@
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "end_time": {
+          "description": "The time when the sale ends",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
             }
           ]
         },
@@ -45,12 +102,32 @@
         "recipient": {
           "description": "The recipient of the sale proceeds",
           "type": "string"
+        },
+        "start_time": {
+          "description": "The time when the sale starts",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
         }
       },
       "additionalProperties": false
     },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     }
   }

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/schema/raw/response_to_sale.json
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/schema/raw/response_to_sale.json
@@ -72,6 +72,7 @@
         "end_time",
         "exchange_rate",
         "recipient",
+        "start_amount",
         "start_time"
       ],
       "properties": {
@@ -102,6 +103,14 @@
         "recipient": {
           "description": "The recipient of the sale proceeds",
           "type": "string"
+        },
+        "start_amount": {
+          "description": "The amount for sale at the given rate at the start of the sale",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
         },
         "start_time": {
           "description": "The time when the sale starts",

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -225,6 +225,7 @@ pub fn execute_start_sale(
         recipient: recipient.unwrap_or(sender),
         start_time: start_expiration,
         end_time: end_expiration,
+        start_amount: amount,
     };
     SALE.save(deps.storage, &asset.to_string(), &sale)?;
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -5,18 +5,22 @@ use andromeda_fungible_tokens::cw20_exchange::{
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     ado_contract::ADOContract,
-    common::context::ExecuteContext,
+    common::{
+        context::ExecuteContext,
+        expiration::{expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO},
+    },
     error::{from_semver, ContractError},
 };
 use cosmwasm_std::{
     attr, coin, ensure, entry_point, from_json, to_json_binary, wasm_execute, BankMsg, Binary,
-    CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
+    BlockInfo, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg,
+    Uint128,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
 use cw_storage_plus::Bound;
-use cw_utils::{nonpayable, one_coin};
+use cw_utils::{nonpayable, one_coin, Expiration};
 use semver::Version;
 
 use crate::state::{SALE, TOKEN_ADDRESS};
@@ -120,7 +124,18 @@ pub fn execute_receive(
             asset,
             exchange_rate,
             recipient,
-        } => execute_start_sale(ctx, amount_sent, asset, exchange_rate, sender, recipient),
+            start_time,
+            duration,
+        } => execute_start_sale(
+            ctx,
+            amount_sent,
+            asset,
+            exchange_rate,
+            sender,
+            recipient,
+            start_time,
+            duration,
+        ),
         Cw20HookMsg::Purchase { recipient } => execute_purchase(
             ctx,
             amount_sent,
@@ -131,6 +146,7 @@ pub fn execute_receive(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_start_sale(
     ctx: ExecuteContext,
     amount: Uint128,
@@ -140,6 +156,9 @@ pub fn execute_start_sale(
     sender: String,
     // The recipient of the sale proceeds
     recipient: Option<String>,
+
+    start_time: Option<u64>,
+    duration: Option<u64>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
@@ -163,6 +182,39 @@ pub fn execute_start_sale(
         }
     );
 
+    let start_expiration = if let Some(start_time) = start_time {
+        expiration_from_milliseconds(start_time)?
+    } else {
+        Expiration::Never {}
+    };
+
+    // Validate start time only if it's provided
+    match start_expiration {
+        Expiration::Never {} => (),
+        _ => {
+            let block_time = block_to_expiration(&ctx.env.block, start_expiration).unwrap();
+
+            // Make sure start time is valid
+            ensure!(
+                start_expiration.gt(&block_time),
+                ContractError::StartTimeInThePast {
+                    current_time: ctx.env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO,
+                    current_block: ctx.env.block.height,
+                }
+            );
+        }
+    }
+
+    let end_expiration = if let Some(duration) = duration {
+        // If there's no start time, consider it as now
+        expiration_from_milliseconds(
+            start_time.unwrap_or(ctx.env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO)
+                + duration,
+        )?
+    } else {
+        Expiration::Never {}
+    };
+
     // Do not allow duplicate sales
     let current_sale = SALE.may_load(deps.storage, &asset.to_string())?;
     ensure!(current_sale.is_none(), ContractError::SaleNotEnded {});
@@ -171,6 +223,8 @@ pub fn execute_start_sale(
         amount,
         exchange_rate,
         recipient: recipient.unwrap_or(sender),
+        start_time: start_expiration,
+        end_time: end_expiration,
     };
     SALE.save(deps.storage, &asset.to_string(), &sale)?;
 
@@ -225,6 +279,17 @@ pub fn execute_purchase(
     let Some(mut sale) = SALE.may_load(deps.storage, &asset_sent.to_string())? else {
         return Err(ContractError::NoOngoingSale {});
     };
+
+    // Check if sale has started, the only two options are an expired start_time or a start time that never expires because if the user doesn't provide a start time, it's saved as Never
+    ensure!(
+        sale.start_time.is_expired(&ctx.env.block) || sale.start_time == Expiration::Never {},
+        ContractError::SaleNotStarted {}
+    );
+    // Check if sale has ended
+    ensure!(
+        !sale.end_time.is_expired(&ctx.env.block),
+        ContractError::SaleEnded {}
+    );
 
     let purchased = amount_sent.checked_div(sale.exchange_rate).unwrap();
     let remainder = amount_sent.checked_sub(purchased.checked_mul(sale.exchange_rate)?)?;
@@ -346,6 +411,14 @@ pub fn execute_cancel_sale(
         attr("action", "cancel_sale"),
         attr("asset", asset.to_string()),
     ]))
+}
+
+fn block_to_expiration(block: &BlockInfo, model: Expiration) -> Option<Expiration> {
+    match model {
+        Expiration::AtTime(_) => Some(Expiration::AtTime(block.time)),
+        Expiration::AtHeight(_) => Some(Expiration::AtHeight(block.height)),
+        Expiration::Never {} => None,
+    }
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -192,8 +192,6 @@ pub fn execute_start_sale(
 
     // Validate start time
     let block_time = block_to_expiration(&ctx.env.block, start_expiration).unwrap();
-
-    // Make sure start time is valid
     ensure!(
         start_expiration.gt(&block_time),
         ContractError::StartTimeInThePast {

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -390,9 +390,14 @@ pub fn execute_cancel_sale(
 
     // Refund any remaining amount
     if !sale.amount.is_zero() {
+        let token_addr = TOKEN_ADDRESS
+            .load(deps.storage)?
+            .get_raw_address(&deps.as_ref())?;
+
+        let token = AssetInfo::Cw20(token_addr);
         resp = resp
             .add_submessage(generate_transfer_message(
-                asset.clone(),
+                token,
                 sale.amount,
                 info.sender.to_string(),
                 REFUND_REPLY_ID,

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -1100,21 +1100,6 @@ pub fn test_cancel_sale() {
 
     // Ensure any remaining funds are returned
     let message = res.messages.first().unwrap();
-    // let expected_message = SubMsg::reply_on_error(
-    //     CosmosMsg::Wasm(
-    //         wasm_execute(
-    //             "exchanged_asset",
-    //             &Cw20ExecuteMsg::Transfer {
-    //                 recipient: owner.to_string(),
-    //                 amount: sale_amount,
-    //             },
-    //             vec![],
-    //         )
-    //         .unwrap(),
-    //     ),
-    //     1,
-
-    // );
     let expected_message = SubMsg::reply_on_error(
         CosmosMsg::Wasm(
             wasm_execute(

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -1080,7 +1080,6 @@ pub fn test_cancel_sale() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
             start_amount: sale_amount,
         },
@@ -1101,10 +1100,25 @@ pub fn test_cancel_sale() {
 
     // Ensure any remaining funds are returned
     let message = res.messages.first().unwrap();
+    // let expected_message = SubMsg::reply_on_error(
+    //     CosmosMsg::Wasm(
+    //         wasm_execute(
+    //             "exchanged_asset",
+    //             &Cw20ExecuteMsg::Transfer {
+    //                 recipient: owner.to_string(),
+    //                 amount: sale_amount,
+    //             },
+    //             vec![],
+    //         )
+    //         .unwrap(),
+    //     ),
+    //     1,
+
+    // );
     let expected_message = SubMsg::reply_on_error(
         CosmosMsg::Wasm(
             wasm_execute(
-                "exchanged_asset",
+                "cw20",
                 &Cw20ExecuteMsg::Transfer {
                     recipient: owner.to_string(),
                     amount: sale_amount,

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -154,7 +154,7 @@ pub fn test_start_sale() {
     let token_info = mock_info(MOCK_TOKEN_ADDRESS, &[]);
 
     init(deps.as_mut()).unwrap();
-    let current_time = env.clone().block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO;
+    let current_time = env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO;
     let exchange_rate = Uint128::from(10u128);
     let sale_amount = Uint128::from(100u128);
     let hook = Cw20HookMsg::StartSale {
@@ -172,7 +172,7 @@ pub fn test_start_sale() {
     };
     let msg = ExecuteMsg::Receive(receive_msg);
 
-    execute(deps.as_mut(), env.clone(), token_info, msg).unwrap();
+    execute(deps.as_mut(), env, token_info, msg).unwrap();
 
     let sale = SALE
         .load(deps.as_ref().storage, &exchange_asset.to_string())
@@ -218,7 +218,7 @@ pub fn test_start_sale_no_start_no_duration() {
     };
     let msg = ExecuteMsg::Receive(receive_msg);
 
-    execute(deps.as_mut(), env.clone(), token_info, msg).unwrap();
+    execute(deps.as_mut(), env, token_info, msg).unwrap();
 
     let sale = SALE
         .load(deps.as_ref().storage, &exchange_asset.to_string())
@@ -382,6 +382,7 @@ pub fn test_purchase_not_enough_sent() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -428,6 +429,7 @@ pub fn test_purchase_no_tokens_left() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::zero(),
         },
     )
     .unwrap();
@@ -469,6 +471,7 @@ pub fn test_purchase_not_enough_tokens() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::one(),
         },
     )
     .unwrap();
@@ -511,6 +514,7 @@ pub fn test_purchase() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -596,6 +600,7 @@ pub fn test_purchase_with_start_and_duration() {
             start_time: Expiration::AtTime(env.block.time.minus_nanos(1)),
             // end time in the future
             end_time: Expiration::AtTime(env.block.time.plus_nanos(1)),
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -679,6 +684,7 @@ pub fn test_purchase_sale_not_started() {
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time.plus_nanos(1)),
             end_time: Expiration::Never {},
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -720,6 +726,7 @@ pub fn test_purchase_sale_duration_ended() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::AtTime(env.block.time.minus_nanos(1)),
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -775,6 +782,7 @@ pub fn test_purchase_not_enough_sent_native() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -813,6 +821,7 @@ pub fn test_purchase_no_tokens_left_native() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::zero(),
         },
     )
     .unwrap();
@@ -847,6 +856,7 @@ pub fn test_purchase_not_enough_tokens_native() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(1u128),
         },
     )
     .unwrap();
@@ -883,6 +893,7 @@ pub fn test_purchase_native() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -951,6 +962,7 @@ pub fn test_purchase_refund() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -999,6 +1011,7 @@ pub fn test_cancel_sale_unauthorised() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -1055,6 +1068,7 @@ pub fn test_cancel_sale() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -1113,6 +1127,7 @@ fn test_query_sale() {
         recipient: "owner".to_string(),
         start_time: Expiration::Never {},
         end_time: Expiration::Never {},
+        start_amount: sale_amount,
     };
     SALE.save(deps.as_mut().storage, &exchange_asset.to_string(), &sale)
         .unwrap();
@@ -1150,6 +1165,7 @@ fn test_andr_query() {
         recipient: "owner".to_string(),
         start_time: Expiration::Never {},
         end_time: Expiration::Never {},
+        start_amount: sale_amount,
     };
     SALE.save(deps.as_mut().storage, &exchange_asset.to_string(), &sale)
         .unwrap();
@@ -1190,6 +1206,7 @@ fn test_purchase_native_invalid_coins() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -1242,6 +1259,7 @@ fn test_query_sale_assets() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -1254,6 +1272,7 @@ fn test_query_sale_assets() {
             recipient: owner.to_string(),
             start_time: Expiration::Never {},
             end_time: Expiration::Never {},
+            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -246,7 +246,7 @@ pub fn test_start_sale_invalid_start_time() {
     let exchange_rate = Uint128::from(10u128);
     let sale_amount = Uint128::from(100u128);
     let hook = Cw20HookMsg::StartSale {
-        asset: exchange_asset.clone(),
+        asset: exchange_asset,
         exchange_rate,
         recipient: None,
         start_time: Some(1),

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -218,7 +218,7 @@ pub fn test_start_sale_no_start_no_duration() {
     };
     let msg = ExecuteMsg::Receive(receive_msg);
 
-    execute(deps.as_mut(), env.clone(), token_info, msg).unwrap();
+    execute(deps.as_mut(), env, token_info, msg).unwrap();
 
     let sale = SALE
         .load(deps.as_ref().storage, &exchange_asset.to_string())

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -218,7 +218,7 @@ pub fn test_start_sale_no_start_no_duration() {
     };
     let msg = ExecuteMsg::Receive(receive_msg);
 
-    execute(deps.as_mut(), env, token_info, msg).unwrap();
+    execute(deps.as_mut(), env.clone(), token_info, msg).unwrap();
 
     let sale = SALE
         .load(deps.as_ref().storage, &exchange_asset.to_string())
@@ -227,7 +227,11 @@ pub fn test_start_sale_no_start_no_duration() {
     assert_eq!(sale.exchange_rate, exchange_rate);
     assert_eq!(sale.amount, sale_amount);
 
-    assert_eq!(sale.start_time, Expiration::Never {});
+    assert_eq!(
+        sale.start_time,
+        // Current time + 1
+        Expiration::AtTime(Timestamp::from_nanos(1571797419880000000))
+    );
 
     assert_eq!(sale.end_time, Expiration::Never {});
 }
@@ -380,7 +384,7 @@ pub fn test_purchase_not_enough_sent() {
             amount: Uint128::from(100u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
             end_time: Expiration::Never {},
             start_amount: Uint128::from(100u128),
         },
@@ -427,7 +431,7 @@ pub fn test_purchase_no_tokens_left() {
             amount: Uint128::zero(),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
             end_time: Expiration::Never {},
             start_amount: Uint128::zero(),
         },
@@ -469,7 +473,8 @@ pub fn test_purchase_not_enough_tokens() {
             amount: Uint128::one(),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::one(),
         },
@@ -512,7 +517,8 @@ pub fn test_purchase() {
             amount: sale_amount,
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: sale_amount,
         },
@@ -724,7 +730,8 @@ pub fn test_purchase_sale_duration_ended() {
             amount: sale_amount,
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::AtTime(env.block.time.minus_nanos(1)),
             start_amount: sale_amount,
         },
@@ -780,7 +787,8 @@ pub fn test_purchase_not_enough_sent_native() {
             amount: Uint128::from(100u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::from(100u128),
         },
@@ -819,7 +827,8 @@ pub fn test_purchase_no_tokens_left_native() {
             amount: Uint128::zero(),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::zero(),
         },
@@ -854,7 +863,8 @@ pub fn test_purchase_not_enough_tokens_native() {
             amount: Uint128::from(1u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::from(1u128),
         },
@@ -891,7 +901,8 @@ pub fn test_purchase_native() {
             amount: sale_amount,
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: sale_amount,
         },
@@ -960,7 +971,8 @@ pub fn test_purchase_refund() {
             amount: Uint128::from(100u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::from(100u128),
         },
@@ -1009,7 +1021,8 @@ pub fn test_cancel_sale_unauthorised() {
             amount: sale_amount,
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: sale_amount,
         },
@@ -1066,7 +1079,8 @@ pub fn test_cancel_sale() {
             amount: sale_amount,
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: sale_amount,
         },
@@ -1125,7 +1139,8 @@ fn test_query_sale() {
         amount: sale_amount,
         exchange_rate,
         recipient: "owner".to_string(),
-        start_time: Expiration::Never {},
+        start_time: Expiration::AtTime(env.block.time),
+
         end_time: Expiration::Never {},
         start_amount: sale_amount,
     };
@@ -1163,7 +1178,8 @@ fn test_andr_query() {
         amount: sale_amount,
         exchange_rate,
         recipient: "owner".to_string(),
-        start_time: Expiration::Never {},
+        start_time: Expiration::AtTime(env.block.time),
+
         end_time: Expiration::Never {},
         start_amount: sale_amount,
     };
@@ -1204,7 +1220,8 @@ fn test_purchase_native_invalid_coins() {
             amount: Uint128::from(100u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::from(100u128),
         },
@@ -1257,7 +1274,8 @@ fn test_query_sale_assets() {
             amount: Uint128::from(100u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::from(100u128),
         },
@@ -1270,7 +1288,8 @@ fn test_query_sale_assets() {
             amount: Uint128::from(100u128),
             exchange_rate,
             recipient: owner.to_string(),
-            start_time: Expiration::Never {},
+            start_time: Expiration::AtTime(env.block.time),
+
             end_time: Expiration::Never {},
             start_amount: Uint128::from(100u128),
         },

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/andromeda-auction.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/andromeda-auction.json
@@ -1292,12 +1292,174 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "andr_hook"
+        ],
+        "properties": {
+          "andr_hook": {
+            "$ref": "#/definitions/AndromedaHook"
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
       "AndrAddr": {
         "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
         "type": "string"
+      },
+      "AndromedaHook": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "on_execute"
+            ],
+            "properties": {
+              "on_execute": {
+                "type": "object",
+                "required": [
+                  "payload",
+                  "sender"
+                ],
+                "properties": {
+                  "payload": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "sender": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "on_funds_transfer"
+            ],
+            "properties": {
+              "on_funds_transfer": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "payload",
+                  "sender"
+                ],
+                "properties": {
+                  "amount": {
+                    "$ref": "#/definitions/Funds"
+                  },
+                  "payload": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "sender": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "on_token_transfer"
+            ],
+            "properties": {
+              "on_token_transfer": {
+                "type": "object",
+                "required": [
+                  "recipient",
+                  "sender",
+                  "token_id"
+                ],
+                "properties": {
+                  "recipient": {
+                    "type": "string"
+                  },
+                  "sender": {
+                    "type": "string"
+                  },
+                  "token_id": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
+      "Cw20Coin": {
+        "type": "object",
+        "required": [
+          "address",
+          "amount"
+        ],
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Funds": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "$ref": "#/definitions/Cw20Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "OrderBy": {
         "type": "string",
@@ -1319,6 +1481,12 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "andr_hook": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Binary",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
     "auction_ids": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "AuctionIdsResponse",
@@ -1384,6 +1552,7 @@
         "high_bidder_addr",
         "high_bidder_amount",
         "is_cancelled",
+        "owner",
         "start_time"
       ],
       "properties": {
@@ -1414,6 +1583,9 @@
               "type": "null"
             }
           ]
+        },
+        "owner": {
+          "type": "string"
         },
         "start_time": {
           "$ref": "#/definitions/Expiration"
@@ -1669,6 +1841,7 @@
         "high_bidder_addr",
         "high_bidder_amount",
         "is_cancelled",
+        "owner",
         "start_time"
       ],
       "properties": {
@@ -1699,6 +1872,9 @@
               "type": "null"
             }
           ]
+        },
+        "owner": {
+          "type": "string"
         },
         "start_time": {
           "$ref": "#/definitions/Expiration"

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/raw/query.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/raw/query.json
@@ -450,12 +450,174 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "andr_hook"
+      ],
+      "properties": {
+        "andr_hook": {
+          "$ref": "#/definitions/AndromedaHook"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
     "AndrAddr": {
       "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
       "type": "string"
+    },
+    "AndromedaHook": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "on_execute"
+          ],
+          "properties": {
+            "on_execute": {
+              "type": "object",
+              "required": [
+                "payload",
+                "sender"
+              ],
+              "properties": {
+                "payload": {
+                  "$ref": "#/definitions/Binary"
+                },
+                "sender": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "on_funds_transfer"
+          ],
+          "properties": {
+            "on_funds_transfer": {
+              "type": "object",
+              "required": [
+                "amount",
+                "payload",
+                "sender"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Funds"
+                },
+                "payload": {
+                  "$ref": "#/definitions/Binary"
+                },
+                "sender": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "on_token_transfer"
+          ],
+          "properties": {
+            "on_token_transfer": {
+              "type": "object",
+              "required": [
+                "recipient",
+                "sender",
+                "token_id"
+              ],
+              "properties": {
+                "recipient": {
+                  "type": "string"
+                },
+                "sender": {
+                  "type": "string"
+                },
+                "token_id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Cw20Coin": {
+      "type": "object",
+      "required": [
+        "address",
+        "amount"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Funds": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "native"
+          ],
+          "properties": {
+            "native": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "cw20"
+          ],
+          "properties": {
+            "cw20": {
+              "$ref": "#/definitions/Cw20Coin"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "OrderBy": {
       "type": "string",

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/raw/response_to_andr_hook.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/raw/response_to_andr_hook.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Binary",
+  "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+  "type": "string"
+}

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/raw/response_to_auction_state.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/raw/response_to_auction_state.json
@@ -9,6 +9,7 @@
     "high_bidder_addr",
     "high_bidder_amount",
     "is_cancelled",
+    "owner",
     "start_time"
   ],
   "properties": {
@@ -39,6 +40,9 @@
           "type": "null"
         }
       ]
+    },
+    "owner": {
+      "type": "string"
     },
     "start_time": {
       "$ref": "#/definitions/Expiration"

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/raw/response_to_latest_auction_state.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/raw/response_to_latest_auction_state.json
@@ -9,6 +9,7 @@
     "high_bidder_addr",
     "high_bidder_amount",
     "is_cancelled",
+    "owner",
     "start_time"
   ],
   "properties": {
@@ -39,6 +40,9 @@
           "type": "null"
         }
       ]
+    },
+    "owner": {
+      "type": "string"
     },
     "start_time": {
       "$ref": "#/definitions/Expiration"

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -268,7 +268,7 @@ fn execute_update_auction(
         &token_auction_state,
     )?;
     Ok(Response::new().add_attributes(vec![
-        attr("action", "start_auction"),
+        attr("action", "update_auction"),
         attr("start_time", start_time.to_string()),
         attr("end_time", end_exp.to_string()),
         attr("coin_denom", coin_denom),

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{amp::AndrAddr, andr_exec, andr_instantiate, andr_query, error::ContractError};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{to_json_binary, Addr, Binary, Deps};
+use cosmwasm_std::{to_json_binary, Binary, Deps};
 use serde::Serialize;
 
 #[cw_serde]
@@ -102,7 +102,7 @@ pub enum ExecuteMsg {
     },
     ClaimOwnership {
         name: Option<String>,
-        new_owner: Option<Addr>,
+        new_owner: Option<AndrAddr>,
     },
     ProxyMessage {
         name: String,

--- a/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
@@ -36,12 +36,12 @@ pub struct Sale {
     pub amount: Uint128,
     /// The recipient of the sale proceeds
     pub recipient: String,
-
     /// The time when the sale starts
     pub start_time: Expiration,
-
     /// The time when the sale ends
     pub end_time: Expiration,
+    /// The amount for sale at the given rate at the start of the sale
+    pub start_amount: Uint128,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
@@ -5,6 +5,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw20::Cw20ReceiveMsg;
 use cw_asset::AssetInfo;
+use cw_utils::Expiration;
 use serde::{Deserialize, Serialize};
 
 #[andr_instantiate]
@@ -35,6 +36,12 @@ pub struct Sale {
     pub amount: Uint128,
     /// The recipient of the sale proceeds
     pub recipient: String,
+
+    /// The time when the sale starts
+    pub start_time: Expiration,
+
+    /// The time when the sale ends
+    pub end_time: Expiration,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -48,6 +55,8 @@ pub enum Cw20HookMsg {
         /// The recipient of the sale proceeds
         /// Sender is used if `None` provided
         recipient: Option<String>,
+        start_time: Option<u64>,
+        duration: Option<u64>,
     },
     /// Purchases tokens
     Purchase {

--- a/packages/std/src/common/expiration.rs
+++ b/packages/std/src/common/expiration.rs
@@ -3,7 +3,7 @@ use cw_utils::Expiration;
 
 use crate::error::ContractError;
 
-pub const MILLISECONDS_TO_NANOSECONDS_RATIO: u64 = 1000000;
+pub const MILLISECONDS_TO_NANOSECONDS_RATIO: u64 = 1_000_000;
 
 /// Creates a CosmWasm Expiration struct given a time in milliseconds
 /// # Arguments

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -248,6 +248,12 @@ pub enum ContractError {
     #[error("AuctionEnded")]
     AuctionEnded {},
 
+    #[error("SaleNotStarted")]
+    SaleNotStarted {},
+
+    #[error("SaleEnded")]
+    SaleEnded {},
+
     #[error("SaleNotOpen")]
     SaleNotOpen {},
 
@@ -543,6 +549,9 @@ pub enum ContractError {
 
     #[error("Invalid expiration")]
     InvalidExpiration {},
+
+    #[error("Invalid start time")]
+    InvalidStartTime {},
 
     #[error("Too many mint messages, limit is {limit}")]
     TooManyMintMessages { limit: u32 },


### PR DESCRIPTION
# Motivation
Fixed the `CancelSale` bug(#267) and gave users the option to set a start and end time for the sale. The starting amount of the sale is also saved as part of the `Sale` struct (#269)
Unrelated adjustment: `ClaimOwnership`'s `new_owner` field in the App Contract is now `Option<AndrAddr>` instead of `Option<Addr>`

# Implementation
The CancelSale function was trying to send the Sale owner the asset he's accepting as payment for his CW20 tokens instead of his tokens themselves. I changed that along with the unit test that expected that erroneous operation.

The `start_time` can't be in the past, and if not provided will be set as the current time + 1. If the duration isn't provided the expiration is set as `Never`. If provided it will be the sum of `duration` and `start_time`.

The `start_amount` is automatically saved in `StartSale`  and can be queried through `QueryMsg::Sale`
So three fields were added to `Sale`:
`    /// The time when the sale starts
    pub start_time: Expiration,
    /// The time when the sale ends
    pub end_time: Expiration,
    /// The amount for sale at the given rate at the start of the sale
    pub start_amount: Uint128,`

Explain the details of the change.

# Testing
Unit tests were made for `CancelSale` and `start_time`/`duration` combinations.
An on-chain test was conducted for `CancelSale`: 
CW20-exchange contract code id: 287
`StartSale`: 6780D4B972C23029D75341F566381E813855D1E01DFD16FFD15FC8EBEFBCE052
`CancelSale`: 22EB8AB9CEE411C176EC73DA14A92C297C6519A945AD4B6F0226976F0A66CCA0

# Notes
I tried mirroring the Auction ADO's timing implementation as much as possible for consistency across our contracts.
Credits to @SlayerAnsh for finding the source of the bug in `CancelSale` and @daniel-wehbe for the on-chain test.

# Future work
Issue #268 is partially resolved. I'm leaving the `UpdateSale` change after the current changes are approved.