### PR TITLE
Feature/staking execute stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ version = "0.1.0"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
+ "andromeda-testing",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
@@ -1714,6 +1715,7 @@ dependencies = [
  "andromeda-splitter",
  "andromeda-std",
  "andromeda-testing",
+ "andromeda-validator-staking",
  "andromeda-vault",
  "andromeda-vfs",
  "cosmwasm-schema",

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -25,3 +25,4 @@ andromeda-finance = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }
+andromeda-testing = { workspace = true }

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -63,22 +63,15 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
-        QueryMsg::StakedTokens {
-            validator,
-            delegator,
-        } => encode_binary(&query_staked_tokens(deps, delegator, validator)?),
+        QueryMsg::StakedTokens { validator } => {
+            encode_binary(&query_staked_tokens(deps, env.contract.address, validator)?)
+        }
         _ => ADOContract::default().query(deps, env, msg),
     }
 }
 
 fn execute_stake(ctx: ExecuteContext, validator: Option<Addr>) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
-
-    // Ensure sender is the contract owner
-    ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {}
-    );
 
     // Ensure only one type of coin is received
     ensure!(

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -1,11 +1,17 @@
 use crate::state::DEFAULT_VALIDATOR;
-use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{
+    ensure, entry_point, Addr, Binary, Deps, DepsMut, Env, FullDelegation, MessageInfo, Response,
+    StakingMsg,
+};
 use cw2::set_contract_version;
 
-use andromeda_finance::validator_staking::InstantiateMsg;
+use andromeda_finance::validator_staking::{is_validator, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 use andromeda_std::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg, ado_contract::ADOContract, error::ContractError,
+    ado_base::InstantiateMsg as BaseInstantiateMsg,
+    ado_contract::ADOContract,
+    common::{context::ExecuteContext, encode_binary},
+    error::ContractError,
 };
 
 const CONTRACT_NAME: &str = "crates.io:andromeda-validator-staking";
@@ -37,4 +43,86 @@ pub fn instantiate(
         },
     )?;
     Ok(inst_resp)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    let ctx = ExecuteContext::new(deps, info, env);
+
+    match msg {
+        ExecuteMsg::Stake { validator } => execute_stake(ctx, validator),
+        _ => ADOContract::default().execute(ctx, msg),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+    match msg {
+        QueryMsg::StakedTokens {
+            validator,
+            delegator,
+        } => encode_binary(&query_staked_tokens(deps, delegator, validator)?),
+        _ => ADOContract::default().query(deps, env, msg),
+    }
+}
+
+fn execute_stake(ctx: ExecuteContext, validator: Option<Addr>) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, info, .. } = ctx;
+
+    // Ensure sender is the contract owner
+    ensure!(
+        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+        ContractError::Unauthorized {}
+    );
+
+    // Ensure only one type of coin is received
+    ensure!(
+        info.funds.len() == 1,
+        ContractError::ExceedsMaxAllowedCoins {}
+    );
+
+    let default_validator = DEFAULT_VALIDATOR.load(deps.storage)?;
+
+    // Use default validator if validator is not specified by stake msg
+    let validator = validator.unwrap_or(default_validator);
+
+    // Check if the validator is valid before staking
+    is_validator(&deps, &validator)?;
+
+    // Delegate funds to the validator
+
+    let funds = &info.funds[0];
+
+    let res = Response::new()
+        .add_message(StakingMsg::Delegate {
+            validator: validator.to_string(),
+            amount: funds.clone(),
+        })
+        .add_attribute("action", "validator-stake")
+        .add_attribute("from", info.sender)
+        .add_attribute("to", validator.to_string())
+        .add_attribute("amount", funds.amount);
+
+    Ok(res)
+}
+
+fn query_staked_tokens(
+    deps: Deps,
+    delegator: Addr,
+    validator: Option<Addr>,
+) -> Result<FullDelegation, ContractError> {
+    let default_validator = DEFAULT_VALIDATOR.load(deps.storage)?;
+
+    // Use default validator if validator is not specified
+    let validator = validator.unwrap_or(default_validator);
+
+    let Some(res) = deps.querier.query_delegation(delegator.to_string(), validator.to_string())? else {
+        return Err(ContractError::InvalidDelegation {});
+    };
+    Ok(res)
 }

