### PR TITLE
Kernel Direct Send

### DIFF
--- a/contracts/data-storage/andromeda-primitive/src/testing/tests.rs
+++ b/contracts/data-storage/andromeda-primitive/src/testing/tests.rs
@@ -39,7 +39,7 @@ fn test_set_and_update_value_with_key() {
 
     assert_eq!(
         GetValueResponse {
-            key: key.unwrap_or("default".into()),
+            key: key.map(|_| "default".into()).unwrap(),
             value
         },
         query_res
@@ -70,7 +70,7 @@ fn test_set_and_update_value_without_key() {
 
     assert_eq!(
         GetValueResponse {
-            key: key.unwrap_or("default".into()),
+            key: key.map(|_| "default".into()).unwrap(),
             value
         },
         query_res

--- a/contracts/data-storage/andromeda-primitive/src/testing/tests.rs
+++ b/contracts/data-storage/andromeda-primitive/src/testing/tests.rs
@@ -18,32 +18,38 @@ fn test_instantiation() {
 #[test]
 fn test_set_and_update_value_with_key() {
     let (mut deps, info) = proper_initialization(PrimitiveRestriction::Private);
-    let key = Some(String::from("key"));
+    let key = String::from("key");
     let value = Primitive::String("value".to_string());
-    set_value(deps.as_mut(), &key, &value, info.sender.as_ref()).unwrap();
+    set_value(
+        deps.as_mut(),
+        &Some(key.clone()),
+        &value,
+        info.sender.as_ref(),
+    )
+    .unwrap();
 
-    let query_res: GetValueResponse = query_value(deps.as_ref(), &key).unwrap();
+    let query_res: GetValueResponse = query_value(deps.as_ref(), &Some(key.clone())).unwrap();
 
     assert_eq!(
         GetValueResponse {
-            key: key.clone().unwrap_or("default".into()),
+            key: key.clone(),
             value
         },
         query_res
     );
 
     let value = Primitive::String("value2".to_string());
-    set_value(deps.as_mut(), &key, &value, info.sender.as_ref()).unwrap();
+    set_value(
+        deps.as_mut(),
+        &Some(key.clone()),
+        &value,
+        info.sender.as_ref(),
+    )
+    .unwrap();
 
-    let query_res: GetValueResponse = query_value(deps.as_ref(), &key).unwrap();
+    let query_res: GetValueResponse = query_value(deps.as_ref(), &Some(key.clone())).unwrap();
 
-    assert_eq!(
-        GetValueResponse {
-            key: key.map(|_| "default".into()).unwrap(),
-            value
-        },
-        query_res
-    );
+    assert_eq!(GetValueResponse { key, value }, query_res);
 }
 
 #[test]
@@ -70,7 +76,7 @@ fn test_set_and_update_value_without_key() {
 
     assert_eq!(
         GetValueResponse {
-            key: key.map(|_| "default".into()).unwrap(),
+            key: "default".to_string(),
             value
         },
         query_res

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -1,17 +1,20 @@
+use core::slice::SlicePattern;
+
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::amp::addresses::AndrAddr;
 use andromeda_std::amp::messages::{AMPCtx, AMPMsg, AMPPkt, IBCConfig};
 use andromeda_std::amp::{ADO_DB_KEY, VFS_KEY};
 
 use andromeda_std::common::context::ExecuteContext;
+use andromeda_std::common::merge_coins;
 use andromeda_std::error::ContractError;
 use andromeda_std::os::aos_querier::AOSQuerier;
 use andromeda_std::os::kernel::{ChannelInfo, IbcExecuteMsg, InternalMsg};
 
 use andromeda_std::os::vfs::vfs_resolve_symlink;
 use cosmwasm_std::{
-    attr, ensure, to_binary, Addr, BankMsg, Binary, ContractInfoResponse, CosmosMsg, DepsMut, Env,
-    IbcMsg, MessageInfo, Response, StdError, SubMsg, WasmMsg,
+    attr, ensure, has_coins, to_binary, Addr, BankMsg, Binary, Coin, ContractInfoResponse,
+    CosmosMsg, DepsMut, Env, IbcMsg, MessageInfo, Response, StdError, SubMsg, WasmMsg,
 };
 
 use crate::ibc::{generate_transfer_message, PACKET_LIFETIME};
@@ -22,8 +25,13 @@ use crate::state::{
 use crate::{query, reply::ReplyId};
 
 pub fn send(ctx: ExecuteContext, message: AMPMsg) -> Result<Response, ContractError> {
+    for funds in message.funds {
+        ensure!(
+            has_coins(ctx.info.funds.as_slice(), &funds),
+            ContractError::InsufficientFunds {}
+        );
+    }
     let res = MsgHandler(message).handle(ctx.deps, ctx.info, ctx.env, ctx.amp_ctx, 0)?;
-
     Ok(res)
 }
 
@@ -52,6 +60,7 @@ pub fn amp_receive(
             error: Some("No messages supplied".to_string())
         }
     );
+    let mut message_funds: Vec<Coin> = vec![];
     for (idx, message) in packet.messages.iter().enumerate() {
         let mut handler = MsgHandler::new(message.clone());
         let msg_res = handler.handle(
@@ -64,7 +73,16 @@ pub fn amp_receive(
         res.messages.extend_from_slice(&msg_res.messages);
         res.attributes.extend_from_slice(&msg_res.attributes);
         res.events.extend_from_slice(&msg_res.events);
+        merge_coins(&mut message_funds, message.funds.to_vec());
     }
+
+    for required_funds in message_funds {
+        ensure!(
+            has_coins(info.funds.as_slice(), &required_funds),
+            ContractError::InsufficientFunds {}
+        );
+    }
+
     Ok(res.add_attribute("action", "handle_amp_packet"))
 }
 

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -1,6 +1,6 @@
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::amp::addresses::AndrAddr;
-use andromeda_std::amp::messages::{AMPMsg, AMPPkt, IBCConfig};
+use andromeda_std::amp::messages::{AMPCtx, AMPMsg, AMPPkt, IBCConfig};
 use andromeda_std::amp::{ADO_DB_KEY, VFS_KEY};
 
 use andromeda_std::common::context::ExecuteContext;
@@ -10,8 +10,8 @@ use andromeda_std::os::kernel::{ChannelInfo, IbcExecuteMsg, InternalMsg};
 
 use andromeda_std::os::vfs::vfs_resolve_symlink;
 use cosmwasm_std::{
-    attr, ensure, to_binary, Addr, BankMsg, Binary, CosmosMsg, DepsMut, Env, IbcMsg, MessageInfo,
-    Response, StdError, SubMsg, WasmMsg,
+    attr, ensure, to_binary, Addr, BankMsg, Binary, ContractInfoResponse, CosmosMsg, DepsMut, Env,
+    IbcMsg, MessageInfo, Response, StdError, SubMsg, WasmMsg,
 };
 
 use crate::ibc::{generate_transfer_message, PACKET_LIFETIME};
@@ -302,7 +302,7 @@ pub fn recover(execute_env: ExecuteContext) -> Result<Response, ContractError> {
 ///
 /// Separated due to common functionality across multiple messages
 #[derive(Clone)]
-struct MsgHandler(AMPMsg);
+pub struct MsgHandler(AMPMsg);
 
 impl MsgHandler {
     pub fn new(msg: AMPMsg) -> Self {
@@ -342,7 +342,7 @@ impl MsgHandler {
 
         match protocol {
             Some("ibc") => self.handle_ibc(deps, info, env, ctx, sequence),
-            _ => self.handle_local(deps, info, env, ctx, sequence),
+            _ => self.handle_local(deps, info, env, ctx.map(|ctx| ctx.ctx), sequence),
         }
     }
 
@@ -353,12 +353,12 @@ impl MsgHandler {
 
     In both situations the sender can define the funds that are being attached to the message.
     */
-    fn handle_local(
+    pub fn handle_local(
         &self,
         deps: DepsMut,
         info: MessageInfo,
         _env: Env,
-        ctx: Option<AMPPkt>,
+        ctx: Option<AMPCtx>,
         sequence: u64,
     ) -> Result<Response, ContractError> {
         let mut res = Response::default();
@@ -366,9 +366,12 @@ impl MsgHandler {
             message,
             recipient,
             funds,
+            config,
             ..
         } = self.message();
         let recipient_addr = recipient.get_raw_address(&deps.as_ref())?;
+
+        let adodb_addr = KERNEL_ADDRESSES.load(deps.storage, ADO_DB_KEY)?;
 
         // A default message is a bank message
         if Binary::default() == message.clone() {
@@ -397,25 +400,44 @@ impl MsgHandler {
                 .add_attributes(attrs);
         } else {
             let origin = if let Some(amp_ctx) = ctx {
-                amp_ctx.ctx.get_origin()
+                amp_ctx.get_origin()
             } else {
                 info.sender.to_string()
             };
             let previous_sender = info.sender.to_string();
 
-            let amp_msg = AMPMsg::new(recipient_addr.clone(), message.clone(), Some(funds.clone()));
+            // Ensure recipient is a smart contract
+            let ContractInfoResponse {
+                code_id: recipient_code_id,
+                ..
+            } = deps
+                .querier
+                .query_wasm_contract_info(recipient_addr.clone())
+                .ok()
+                .ok_or(ContractError::InvalidPacket {
+                    error: Some("Recipient is not a contract".to_string()),
+                })?;
 
-            let new_packet = AMPPkt::new(origin, previous_sender, vec![amp_msg]);
-
-            let sub_msg = if funds.is_empty() {
-                new_packet.to_sub_msg(recipient_addr.clone(), None, ReplyId::AMPMsg.repr())?
+            let sub_msg = if config.direct
+                || AOSQuerier::ado_type_getter(&deps.querier, &adodb_addr, recipient_code_id)?
+                    .is_none()
+            {
+                // Message is direct (no AMP Ctx)
+                self.message()
+                    .generate_sub_msg_direct(recipient_addr.clone(), ReplyId::AMPMsg.repr())
             } else {
+                let amp_msg =
+                    AMPMsg::new(recipient_addr.clone(), message.clone(), Some(funds.clone()));
+
+                let new_packet = AMPPkt::new(origin, previous_sender, vec![amp_msg]);
+
                 new_packet.to_sub_msg(
                     recipient_addr.clone(),
                     Some(funds.clone()),
                     ReplyId::AMPMsg.repr(),
                 )?
             };
+
             res = res
                 .add_submessage(sub_msg)
                 .add_attributes(vec![attr(format!("recipient:{sequence}"), recipient_addr)]);

--- a/contracts/os/andromeda-kernel/src/reply.rs
+++ b/contracts/os/andromeda-kernel/src/reply.rs
@@ -58,7 +58,9 @@ pub fn on_reply_ibc_hooks_packet_send(
     msg: Reply,
 ) -> Result<Response, ContractError> {
     let SubMsgResult::Ok(SubMsgResponse { data: Some(b), .. }) = msg.result else {
-        return Err(ContractError::InvalidPacket { error: Some(format!("ibc hooks: failed reply: {:?}", msg.result)) })
+        return Err(ContractError::InvalidPacket {
+            error: Some(format!("ibc hooks: failed reply: {:?}", msg.result)),
+        });
     };
 
     let MsgTransferResponse { sequence } =

--- a/contracts/os/andromeda-kernel/src/sudo.rs
+++ b/contracts/os/andromeda-kernel/src/sudo.rs
@@ -24,7 +24,7 @@ pub mod ibc_lifecycle {
             OUTGOING_IBC_PACKETS.may_load(deps.storage, (&source_channel, sequence))?;
         let Some(inflight_packet) = sent_packet else {
             // If there isn't, continue
-            return Ok(response.add_attribute("msg", "received unexpected ack"))
+            return Ok(response.add_attribute("msg", "received unexpected ack"));
         };
         OUTGOING_IBC_PACKETS.remove(deps.storage, (&source_channel, sequence));
 
@@ -61,7 +61,7 @@ pub mod ibc_lifecycle {
             OUTGOING_IBC_PACKETS.may_load(deps.storage, (&source_channel, sequence))?;
         let Some(inflight_packet) = sent_packet else {
             // If there isn't, continue
-            return Ok(response.add_attribute("msg", "received unexpected timeout"))
+            return Ok(response.add_attribute("msg", "received unexpected timeout"));
         };
         // Remove the in-flight packet
         OUTGOING_IBC_PACKETS.remove(deps.storage, (&source_channel, sequence));

--- a/contracts/os/andromeda-kernel/src/testing/mod.rs
+++ b/contracts/os/andromeda-kernel/src/testing/mod.rs
@@ -1,1 +1,2 @@
+mod test_handler;
 mod tests;

--- a/contracts/os/andromeda-kernel/src/testing/test_handler.rs
+++ b/contracts/os/andromeda-kernel/src/testing/test_handler.rs
@@ -1,0 +1,224 @@
+use crate::{execute::MsgHandler, reply::ReplyId, state::KERNEL_ADDRESSES};
+use andromeda_std::{
+    amp::{
+        messages::{AMPCtx, AMPMsg, AMPPkt},
+        ADO_DB_KEY,
+    },
+    error::ContractError,
+    testing::mock_querier::{
+        mock_dependencies_custom, FAKE_VFS_PATH, INVALID_CONTRACT, MOCK_ADODB_CONTRACT,
+        MOCK_APP_CONTRACT, MOCK_WALLET,
+    },
+};
+use cosmwasm_std::{
+    coin,
+    testing::{mock_env, mock_info},
+    to_binary, Addr, BankMsg, Binary, SubMsg,
+};
+
+struct TestHandleLocalCase {
+    name: &'static str,
+    sender: &'static str,
+    msg: AMPMsg,
+    ctx: Option<AMPCtx>,
+    expected_submessage: SubMsg,
+    expected_error: Option<ContractError>,
+}
+
+#[test]
+fn test_handle_local() {
+    let test_cases = vec![
+        TestHandleLocalCase {
+            name: "Valid message to ADO (no funds/context)",
+            sender: "sender",
+            msg: AMPMsg::new(MOCK_APP_CONTRACT, to_binary(&true).unwrap(), None),
+            ctx: None,
+            expected_submessage: AMPPkt::new(
+                "sender",
+                "sender",
+                vec![AMPMsg::new(
+                    MOCK_APP_CONTRACT,
+                    to_binary(&true).unwrap(),
+                    None,
+                )],
+            )
+            .to_sub_msg(MOCK_APP_CONTRACT, None, ReplyId::AMPMsg.repr())
+            .unwrap(),
+            expected_error: None,
+        },
+        TestHandleLocalCase {
+            name: "Valid message to ADO (no funds)",
+            sender: "sender",
+            msg: AMPMsg::new(MOCK_APP_CONTRACT, to_binary(&true).unwrap(), None),
+            ctx: Some(AMPCtx::new("origin", MOCK_APP_CONTRACT, 1, None)),
+            expected_submessage: AMPPkt::new(
+                "origin",
+                "sender",
+                vec![AMPMsg::new(
+                    MOCK_APP_CONTRACT,
+                    to_binary(&true).unwrap(),
+                    None,
+                )],
+            )
+            .to_sub_msg(MOCK_APP_CONTRACT, None, ReplyId::AMPMsg.repr())
+            .unwrap(),
+            expected_error: None,
+        },
+        TestHandleLocalCase {
+            name: "Valid message to ADO w/ funds",
+            sender: "sender",
+            msg: AMPMsg::new(
+                MOCK_APP_CONTRACT,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            ),
+            ctx: Some(AMPCtx::new("origin", MOCK_APP_CONTRACT, 1, None)),
+            expected_submessage: AMPPkt::new(
+                "origin",
+                "sender",
+                vec![AMPMsg::new(
+                    MOCK_APP_CONTRACT,
+                    to_binary(&true).unwrap(),
+                    Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+                )],
+            )
+            .to_sub_msg(
+                MOCK_APP_CONTRACT,
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+                ReplyId::AMPMsg.repr(),
+            )
+            .unwrap(),
+            expected_error: None,
+        },
+        TestHandleLocalCase {
+            name: "Valid message direct to Non-ADO (no funds)",
+            sender: "sender",
+            msg: AMPMsg::new(INVALID_CONTRACT, to_binary(&true).unwrap(), None),
+            ctx: None,
+            expected_submessage: AMPMsg::new(INVALID_CONTRACT, to_binary(&true).unwrap(), None)
+                .generate_sub_msg_direct(Addr::unchecked(INVALID_CONTRACT), ReplyId::AMPMsg.repr()),
+            expected_error: None,
+        },
+        TestHandleLocalCase {
+            name: "Valid message direct to Non-ADO w/ funds",
+            sender: "sender",
+            msg: AMPMsg::new(
+                INVALID_CONTRACT,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            ),
+            ctx: None,
+            expected_submessage: AMPMsg::new(
+                INVALID_CONTRACT,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            )
+            .generate_sub_msg_direct(Addr::unchecked(INVALID_CONTRACT), ReplyId::AMPMsg.repr()),
+            expected_error: None,
+        },
+        TestHandleLocalCase {
+            name: "Recipient not a contract",
+            sender: "sender",
+            msg: AMPMsg::new(
+                MOCK_WALLET,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            ),
+            ctx: None,
+            expected_submessage: AMPMsg::new(
+                INVALID_CONTRACT,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            )
+            .generate_sub_msg_direct(Addr::unchecked(INVALID_CONTRACT), ReplyId::AMPMsg.repr()),
+            expected_error: Some(ContractError::InvalidPacket {
+                error: Some("Recipient is not a contract".to_string()),
+            }),
+        },
+        TestHandleLocalCase {
+            name: "Invalid Recipient Path",
+            sender: "sender",
+            msg: AMPMsg::new(
+                FAKE_VFS_PATH,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            ),
+            ctx: None,
+            expected_submessage: AMPMsg::new(
+                FAKE_VFS_PATH,
+                to_binary(&true).unwrap(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            )
+            .generate_sub_msg_direct(Addr::unchecked(INVALID_CONTRACT), ReplyId::AMPMsg.repr()),
+            expected_error: Some(ContractError::InvalidPathname {
+                error: Some(format!(
+                    "{:?} does not exist in the file system",
+                    FAKE_VFS_PATH
+                )),
+            }),
+        },
+        TestHandleLocalCase {
+            name: "Valid bank send message",
+            sender: "sender",
+            msg: AMPMsg::new(
+                "receiver",
+                Binary::default(),
+                Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
+            ),
+            ctx: None,
+            expected_submessage: SubMsg::reply_on_error(
+                BankMsg::Send {
+                    to_address: "receiver".to_string(),
+                    amount: vec![coin(100, "denom"), coin(200, "denom_two")],
+                },
+                ReplyId::AMPMsg.repr(),
+            ),
+            expected_error: None,
+        },
+        TestHandleLocalCase {
+            name: "Bank send no funds",
+            sender: "sender",
+            msg: AMPMsg::new("receiver", Binary::default(), None),
+            ctx: None,
+            expected_submessage: SubMsg::reply_on_error(
+                BankMsg::Send {
+                    to_address: "receiver".to_string(),
+                    amount: vec![],
+                },
+                ReplyId::AMPMsg.repr(),
+            ),
+            expected_error: Some(ContractError::InvalidPacket {
+                error: Some("No message or funds supplied".to_string()),
+            }),
+        },
+    ];
+
+    for test in test_cases {
+        let mut deps = mock_dependencies_custom(&[]);
+        let info = mock_info(test.sender, &[]);
+
+        KERNEL_ADDRESSES
+            .save(
+                deps.as_mut().storage,
+                ADO_DB_KEY,
+                &Addr::unchecked(MOCK_ADODB_CONTRACT),
+            )
+            .unwrap();
+
+        let res =
+            MsgHandler::new(test.msg).handle_local(deps.as_mut(), info, mock_env(), test.ctx, 0);
+
+        if let Some(err) = test.expected_error {
+            assert_eq!(res.unwrap_err(), err, "{}", test.name);
+            continue;
+        }
+
+        let response = res.unwrap();
+
+        assert_eq!(
+            response.messages[0], test.expected_submessage,
+            "{}",
+            test.name
+        );
+    }
+}

--- a/packages/andromeda-finance/src/timelock.rs
+++ b/packages/andromeda-finance/src/timelock.rs
@@ -112,7 +112,7 @@ impl Escrow {
     ///
     /// Returns nothing as it is done in place.
     pub fn add_funds(&mut self, coins_to_add: Vec<Coin>) {
-        merge_coins(&mut self.coins, coins_to_add);
+        self.coins = merge_coins(self.coins.to_vec(), coins_to_add);
     }
 }
 

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -88,7 +88,14 @@ impl AndrAddr {
                 let valid_vfs_path =
                     self.local_path_to_vfs_path(deps.storage, &deps.querier, vfs_contract.clone())?;
                 let vfs_addr = Addr::unchecked(vfs_contract);
-                vfs_resolve_path(valid_vfs_path, vfs_addr, &deps.querier)
+                vfs_resolve_path(valid_vfs_path.clone(), vfs_addr, &deps.querier)
+                    .ok()
+                    .ok_or(ContractError::InvalidPathname {
+                        error: Some(format!(
+                            "{:?} does not exist in the file system",
+                            valid_vfs_path.0
+                        )),
+                    })
             }
         }
     }

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -5,8 +5,8 @@ use crate::os::aos_querier::AOSQuerier;
 use crate::os::{kernel::ExecuteMsg as KernelExecuteMsg, kernel::QueryMsg as KernelQueryMsg};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Coin, ContractInfoResponse, CosmosMsg, Deps, MessageInfo,
-    QueryRequest, ReplyOn, SubMsg, WasmMsg, WasmQuery,
+    to_binary, wasm_execute, Addr, Binary, Coin, ContractInfoResponse, CosmosMsg, Deps, Empty,
+    MessageInfo, QueryRequest, ReplyOn, SubMsg, WasmMsg, WasmQuery,
 };
 
 use super::addresses::AndrAddr;
@@ -148,6 +148,15 @@ impl AMPMsg {
                 funds: self.funds.to_vec(),
             }),
         })
+    }
+
+    pub fn generate_sub_msg_direct(&self, addr: Addr, id: u64) -> SubMsg<Empty> {
+        SubMsg {
+            id,
+            reply_on: self.config.reply_on.clone(),
+            gas_limit: self.config.gas_limit,
+            msg: CosmosMsg::Wasm(wasm_execute(addr, &self.message, self.funds.to_vec()).unwrap()),
+        }
     }
 
     pub fn to_ibc_hooks_memo(&self, contract_addr: String, callback_addr: String) -> String {

--- a/packages/std/src/common/mod.rs
+++ b/packages/std/src/common/mod.rs
@@ -7,8 +7,8 @@ pub mod withdraw;
 
 use crate::error::ContractError;
 use cosmwasm_std::{
-    ensure, from_binary, to_binary, BankMsg, Binary, Coin, CosmosMsg, QuerierWrapper, SubMsg,
-    Uint128,
+    ensure, from_binary, has_coins, to_binary, BankMsg, Binary, Coin, CosmosMsg, QuerierWrapper,
+    SubMsg, Uint128,
 };
 use cw20::Cw20Coin;
 
@@ -103,9 +103,14 @@ pub fn merge_sub_msgs(msgs: Vec<SubMsg>) -> Vec<SubMsg> {
     for msg in msgs.into_iter() {
         match msg.msg {
             CosmosMsg::Bank(BankMsg::Send { to_address, amount }) => {
-                let current_coins = map.get_mut(&to_address);
+                let current_coins = map.get(&to_address);
                 match current_coins {
-                    Some(current_coins) => merge_coins(current_coins, amount),
+                    Some(current_coins) => {
+                        map.insert(
+                            to_address.to_owned(),
+                            merge_coins(current_coins.to_vec(), amount),
+                        );
+                    }
                     None => {
                         map.insert(to_address.to_owned(), amount);
                     }
@@ -134,25 +139,46 @@ pub fn merge_sub_msgs(msgs: Vec<SubMsg>) -> Vec<SubMsg> {
 ///                    same denom
 ///
 /// Returns nothing as it is done in place.
-pub fn merge_coins(coins: &mut Vec<Coin>, coins_to_add: Vec<Coin>) {
+pub fn merge_coins(coins: Vec<Coin>, coins_to_add: Vec<Coin>) -> Vec<Coin> {
+    let mut new_coins: Vec<Coin> = if !coins.is_empty() {
+        merge_coins(vec![], coins.to_vec())
+    } else {
+        vec![]
+    };
     // Not the most efficient algorithm (O(n * m)) but we don't expect to deal with very large arrays of Coin,
     // typically at most 2 denoms. Even in the future there are not that many Terra native coins
     // where this will be a problem.
-    for coin in coins.iter_mut() {
-        let same_denom_coin: Vec<&Coin> = coins_to_add
-            .iter()
-            .filter(|&c| c.denom == coin.denom)
-            .collect();
-        for same_coin in same_denom_coin.iter() {
-            // coin.amount = coin.amount.checked_add(same_coin.amount)?;
-            coin.amount += same_coin.amount;
+
+    for coin in coins_to_add.clone() {
+        let mut same_denom_coins = new_coins.iter_mut().filter(|c| c.denom == coin.denom);
+        if let Some(same_denom_coin) = same_denom_coins.next() {
+            same_denom_coin.amount += coin.amount
+        } else {
+            new_coins.push(coin);
         }
     }
-    for coin_to_add in coins_to_add.iter() {
-        if !coins.iter().any(|c| c.denom == coin_to_add.denom) {
-            coins.push(coin_to_add.clone());
-        }
+
+    new_coins
+}
+
+/// Checks if the required funds can be covered by merging the provided coins.
+///
+/// ## Arguments
+/// * `coins` - The vector of `Coin` structs representing the available coins
+/// * `required` - The vector of `Coin` structs representing the required funds
+///
+/// Returns true if the required funds can be covered by merging the available coins, false otherwise.
+pub fn has_coins_merged(coins: &[Coin], required: &[Coin]) -> bool {
+    let merged_coins = merge_coins(vec![], coins.to_vec());
+    let merged_required = merge_coins(vec![], required.to_vec());
+
+    for required_funds in merged_required {
+        if !has_coins(&merged_coins, &required_funds) {
+            return false;
+        };
     }
+
+    true
 }
 
 /// Deducts a given amount from a vector of `Coin` structs. Alters the given vector, does not return a new vector.
@@ -217,19 +243,20 @@ mod test {
 
     #[test]
     fn test_merge_coins() {
-        let mut coins = vec![coin(100, "uusd"), coin(100, "uluna")];
+        let coins = vec![coin(100, "uusd"), coin(100, "uluna")];
         let funds_to_add = vec![
             coin(25, "uluna"),
             coin(50, "uusd"),
             coin(100, "ucad"),
             coin(50, "uluna"),
             coin(100, "uluna"),
+            coin(100, "ucad"),
         ];
 
-        merge_coins(&mut coins, funds_to_add);
+        let res = merge_coins(coins, funds_to_add);
         assert_eq!(
-            vec![coin(150, "uusd"), coin(275, "uluna"), coin(100, "ucad")],
-            coins
+            vec![coin(150, "uusd"), coin(275, "uluna"), coin(200, "ucad")],
+            res
         );
     }
 
@@ -301,5 +328,28 @@ mod test {
         let e = deduct_funds(&mut funds, &coin(10, "uluna")).unwrap_err();
 
         assert_eq!(ContractError::InsufficientFunds {}, e);
+    }
+    #[test]
+    fn test_has_coins_merged() {
+        let available_coins: Vec<Coin> = vec![
+            coin(50, "uluna"),
+            coin(200, "uusd"),
+            coin(50, "ukrw"),
+            coin(25, "uluna"),
+            coin(25, "uluna"),
+        ];
+        let required_funds: Vec<Coin> = vec![
+            coin(50, "uluna"),
+            coin(100, "uusd"),
+            coin(50, "ukrw"),
+            coin(50, "uluna"),
+        ];
+
+        assert!(has_coins_merged(&available_coins, &required_funds));
+
+        let insufficient_funds: Vec<Coin> =
+            vec![coin(10, "uluna"), coin(100, "uusd"), coin(50, "ukrw")];
+
+        assert!(!has_coins_merged(&insufficient_funds, &required_funds));
     }
 }

--- a/packages/std/src/common/mod.rs
+++ b/packages/std/src/common/mod.rs
@@ -149,7 +149,7 @@ pub fn merge_coins(coins: Vec<Coin>, coins_to_add: Vec<Coin>) -> Vec<Coin> {
     // typically at most 2 denoms. Even in the future there are not that many Terra native coins
     // where this will be a problem.
 
-    for coin in coins_to_add.clone() {
+    for coin in coins_to_add {
         let mut same_denom_coins = new_coins.iter_mut().filter(|c| c.denom == coin.denom);
         if let Some(same_denom_coin) = same_denom_coins.next() {
             same_denom_coin.amount += coin.amount

--- a/packages/std/src/testing/mock_querier.rs
+++ b/packages/std/src/testing/mock_querier.rs
@@ -60,6 +60,8 @@ pub const MOCK_ACTION: &str = "action";
 pub const UNWHITELISTED_ADDRESS: &str = "unwhitelisted_address";
 pub const RATES_EXCLUDED_ADDRESS: &str = "rates_excluded_address";
 
+pub const MOCK_WALLET: &str = "mock_wallet";
+
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
 }
@@ -163,6 +165,11 @@ impl MockAndromedaQuerier {
             }
             // Defaults to code ID 1, returns 2 for `INVALID_CONTRACT` which is considered an invalid ADODB code id
             QueryRequest::Wasm(WasmQuery::ContractInfo { contract_addr }) => {
+                if contract_addr == MOCK_WALLET {
+                    return SystemResult::Ok(ContractResult::Err(
+                        "Not a valid contract".to_string(),
+                    ));
+                }
                 let mut resp = ContractInfoResponse::default();
                 resp.code_id = match contract_addr.as_str() {
                     MOCK_APP_CONTRACT => 3,
@@ -490,7 +497,7 @@ impl MockAndromedaQuerier {
                 } else if key == generic_contract_key {
                     SystemResult::Ok(ContractResult::Ok(to_binary("ADOType").unwrap()))
                 } else {
-                    SystemResult::Ok(ContractResult::Err("Invalid Key".to_string()))
+                    SystemResult::Ok(ContractResult::Ok(Binary::default()))
                 }
             } else {
                 SystemResult::Ok(ContractResult::Err("Invalid Key".to_string()))


### PR DESCRIPTION
# Motivation

Previously the Kernel had no method of determining if the recipient as a contract and if that contract was an ADO. These changes are to enable detection of messages to non-ADO contracts and strip any `AMPCtx` before sending the message directly. It also enables use of the `direct` field of an `AMPMsg`'s config. 

# Implementation

Upon receiving a local message the handler now first checks if the recipient address has a valid `ContractInfo` response, to determine if its a contract. Next it checks if the `AMPMsg` is configured to be direct, and then finally checks if the recipient address is not a valid ADO code id. If these checks are met then the message is generated as a direct sub message, otherwise (if it is a contract) it continues as before.

# Testing

Unit tests can be checked with:

```
cargo unit-test test_handle_local
```

Tests were written in `/contracts/os/andromeda-kernel/src/testing/test_handle`.
