### PR TITLE
Feature/staking state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "andromeda-validator-staking"
+version = "0.1.0"
+dependencies = [
+ "andromeda-finance",
+ "andromeda-std",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+]
+
+[[package]]
 name = "andromeda-vault"
 version = "0.2.0"
 dependencies = [

--- a/contracts/finance/andromeda-validator-staking/.cargo/config
+++ b/contracts/finance/andromeda-validator-staking/.cargo/config
@@ -1,0 +1,3 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+schema = "run --example schema"

--- a/contracts/finance/andromeda-validator-staking/.gitignore
+++ b/contracts/finance/andromeda-validator-staking/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "andromeda-validator-staking"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.65.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+testing = ["cw-multi-test"]
+
+[dependencies]
+cosmwasm-std = { workspace = true, features = ["staking"]  }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+
+andromeda-std = { workspace = true }
+andromeda-finance = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cw-multi-test = { workspace = true, optional = true }

--- a/contracts/finance/andromeda-validator-staking/examples/schema.rs
+++ b/contracts/finance/andromeda-validator-staking/examples/schema.rs
@@ -1,0 +1,8 @@
+use andromeda_finance::validator_staking::InstantiateMsg;
+use cosmwasm_schema::write_api;
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+    }
+}

--- a/contracts/finance/andromeda-validator-staking/schema/andromeda-validator-staking.json
+++ b/contracts/finance/andromeda-validator-staking/schema/andromeda-validator-staking.json
@@ -17,15 +17,6 @@
       "kernel_address": {
         "type": "string"
       },
-      "modules": {
-        "type": [
-          "array",
-          "null"
-        ],
-        "items": {
-          "$ref": "#/definitions/Module"
-        }
-      },
       "owner": {
         "type": [
           "string",
@@ -38,33 +29,6 @@
       "Addr": {
         "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
         "type": "string"
-      },
-      "AndrAddr": {
-        "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
-        "type": "string"
-      },
-      "Module": {
-        "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
-        "type": "object",
-        "required": [
-          "address",
-          "is_mutable"
-        ],
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/AndrAddr"
-          },
-          "is_mutable": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
       }
     }
   },

--- a/contracts/finance/andromeda-validator-staking/schema/andromeda-validator-staking.json
+++ b/contracts/finance/andromeda-validator-staking/schema/andromeda-validator-staking.json
@@ -1,0 +1,76 @@
+{
+  "contract_name": "andromeda-validator-staking",
+  "contract_version": "0.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "default_validator",
+      "kernel_address"
+    ],
+    "properties": {
+      "default_validator": {
+        "$ref": "#/definitions/Addr"
+      },
+      "kernel_address": {
+        "type": "string"
+      },
+      "modules": {
+        "type": [
+          "array",
+          "null"
+        ],
+        "items": {
+          "$ref": "#/definitions/Module"
+        }
+      },
+      "owner": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
+      "AndrAddr": {
+        "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+        "type": "string"
+      },
+      "Module": {
+        "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+        "type": "object",
+        "required": [
+          "address",
+          "is_mutable"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/definitions/AndrAddr"
+          },
+          "is_mutable": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "execute": null,
+  "query": null,
+  "migrate": null,
+  "sudo": null,
+  "responses": null
+}

--- a/contracts/finance/andromeda-validator-staking/schema/raw/instantiate.json
+++ b/contracts/finance/andromeda-validator-staking/schema/raw/instantiate.json
@@ -13,15 +13,6 @@
     "kernel_address": {
       "type": "string"
     },
-    "modules": {
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Module"
-      }
-    },
     "owner": {
       "type": [
         "string",
@@ -34,33 +25,6 @@
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
-    },
-    "AndrAddr": {
-      "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
-      "type": "string"
-    },
-    "Module": {
-      "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
-      "type": "object",
-      "required": [
-        "address",
-        "is_mutable"
-      ],
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/AndrAddr"
-        },
-        "is_mutable": {
-          "type": "boolean"
-        },
-        "name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "additionalProperties": false
     }
   }
 }

