### PR TITLE
270 marketplace021 extended options in startsale struct

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/andromeda-marketplace.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/andromeda-marketplace.json
@@ -1112,12 +1112,174 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "andr_hook"
+        ],
+        "properties": {
+          "andr_hook": {
+            "$ref": "#/definitions/AndromedaHook"
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
       "AndrAddr": {
         "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
         "type": "string"
+      },
+      "AndromedaHook": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "on_execute"
+            ],
+            "properties": {
+              "on_execute": {
+                "type": "object",
+                "required": [
+                  "payload",
+                  "sender"
+                ],
+                "properties": {
+                  "payload": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "sender": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "on_funds_transfer"
+            ],
+            "properties": {
+              "on_funds_transfer": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "payload",
+                  "sender"
+                ],
+                "properties": {
+                  "amount": {
+                    "$ref": "#/definitions/Funds"
+                  },
+                  "payload": {
+                    "$ref": "#/definitions/Binary"
+                  },
+                  "sender": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "on_token_transfer"
+            ],
+            "properties": {
+              "on_token_transfer": {
+                "type": "object",
+                "required": [
+                  "recipient",
+                  "sender",
+                  "token_id"
+                ],
+                "properties": {
+                  "recipient": {
+                    "type": "string"
+                  },
+                  "sender": {
+                    "type": "string"
+                  },
+                  "token_id": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
+      "Cw20Coin": {
+        "type": "object",
+        "required": [
+          "address",
+          "amount"
+        ],
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Funds": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "native"
+            ],
+            "properties": {
+              "native": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "cw20"
+            ],
+            "properties": {
+              "cw20": {
+                "$ref": "#/definitions/Cw20Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -1132,6 +1294,12 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "andr_hook": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Binary",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
     "balance": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "BalanceResponse",
@@ -1251,6 +1419,7 @@
           "type": "string",
           "enum": [
             "open",
+            "expired",
             "executed",
             "cancelled"
           ]
@@ -1608,6 +1777,7 @@
           "type": "string",
           "enum": [
             "open",
+            "expired",
             "executed",
             "cancelled"
           ]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/cw721receive.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/cw721receive.json
@@ -19,8 +19,24 @@
             "coin_denom": {
               "type": "string"
             },
+            "duration": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
             "price": {
               "$ref": "#/definitions/Uint128"
+            },
+            "start_time": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false

--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/query.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/query.json
@@ -326,12 +326,174 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "andr_hook"
+      ],
+      "properties": {
+        "andr_hook": {
+          "$ref": "#/definitions/AndromedaHook"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
     "AndrAddr": {
       "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
       "type": "string"
+    },
+    "AndromedaHook": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "on_execute"
+          ],
+          "properties": {
+            "on_execute": {
+              "type": "object",
+              "required": [
+                "payload",
+                "sender"
+              ],
+              "properties": {
+                "payload": {
+                  "$ref": "#/definitions/Binary"
+                },
+                "sender": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "on_funds_transfer"
+          ],
+          "properties": {
+            "on_funds_transfer": {
+              "type": "object",
+              "required": [
+                "amount",
+                "payload",
+                "sender"
+              ],
+              "properties": {
+                "amount": {
+                  "$ref": "#/definitions/Funds"
+                },
+                "payload": {
+                  "$ref": "#/definitions/Binary"
+                },
+                "sender": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "on_token_transfer"
+          ],
+          "properties": {
+            "on_token_transfer": {
+              "type": "object",
+              "required": [
+                "recipient",
+                "sender",
+                "token_id"
+              ],
+              "properties": {
+                "recipient": {
+                  "type": "string"
+                },
+                "sender": {
+                  "type": "string"
+                },
+                "token_id": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      }
+    },
+    "Cw20Coin": {
+      "type": "object",
+      "required": [
+        "address",
+        "amount"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Funds": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "native"
+          ],
+          "properties": {
+            "native": {
+              "$ref": "#/definitions/Coin"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "cw20"
+          ],
+          "properties": {
+            "cw20": {
+              "$ref": "#/definitions/Cw20Coin"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/response_to_andr_hook.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/response_to_andr_hook.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Binary",
+  "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+  "type": "string"
+}

--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/response_to_latest_sale_state.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/response_to_latest_sale_state.json
@@ -28,6 +28,7 @@
       "type": "string",
       "enum": [
         "open",
+        "expired",
         "executed",
         "cancelled"
       ]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/response_to_sale_state.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/raw/response_to_sale_state.json
@@ -28,6 +28,7 @@
       "type": "string",
       "enum": [
         "open",
+        "expired",
         "executed",
         "cancelled"
       ]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -10,7 +10,7 @@ use andromeda_std::ado_contract::ADOContract;
 
 use andromeda_std::common::context::ExecuteContext;
 use andromeda_std::common::expiration::{
-    block_to_expiration, expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO,
+    expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO,
 };
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -174,18 +174,15 @@ fn execute_start_sale(
     };
 
     // To guard against misleading start times
-    // let block_time = block_to_expiration(&env.block, start_expiration).unwrap();
-    // println!(
-    //     "block time is: {:?} and start_expiration is: {:?}",
-    //     block_time, start_expiration
-    // );
-    // ensure!(
-    //     start_expiration.gt(&block_time),
-    //     ContractError::StartTimeInThePast {
-    //         current_time: env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO,
-    //         current_block: env.block.height,
-    //     }
-    // );
+    let recent_past_timestamp = env.block.time.minus_seconds(1);
+    let recent_past_expiration = expiration_from_milliseconds(recent_past_timestamp.seconds())?;
+    ensure!(
+        start_expiration.gt(&recent_past_expiration),
+        ContractError::StartTimeInThePast {
+            current_time: env.block.time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO,
+            current_block: env.block.height,
+        }
+    );
 
     let sale_id = get_and_increment_next_sale_id(deps.storage, &token_id, &token_address)?;
     let status = Status::Open;

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -284,7 +284,7 @@ fn execute_buy(
             // If start time hasn't expired, it means that the sale hasn't started yet.
             ensure!(
                 token_sale_state.start_time.is_expired(&env.block),
-                ContractError::SaleNotStarted {}
+                ContractError::SaleNotOpen {}
             );
         }
         Status::Expired => return Err(ContractError::SaleExpired {}),

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
@@ -68,6 +68,8 @@ pub fn mock_start_sale(price: Uint128, coin_denom: impl Into<String>) -> Cw721Ho
     Cw721HookMsg::StartSale {
         price,
         coin_denom: coin_denom.into(),
+        start_time: None,
+        duration: None,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
@@ -4,6 +4,7 @@ use andromeda_std::error::ContractError;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Order, Storage, SubMsg, Uint128};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, Map, MultiIndex};
+use cw_utils::Expiration;
 
 const MAX_LIMIT: u64 = 30;
 const DEFAULT_LIMIT: u64 = 10;
@@ -17,6 +18,8 @@ pub struct TokenSaleState {
     pub token_address: String,
     pub price: Uint128,
     pub status: Status,
+    pub start_time: Expiration,
+    pub end_time: Expiration,
 }
 
 #[cw_serde]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/mock_querier.rs
@@ -1,8 +1,6 @@
 use andromeda_app::app::QueryMsg as AppQueryMsg;
 use andromeda_std::testing::mock_querier::MockAndromedaQuerier;
-pub use andromeda_std::testing::mock_querier::{
-    MOCK_ADDRESS_LIST_CONTRACT, MOCK_APP_CONTRACT, MOCK_KERNEL_CONTRACT,
-};
+pub use andromeda_std::testing::mock_querier::{MOCK_APP_CONTRACT, MOCK_KERNEL_CONTRACT};
 use andromeda_std::{
     ado_base::hooks::{AndromedaHook, HookMsg, OnFundsTransferResponse},
     ado_contract::ADOContract,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -198,7 +198,7 @@ fn test_execute_buy_non_existing_sale() {
 }
 
 #[test]
-fn execute_buy_sale_not_open_already_bought() {
+fn test_execute_buy_sale_not_open_already_bought() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
     let _res = init(deps.as_mut(), None);
@@ -225,7 +225,7 @@ fn execute_buy_sale_not_open_already_bought() {
 }
 
 #[test]
-fn execute_buy_sale_not_open_cancelled() {
+fn test_execute_buy_sale_not_open_cancelled() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -252,7 +252,7 @@ fn execute_buy_sale_not_open_cancelled() {
 }
 
 #[test]
-fn execute_buy_token_owner_cannot_buy() {
+fn test_execute_buy_token_owner_cannot_buy() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -272,7 +272,7 @@ fn execute_buy_token_owner_cannot_buy() {
 }
 
 #[test]
-fn execute_buy_invalid_coins_sent() {
+fn test_execute_buy_invalid_coins_sent() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -316,7 +316,7 @@ fn execute_buy_invalid_coins_sent() {
 }
 
 #[test]
-fn execute_buy_works() {
+fn test_execute_buy_works() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -335,7 +335,7 @@ fn execute_buy_works() {
 }
 
 #[test]
-fn execute_buy_future_start() {
+fn test_execute_buy_future_start() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -356,7 +356,7 @@ fn execute_buy_future_start() {
 }
 
 #[test]
-fn execute_buy_sale_expired() {
+fn test_execute_buy_sale_expired() {
     let mut deps = mock_dependencies_custom(&[]);
     let mut env = mock_env();
 
@@ -378,7 +378,7 @@ fn execute_buy_sale_expired() {
 }
 
 #[test]
-fn execute_update_sale_unauthorized() {
+fn test_execute_update_sale_unauthorized() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -400,7 +400,7 @@ fn execute_update_sale_unauthorized() {
 }
 
 #[test]
-fn execute_update_sale_invalid_price() {
+fn test_execute_update_sale_invalid_price() {
     let mut deps = mock_dependencies_custom(&[]);
     let env = mock_env();
 
@@ -422,7 +422,7 @@ fn execute_update_sale_invalid_price() {
 }
 
 #[test]
-fn execute_start_sale_invalid_price() {
+fn test_execute_start_sale_invalid_price() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut(), None);
 
@@ -445,7 +445,7 @@ fn execute_start_sale_invalid_price() {
 }
 
 #[test]
-fn execute_buy_with_tax_and_royalty_insufficient_funds() {
+fn test_execute_buy_with_tax_and_royalty_insufficient_funds() {
     let mut deps = mock_dependencies_custom(&[]);
     let modules = vec![Module {
         name: Some(RATES.to_owned()),
@@ -468,7 +468,7 @@ fn execute_buy_with_tax_and_royalty_insufficient_funds() {
 }
 
 #[test]
-fn execute_buy_with_tax_and_royalty_works() {
+fn test_execute_buy_with_tax_and_royalty_works() {
     let mut deps = mock_dependencies_custom(&[]);
     let modules = vec![Module {
         name: Some(RATES.to_owned()),

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -13,7 +13,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     coin, coins,
     testing::{mock_env, mock_info},
-    BankMsg, CosmosMsg, Deps, DepsMut, Env, Response, SubMsg, Timestamp, Uint128, WasmMsg,
+    BankMsg, CosmosMsg, Deps, DepsMut, Env, Response, SubMsg, Uint128, WasmMsg,
 };
 use cw721::{Cw721ExecuteMsg, Cw721ReceiveMsg};
 use cw_utils::Expiration;

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -352,7 +352,7 @@ fn execute_buy_future_start() {
     let info = mock_info("someone", &coins(100, "uusd".to_string()));
     // The start time is ahead of the current block time, so it should return a Sale Not Started error.
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::SaleNotStarted {})
+    assert_eq!(err, ContractError::SaleNotOpen {})
 }
 
 #[test]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -271,30 +271,6 @@ fn execute_buy_token_owner_cannot_buy() {
     assert_eq!(ContractError::TokenOwnerCannotBuy {}, res.unwrap_err());
 }
 
-// #[test]
-// fn execute_buy_whitelist() {
-//     let mut deps = mock_dependencies_custom(&[]);
-//     let env = mock_env();
-//     let info = mock_info("owner", &[]);
-//     let msg = InstantiateMsg {
-//     let _res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
-
-//     start_sale(deps.as_mut(), Some(vec![Addr::unchecked("sender")]));
-//     assert_sale_created(deps.as_ref(), Some(vec![Addr::unchecked("sender")]));
-
-//     let msg = ExecuteMsg::Buy {
-//         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
-//         token_address: MOCK_TOKEN_ADDR.to_string(),
-//     };
-
-//     let info = mock_info("not_sender", &coins(100, "uusd".to_string()));
-//     let res = execute(deps.as_mut(), env.clone(), info, msg.clone());
-//     assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
-
-//     let info = mock_info("sender", &coins(100, "uusd".to_string()));
-//     let _res = execute(deps.as_mut(), env, info, msg).unwrap();
-// }
-
 #[test]
 fn execute_buy_invalid_coins_sent() {
     let mut deps = mock_dependencies_custom(&[]);

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -46,7 +46,6 @@ pub enum Cw721HookMsg {
 #[cw_serde]
 pub enum Status {
     Open,
-    Pending,
     Expired,
     Executed,
     Cancelled,
@@ -55,7 +54,6 @@ impl Display for Status {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             Status::Open => f.write_str("Open"),
-            Status::Pending => f.write_str("Pending"),
             Status::Expired => f.write_str("Expired"),
             Status::Executed => f.write_str("Executed"),
             Status::Cancelled => f.write_str("Cancelled"),

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -2,6 +2,7 @@ use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw721::Cw721ReceiveMsg;
+use std::fmt::{Display, Formatter, Result};
 
 #[andr_instantiate]
 #[andr_instantiate_modules]
@@ -35,13 +36,31 @@ pub enum ExecuteMsg {
 pub enum Cw721HookMsg {
     /// Starts a new sale with the given parameters. The sale info can be modified before it
     /// has started but is immutable after that.
-    StartSale { price: Uint128, coin_denom: String },
+    StartSale {
+        price: Uint128,
+        coin_denom: String,
+        start_time: Option<u64>,
+        duration: Option<u64>,
+    },
 }
 #[cw_serde]
 pub enum Status {
     Open,
+    Pending,
+    Expired,
     Executed,
     Cancelled,
+}
+impl Display for Status {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            Status::Open => f.write_str("Open"),
+            Status::Pending => f.write_str("Pending"),
+            Status::Expired => f.write_str("Expired"),
+            Status::Executed => f.write_str("Executed"),
+            Status::Cancelled => f.write_str("Cancelled"),
+        }
+    }
 }
 
 #[cw_serde]

--- a/packages/std/src/common/expiration.rs
+++ b/packages/std/src/common/expiration.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure, Timestamp};
+use cosmwasm_std::{ensure, BlockInfo, Timestamp};
 use cw_utils::Expiration;
 
 use crate::error::ContractError;
@@ -21,6 +21,14 @@ pub fn expiration_from_milliseconds(time: u64) -> Result<Expiration, ContractErr
     Ok(Expiration::AtTime(Timestamp::from_nanos(
         time * MILLISECONDS_TO_NANOSECONDS_RATIO,
     )))
+}
+
+pub fn block_to_expiration(block: &BlockInfo, model: Expiration) -> Option<Expiration> {
+    match model {
+        Expiration::AtTime(_) => Some(Expiration::AtTime(block.time)),
+        Expiration::AtHeight(_) => Some(Expiration::AtHeight(block.height)),
+        Expiration::Never {} => None,
+    }
 }
 
 #[cfg(test)]

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -260,9 +260,6 @@ pub enum ContractError {
     #[error("SaleCancelled")]
     SaleCancelled {},
 
-    #[error("SaleNotStarted")]
-    SaleNotStarted {},
-
     #[error("NoTargetADOs")]
     NoTargetADOs {},
 

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -251,6 +251,18 @@ pub enum ContractError {
     #[error("SaleNotOpen")]
     SaleNotOpen {},
 
+    #[error("SaleExpired")]
+    SaleExpired {},
+
+    #[error("SaleExecuted")]
+    SaleExecuted {},
+
+    #[error("SaleCancelled")]
+    SaleCancelled {},
+
+    #[error("SaleNotStarted")]
+    SaleNotStarted {},
+
     #[error("NoTargetADOs")]
     NoTargetADOs {},
 


### PR DESCRIPTION
# Motivation
Added the option of setting a start time and duration for sales in the marketplace ADO. These changes address issue #270.

# Implementation
The start time defaults to the current block time, and if duration isn't provided, the end time defaults to `Expiration::Never {}`.
When provided, the start time cannot be more than a second behind the current time. This guards against misleading start times. 
The duration is added to the current time which yields the end time's expiration.
Buying tokens isn't allowed before the start time and after the end time's expiration.

# Testing
Unit tests were created. No on-chain tests were conducted.

# Notes
I went for current time - 1 seconds instead of current time as a guard against misleading start times because the unit tests were erroring. The block time's value was 1571797419879305533 whereas the start_expiration which was set to current time was 1571797419879000000
So I started checking the start time was greater than block time - 1 second.


# Future work
Do we want to allow the start time and duration to be updated through the `UpdateSale` message?
Should we enforce a minimum duration and maximum start time? 