--- a/contracts/finance/andromeda-validator-staking/src/lib.rs
+++ b/contracts/finance/andromeda-validator-staking/src/lib.rs
@@ -3,3 +3,6 @@ pub mod state;
 
 #[cfg(test)]
 mod testing;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+pub mod mock;

--- a/contracts/finance/andromeda-validator-staking/src/mock.rs
+++ b/contracts/finance/andromeda-validator-staking/src/mock.rs
@@ -23,13 +23,8 @@ impl MockValidatorStaking {
         self.execute(app, &msg, sender, &funds)
     }
 
-    pub fn query_staked_tokens(
-        &self,
-        app: &App,
-        delegator: Addr,
-        validator: Option<Addr>,
-    ) -> Delegation {
-        let msg = mock_get_staked_tokens(delegator, validator);
+    pub fn query_staked_tokens(&self, app: &App, validator: Option<Addr>) -> Delegation {
+        let msg = mock_get_staked_tokens(validator);
         self.query(app, msg)
     }
 }
@@ -55,9 +50,6 @@ pub fn mock_execute_stake(validator: Option<Addr>) -> ExecuteMsg {
     ExecuteMsg::Stake { validator }
 }
 
-pub fn mock_get_staked_tokens(delegator: Addr, validator: Option<Addr>) -> QueryMsg {
-    QueryMsg::StakedTokens {
-        delegator,
-        validator,
-    }
+pub fn mock_get_staked_tokens(validator: Option<Addr>) -> QueryMsg {
+    QueryMsg::StakedTokens { validator }
 }

--- a/contracts/finance/andromeda-validator-staking/src/mock.rs
+++ b/contracts/finance/andromeda-validator-staking/src/mock.rs
@@ -1,0 +1,63 @@
+use andromeda_finance::validator_staking::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::{Addr, Coin, Delegation, Empty};
+
+use crate::contract::{execute, instantiate, query};
+use andromeda_testing::{
+    mock_ado,
+    mock_contract::{ExecuteResult, MockADO, MockContract},
+};
+use cw_multi_test::{App, Contract, ContractWrapper};
+
+pub struct MockValidatorStaking(Addr);
+mock_ado!(MockValidatorStaking, ExecuteMsg, QueryMsg);
+
+impl MockValidatorStaking {
+    pub fn execute_stake(
+        &self,
+        app: &mut App,
+        sender: Addr,
+        validator: Option<Addr>,
+        funds: Vec<Coin>,
+    ) -> ExecuteResult {
+        let msg = mock_execute_stake(validator);
+        self.execute(app, &msg, sender, &funds)
+    }
+
+    pub fn query_staked_tokens(
+        &self,
+        app: &App,
+        delegator: Addr,
+        validator: Option<Addr>,
+    ) -> Delegation {
+        let msg = mock_get_staked_tokens(delegator, validator);
+        self.query(app, msg)
+    }
+}
+
+pub fn mock_andromeda_validator_staking() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new_with_empty(execute, instantiate, query);
+    Box::new(contract)
+}
+
+pub fn mock_validator_staking_instantiate_msg(
+    default_validator: Addr,
+    owner: Option<String>,
+    kernel_address: String,
+) -> InstantiateMsg {
+    InstantiateMsg {
+        default_validator,
+        owner,
+        kernel_address,
+    }
+}
+
+pub fn mock_execute_stake(validator: Option<Addr>) -> ExecuteMsg {
+    ExecuteMsg::Stake { validator }
+}
+
+pub fn mock_get_staked_tokens(delegator: Addr, validator: Option<Addr>) -> QueryMsg {
+    QueryMsg::StakedTokens {
+        delegator,
+        validator,
+    }
+}