--- a/contracts/finance/andromeda-validator-staking/schema/raw/instantiate.json
+++ b/contracts/finance/andromeda-validator-staking/schema/raw/instantiate.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "default_validator",
+    "kernel_address"
+  ],
+  "properties": {
+    "default_validator": {
+      "$ref": "#/definitions/Addr"
+    },
+    "kernel_address": {
+      "type": "string"
+    },
+    "modules": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Module"
+      }
+    },
+    "owner": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "AndrAddr": {
+      "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+      "type": "string"
+    },
+    "Module": {
+      "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
+      "type": "object",
+      "required": [
+        "address",
+        "is_mutable"
+      ],
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/AndrAddr"
+        },
+        "is_mutable": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -1,0 +1,40 @@
+use crate::state::DEFAULT_VALIDATOR;
+use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, Response};
+use cw2::set_contract_version;
+
+use andromeda_finance::validator_staking::InstantiateMsg;
+
+use andromeda_std::{
+    ado_base::InstantiateMsg as BaseInstantiateMsg, ado_contract::ADOContract, error::ContractError,
+};
+
+const CONTRACT_NAME: &str = "crates.io:andromeda-validator-staking";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    msg.validate(&deps)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    DEFAULT_VALIDATOR.save(deps.storage, &msg.default_validator)?;
+
+    let inst_resp = ADOContract::default().instantiate(
+        deps.storage,
+        env,
+        deps.api,
+        info,
+        BaseInstantiateMsg {
+            ado_type: "validator-staking".to_string(),
+            ado_version: CONTRACT_VERSION.to_string(),
+            operators: None,
+            kernel_address: msg.kernel_address,
+            owner: msg.owner,
+        },
+    )?;
+    Ok(inst_resp)
+}

--- a/contracts/finance/andromeda-validator-staking/src/lib.rs
+++ b/contracts/finance/andromeda-validator-staking/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod contract;
+pub mod state;
+
+#[cfg(test)]
+mod testing;

--- a/contracts/finance/andromeda-validator-staking/src/state.rs
+++ b/contracts/finance/andromeda-validator-staking/src/state.rs
@@ -1,0 +1,4 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+pub const DEFAULT_VALIDATOR: Item<Addr> = Item::new("default_validator");

--- a/contracts/finance/andromeda-validator-staking/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/mock_querier.rs
@@ -1,0 +1,23 @@
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{Decimal, OwnedDeps, Validator};
+
+pub const VALID_VALIDATOR: &str = "valid_validator";
+
+pub fn mock_dependencies_custom() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    let valid_validator = Validator {
+        address: String::from(VALID_VALIDATOR),
+        commission: Decimal::percent(1),
+        max_commission: Decimal::percent(3),
+        max_change_rate: Decimal::percent(1),
+    };
+
+    let mut custom_querier: MockQuerier = MockQuerier::default();
+    custom_querier.update_staking("uandr", &[valid_validator], &[]);
+    let storage = MockStorage::default();
+    OwnedDeps {
+        storage,
+        api: MockApi::default(),
+        querier: custom_querier,
+        custom_query_type: std::marker::PhantomData,
+    }
+}

--- a/contracts/finance/andromeda-validator-staking/src/testing/mod.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/mod.rs
@@ -1,0 +1,2 @@
+mod mock_querier;
+mod tests;

--- a/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
@@ -18,7 +18,6 @@ fn init(deps: DepsMut, default_validator: Addr) -> Result<Response, ContractErro
         default_validator,
         owner: Some(OWNER.to_owned()),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
-        modules: None,
     };
 
     let info = mock_info("owner", &[]);

--- a/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
@@ -1,0 +1,39 @@
+use crate::{
+    contract::instantiate,
+    testing::mock_querier::{mock_dependencies_custom, VALID_VALIDATOR},
+};
+
+use andromeda_std::{error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT};
+use cosmwasm_std::{
+    testing::{mock_env, mock_info},
+    Addr, DepsMut, Response,
+};
+
+use andromeda_finance::validator_staking::InstantiateMsg;
+
+const OWNER: &str = "creator";
+
+fn init(deps: DepsMut, default_validator: Addr) -> Result<Response, ContractError> {
+    let msg = InstantiateMsg {
+        default_validator,
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        modules: None,
+    };
+
+    let info = mock_info("owner", &[]);
+    instantiate(deps, mock_env(), info, msg)
+}
+
+#[test]
+fn test_instantiate() {
+    let mut deps = mock_dependencies_custom();
+
+    let fake_validator = Addr::unchecked("fake_validator");
+    let res = init(deps.as_mut(), fake_validator);
+    assert_eq!(ContractError::InvalidValidator {}, res.unwrap_err());
+
+    let default_validator = Addr::unchecked(VALID_VALIDATOR);
+    let res = init(deps.as_mut(), default_validator).unwrap();
+    assert_eq!(0, res.messages.len());
+}

--- a/packages/andromeda-finance/Cargo.toml
+++ b/packages/andromeda-finance/Cargo.toml
@@ -12,7 +12,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, features= ["staking"] }
 cosmwasm-schema = { workspace = true }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 cw-utils = { workspace = true }

--- a/packages/andromeda-finance/src/lib.rs
+++ b/packages/andromeda-finance/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cross_chain_swap;
 pub mod rate_limiting_withdrawals;
 pub mod splitter;
 pub mod timelock;
+pub mod validator_staking;
 pub mod vesting;
 pub mod weighted_splitter;

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -1,0 +1,24 @@
+use andromeda_std::{andr_instantiate, andr_instantiate_modules, error::ContractError};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, DepsMut};
+
+#[andr_instantiate]
+#[andr_instantiate_modules]
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub default_validator: Addr,
+}
+
+impl InstantiateMsg {
+    pub fn validate(&self, deps: &DepsMut) -> Result<bool, ContractError> {
+        validate_validator(deps, &self.default_validator)
+    }
+}
+
+pub fn validate_validator(deps: &DepsMut, validator: &Addr) -> Result<bool, ContractError> {
+    let validator = deps.querier.query_validator(validator)?;
+    if validator.is_none() {
+        return Err(ContractError::InvalidValidator {});
+    }
+    Ok(true)
+}

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -1,9 +1,8 @@
-use andromeda_std::{andr_instantiate, andr_instantiate_modules, error::ContractError};
+use andromeda_std::{andr_instantiate, error::ContractError};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, DepsMut};
 
 #[andr_instantiate]
-#[andr_instantiate_modules]
 #[cw_serde]
 pub struct InstantiateMsg {
     pub default_validator: Addr,

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -10,11 +10,11 @@ pub struct InstantiateMsg {
 
 impl InstantiateMsg {
     pub fn validate(&self, deps: &DepsMut) -> Result<bool, ContractError> {
-        validate_validator(deps, &self.default_validator)
+        is_validator(deps, &self.default_validator)
     }
 }
 
-pub fn validate_validator(deps: &DepsMut, validator: &Addr) -> Result<bool, ContractError> {
+pub fn is_validator(deps: &DepsMut, validator: &Addr) -> Result<bool, ContractError> {
     let validator = deps.querier.query_validator(validator)?;
     if validator.is_none() {
         return Err(ContractError::InvalidValidator {});

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -41,6 +41,9 @@ pub enum ContractError {
     #[error("InvalidSender")]
     InvalidSender {},
 
+    #[error("InvalidValidator")]
+    InvalidValidator {},
+
     #[error("RewardTooLow")]
     RewardTooLow {},
 


### PR DESCRIPTION
# Motivation
Solved following issues to implement Staking ADO.
- https://github.com/andromedaprotocol/andromeda-core/issues/289
- https://github.com/andromedaprotocol/andromeda-core/issues/290
- https://github.com/andromedaprotocol/andromeda-core/issues/291

# Implementation
- Added `validator_staking` to `packages/andromeda/finance/src` with following content.
   - `InstantiateMsg`
   - `validate_validator` helper function that validates whether or not given validator address is valid validator
   - `validate` trait for  `InstantiateMsg` which is validating the message by calling `validate_validator`
- Added `andromeda-validator-staking` to `contracts/finance/andromeda-validator-staking`
   - `instantiate` entrypoint function is added which validate the msg and save default validator to the storage
   - `state` is containing only one item, `DEFAULT_VALIDATOR`
# Testing
- `instantiate` function is tested with both valid and invalid validator address in `contracts/finance/andromeda-validator-staking/src/testing/tests`

# Future work
Need to solve following issues to complete staking ado
- https://github.com/andromedaprotocol/andromeda-core/issues/292
- https://github.com/andromedaprotocol/andromeda-core/issues/293
- https://github.com/andromedaprotocol/andromeda-core/issues/294
- https://github.com/andromedaprotocol/andromeda-core/issues/295
- https://github.com/andromedaprotocol/andromeda-core/issues/296