--- a/contracts/finance/andromeda-validator-staking/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/mock_querier.rs
@@ -1,9 +1,17 @@
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{Decimal, OwnedDeps, Validator};
 
+pub const DEFAULT_VALIDATOR: &str = "default_validator";
 pub const VALID_VALIDATOR: &str = "valid_validator";
 
 pub fn mock_dependencies_custom() -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    let default_validator = Validator {
+        address: String::from(DEFAULT_VALIDATOR),
+        commission: Decimal::percent(1),
+        max_commission: Decimal::percent(3),
+        max_change_rate: Decimal::percent(1),
+    };
+
     let valid_validator = Validator {
         address: String::from(VALID_VALIDATOR),
         commission: Decimal::percent(1),
@@ -12,7 +20,7 @@ pub fn mock_dependencies_custom() -> OwnedDeps<MockStorage, MockApi, MockQuerier
     };
 
     let mut custom_querier: MockQuerier = MockQuerier::default();
-    custom_querier.update_staking("uandr", &[valid_validator], &[]);
+    custom_querier.update_staking("uandr", &[default_validator, valid_validator], &[]);
     let storage = MockStorage::default();
     OwnedDeps {
         storage,

--- a/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
@@ -1,16 +1,16 @@
 use crate::{
-    contract::{instantiate, execute},
-    testing::mock_querier::{mock_dependencies_custom, VALID_VALIDATOR, DEFAULT_VALIDATOR},
+    contract::{execute, instantiate},
+    testing::mock_querier::{mock_dependencies_custom, DEFAULT_VALIDATOR, VALID_VALIDATOR},
 };
 
 use andromeda_std::{error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT};
 use cosmwasm_std::{
+    coin,
     testing::{mock_env, mock_info},
-    Addr, DepsMut, Response,
-    coin, StakingMsg,
+    Addr, DepsMut, Response, StakingMsg,
 };
 
-use andromeda_finance::validator_staking::{InstantiateMsg, ExecuteMsg};
+use andromeda_finance::validator_staking::{ExecuteMsg, InstantiateMsg};
 
 const OWNER: &str = "creator";
 
@@ -44,13 +44,8 @@ fn test_stake_with_invalid_funds() {
     let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
     init(deps.as_mut(), default_validator).unwrap();
 
-    let msg = ExecuteMsg::Stake {
-        validator: None
-    };
-    let info = mock_info("owner", &[
-        coin(100, "uandr"),
-        coin(100, "usdc"),
-    ]);
+    let msg = ExecuteMsg::Stake { validator: None };
+    let info = mock_info("owner", &[coin(100, "uandr"), coin(100, "usdc")]);
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 
@@ -63,12 +58,8 @@ fn test_stake_with_default_validator() {
     let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
     init(deps.as_mut(), default_validator).unwrap();
 
-    let msg = ExecuteMsg::Stake {
-        validator: None
-    };
-    let info = mock_info("owner", &[
-        coin(100, "uandr")
-    ]);
+    let msg = ExecuteMsg::Stake { validator: None };
+    let info = mock_info("owner", &[coin(100, "uandr")]);
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
 
@@ -93,11 +84,9 @@ fn test_stake_with_validator() {
     init(deps.as_mut(), default_validator).unwrap();
 
     let msg = ExecuteMsg::Stake {
-        validator: Some(valid_validator)
+        validator: Some(valid_validator),
     };
-    let info = mock_info("owner", &[
-        coin(100, "uandr")
-    ]);
+    let info = mock_info("owner", &[coin(100, "uandr")]);
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
 
@@ -122,11 +111,9 @@ fn test_stake_with_invalid_validator() {
     init(deps.as_mut(), default_validator).unwrap();
 
     let msg = ExecuteMsg::Stake {
-        validator: Some(fake_validator)
+        validator: Some(fake_validator),
     };
-    let info = mock_info("owner", &[
-        coin(100, "uandr"),
-    ]);
+    let info = mock_info("owner", &[coin(100, "uandr")]);
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
 

--- a/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
@@ -1,15 +1,16 @@
 use crate::{
-    contract::instantiate,
-    testing::mock_querier::{mock_dependencies_custom, VALID_VALIDATOR},
+    contract::{instantiate, execute},
+    testing::mock_querier::{mock_dependencies_custom, VALID_VALIDATOR, DEFAULT_VALIDATOR},
 };
 
 use andromeda_std::{error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT};
 use cosmwasm_std::{
     testing::{mock_env, mock_info},
     Addr, DepsMut, Response,
+    coin, StakingMsg,
 };
 
-use andromeda_finance::validator_staking::InstantiateMsg;
+use andromeda_finance::validator_staking::{InstantiateMsg, ExecuteMsg};
 
 const OWNER: &str = "creator";
 
@@ -32,7 +33,102 @@ fn test_instantiate() {
     let res = init(deps.as_mut(), fake_validator);
     assert_eq!(ContractError::InvalidValidator {}, res.unwrap_err());
 
-    let default_validator = Addr::unchecked(VALID_VALIDATOR);
+    let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
     let res = init(deps.as_mut(), default_validator).unwrap();
     assert_eq!(0, res.messages.len());
+}
+
+#[test]
+fn test_stake_with_invalid_funds() {
+    let mut deps = mock_dependencies_custom();
+    let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
+    init(deps.as_mut(), default_validator).unwrap();
+
+    let msg = ExecuteMsg::Stake {
+        validator: None
+    };
+    let info = mock_info("owner", &[
+        coin(100, "uandr"),
+        coin(100, "usdc"),
+    ]);
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+
+    assert_eq!(res, ContractError::ExceedsMaxAllowedCoins {});
+}
+
+#[test]
+fn test_stake_with_default_validator() {
+    let mut deps = mock_dependencies_custom();
+    let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
+    init(deps.as_mut(), default_validator).unwrap();
+
+    let msg = ExecuteMsg::Stake {
+        validator: None
+    };
+    let info = mock_info("owner", &[
+        coin(100, "uandr")
+    ]);
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    let expected_res: Response = Response::new()
+        .add_message(StakingMsg::Delegate {
+            validator: DEFAULT_VALIDATOR.to_string(),
+            amount: coin(100, "uandr"),
+        })
+        .add_attribute("action", "validator-stake")
+        .add_attribute("from", "owner".to_string())
+        .add_attribute("to", DEFAULT_VALIDATOR.to_string())
+        .add_attribute("amount", "100".to_string());
+
+    assert_eq!(res.unwrap(), expected_res);
+}
+
+#[test]
+fn test_stake_with_validator() {
+    let mut deps = mock_dependencies_custom();
+    let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
+    let valid_validator = Addr::unchecked(VALID_VALIDATOR);
+    init(deps.as_mut(), default_validator).unwrap();
+
+    let msg = ExecuteMsg::Stake {
+        validator: Some(valid_validator)
+    };
+    let info = mock_info("owner", &[
+        coin(100, "uandr")
+    ]);
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    let expected_res: Response = Response::new()
+        .add_message(StakingMsg::Delegate {
+            validator: VALID_VALIDATOR.to_string(),
+            amount: coin(100, "uandr"),
+        })
+        .add_attribute("action", "validator-stake")
+        .add_attribute("from", "owner".to_string())
+        .add_attribute("to", VALID_VALIDATOR.to_string())
+        .add_attribute("amount", "100".to_string());
+
+    assert_eq!(res.unwrap(), expected_res);
+}
+
+#[test]
+fn test_stake_with_invalid_validator() {
+    let mut deps = mock_dependencies_custom();
+    let fake_validator = Addr::unchecked("fake_validator");
+    let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
+    init(deps.as_mut(), default_validator).unwrap();
+
+    let msg = ExecuteMsg::Stake {
+        validator: Some(fake_validator)
+    };
+    let info = mock_info("owner", &[
+        coin(100, "uandr"),
+    ]);
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+
+    assert_eq!(res, ContractError::InvalidValidator {});
 }

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -1,11 +1,28 @@
-use andromeda_std::{andr_instantiate, error::ContractError};
-use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, DepsMut};
+use andromeda_std::{andr_exec, andr_instantiate, andr_query, error::ContractError};
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{Addr, DepsMut, FullDelegation};
 
 #[andr_instantiate]
 #[cw_serde]
 pub struct InstantiateMsg {
     pub default_validator: Addr,
+}
+
+#[andr_exec]
+#[cw_serde]
+pub enum ExecuteMsg {
+    Stake { validator: Option<Addr> },
+}
+
+#[andr_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(Option<FullDelegation>)]
+    StakedTokens {
+        delegator: Addr,
+        validator: Option<Addr>,
+    },
 }
 
 impl InstantiateMsg {

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -19,10 +19,7 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(Option<FullDelegation>)]
-    StakedTokens {
-        delegator: Addr,
-        validator: Option<Addr>,
-    },
+    StakedTokens { validator: Option<Addr> },
 }
 
 impl InstantiateMsg {

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -44,6 +44,9 @@ pub enum ContractError {
     #[error("InvalidValidator")]
     InvalidValidator {},
 
+    #[error("InvalidDelegation")]
+    InvalidDelegation {},
+
     #[error("RewardTooLow")]
     RewardTooLow {},
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -63,6 +63,11 @@ andromeda-splitter = { path = "../contracts/finance/andromeda-splitter", feature
     "testing",
 ] }
 
+andromeda-validator-staking = { path = "../contracts/finance/andromeda-validator-staking", features = [
+    "testing",
+] }
+
+
 # Data Storage
 andromeda-data-storage = { workspace = true }
 andromeda-primitive = { path = "../contracts/data-storage/andromeda-primitive", features = [
@@ -86,7 +91,7 @@ andromeda-vfs = { path = "../contracts/os/andromeda-vfs", features = [
 andromeda-testing = { workspace = true }
 
 #Cosmwasm Crates
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, features = ["staking"] }
 cosmwasm-schema = { workspace = true }
 cw721-base = { workspace = true }
 cw721 = { workspace = true }
@@ -116,6 +121,9 @@ name = "marketplace_app"
 
 [[test]]
 name = "splitter"
+
+[[test]]
+name = "validator_staking"
 
 # [[test]]
 # name = "cw20_staking_app"

--- a/tests-integration/tests/mod.rs
+++ b/tests-integration/tests/mod.rs
@@ -9,3 +9,6 @@ mod kernel;
 
 #[cfg(test)]
 mod crowdfund_app;
+
+#[cfg(test)]
+mod validator_staking;

--- a/tests-integration/tests/validator_staking.rs
+++ b/tests-integration/tests/validator_staking.rs
@@ -1,0 +1,100 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use andromeda_app::app::AppComponent;
+use andromeda_app_contract::mock::{mock_andromeda_app, MockApp};
+
+use andromeda_validator_staking::mock::{
+    mock_andromeda_validator_staking, mock_validator_staking_instantiate_msg, MockValidatorStaking,
+};
+
+use andromeda_testing::{mock::MockAndromeda, MockContract};
+use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal, Timestamp, Validator};
+use cw_multi_test::App;
+
+fn mock_app() -> App {
+    App::new(|router, api, storage| {
+        router
+            .bank
+            .init_balance(
+                storage,
+                &Addr::unchecked("owner"),
+                [coin(1000, "TOKEN")].to_vec(),
+            )
+            .unwrap();
+
+        router
+            .staking
+            .add_validator(
+                api,
+                storage,
+                &BlockInfo {
+                    height: 0,
+                    time: Timestamp::default(),
+                    chain_id: "my-testnet".to_string(),
+                },
+                Validator {
+                    address: "validator_1".to_string(),
+                    commission: Decimal::zero(),
+                    max_commission: Decimal::percent(20),
+                    max_change_rate: Decimal::percent(1),
+                },
+            )
+            .unwrap();
+    })
+}
+
+fn mock_andromeda(app: &mut App, admin_address: Addr) -> MockAndromeda {
+    MockAndromeda::new(app, &admin_address)
+}
+
+#[test]
+fn test_validator_stake() {
+    let owner = Addr::unchecked("owner");
+    let validator_1 = Addr::unchecked("validator_1");
+
+    let mut router = mock_app();
+
+    let andr = mock_andromeda(&mut router, owner.clone());
+
+    andr.store_ado(&mut router, mock_andromeda_app(), "app");
+    andr.store_ado(
+        &mut router,
+        mock_andromeda_validator_staking(),
+        "validator-staking",
+    );
+    let validator_staking_init_msg =
+        mock_validator_staking_instantiate_msg(validator_1, None, andr.kernel.addr().to_string());
+
+    let validator_staking_component = AppComponent::new(
+        "1".to_string(),
+        "validator-staking".to_string(),
+        to_json_binary(&validator_staking_init_msg).unwrap(),
+    );
+
+    let app_components = vec![validator_staking_component.clone()];
+    let app = MockApp::instantiate(
+        andr.get_code_id(&mut router, "app"),
+        owner.clone(),
+        &mut router,
+        "Validator Staking App",
+        app_components,
+        andr.kernel.addr(),
+        Some(owner.to_string()),
+    );
+
+    let validator_staking: MockValidatorStaking =
+        app.query_ado_by_component_name(&router, validator_staking_component.name);
+
+    let funds = vec![coin(1000, "TOKEN")];
+    app.execute_claim_ownership(&mut router, owner.clone(), Some("1".to_string()))
+        .unwrap();
+    validator_staking
+        .execute_stake(&mut router, owner.clone(), None, funds)
+        .unwrap();
+
+    let stake_info = validator_staking.query_staked_tokens(&router, owner, None);
+    println!(
+        "==================================={:?}===================================",
+        stake_info
+    );
+}

--- a/tests-integration/tests/validator_staking.rs
+++ b/tests-integration/tests/validator_staking.rs
@@ -113,7 +113,7 @@ fn test_validator_stake() {
 
     let funds = vec![coin(1000, "TOKEN")];
     validator_staking
-        .execute_stake(&mut router, owner.clone(), None, funds)
+        .execute_stake(&mut router, owner, None, funds)
         .unwrap();
 
     let stake_info = validator_staking.query_staked_tokens(&router, None);


### PR DESCRIPTION
# Motivation
Solved following issues to implement Staking ADO.

- https://github.com/andromedaprotocol/andromeda-core/issues/292
- https://github.com/andromedaprotocol/andromeda-core/issues/293
- https://github.com/andromedaprotocol/andromeda-core/issues/294

# Implementation
- Added `ExecuteMsg`  and `QueryMsg` to `packages/andromeda-finance/src/validator_staking.rs`
- Added `execute` handler to `contracts/finance/andromeda-validator-staking/src/contract.rs`
   - In case `validator` is not specified by `ExecuteMsg::Stake` msg, it is set as `default_validator`
   - Before staking, the validator is validated after identifying which validator to use for security purpose

# Testing
- Added unit tests in `contracts/finance/andromeda-validator-staking/src/testing/tests`
- Integration test is added to `tests-integration/tests/validator_staking.rs`

# Future work
Need to solve following issues to complete staking ado
- https://github.com/andromedaprotocol/andromeda-core/issues/295
- https://github.com/andromedaprotocol/andromeda-core/issues/296