### PR TITLE
[1.0.rc-1] os ownership messages, lockdrop fix, and marketplace query

### DIFF
--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -137,7 +137,7 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
         ExecuteMsg::EnableClaims {} => execute_enable_claims(ctx),
         ExecuteMsg::ClaimRewards {} => execute_claim_rewards(ctx),
         // ExecuteMsg::WithdrawProceeds { recipient } => execute_withdraw_proceeds(ctx, recipient),
-        _ => handle_execute(ctx, msg),
+        _ => ADOContract::default().execute(ctx, msg),
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
@@ -59,6 +59,8 @@ impl From<TokenSaleState> for SaleStateResponse {
             sale_id: token_sale_state.sale_id,
             status: token_sale_state.status,
             price: token_sale_state.price,
+            start_time: token_sale_state.start_time,
+            end_time: token_sale_state.end_time,
         }
     }
 }

--- a/contracts/os/andromeda-adodb/src/contract.rs
+++ b/contracts/os/andromeda-adodb/src/contract.rs
@@ -89,6 +89,10 @@ pub fn execute(
             ado_type,
             publisher,
         } => execute::update_publisher(deps, info, &ADOVersion::from_string(ado_type), publisher),
+        // Base message
+        ExecuteMsg::Ownership(ownership_message) => {
+            ADOContract::default().execute_ownership(deps, env, info, ownership_message)
+        }
     }
 }
 

--- a/contracts/os/andromeda-economics/src/contract.rs
+++ b/contracts/os/andromeda-economics/src/contract.rs
@@ -79,6 +79,10 @@ pub fn execute(
             execute::withdraw_cw20(deps, info, amount, asset)
         }
         ExecuteMsg::Receive(cw20msg) => cw20_receive(deps, env, info, cw20msg),
+        // Base message
+        ExecuteMsg::Ownership(ownership_message) => {
+            ADOContract::default().execute_ownership(deps, env, info, ownership_message)
+        }
     }
 }
 

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -109,6 +109,13 @@ pub fn execute(
         ),
         ExecuteMsg::Recover {} => execute::recover(execute_env),
         ExecuteMsg::Internal(msg) => execute::internal(execute_env, msg),
+        // Base message
+        ExecuteMsg::Ownership(ownership_message) => ADOContract::default().execute_ownership(
+            execute_env.deps,
+            execute_env.env,
+            execute_env.info,
+            ownership_message,
+        ),
     }
 }
 

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -83,6 +83,13 @@ pub fn execute(
         ExecuteMsg::RegisterUserCrossChain { chain, address } => {
             execute::register_user_cross_chain(execute_env, chain, address)
         }
+        // Base message
+        ExecuteMsg::Ownership(ownership_message) => ADOContract::default().execute_ownership(
+            execute_env.deps,
+            execute_env.env,
+            execute_env.info,
+            ownership_message,
+        ),
     }
 }
 

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -1,7 +1,7 @@
 use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
-use cw721::Cw721ReceiveMsg;
+use cw721::{Cw721ReceiveMsg, Expiration};
 use std::fmt::{Display, Formatter, Result};
 
 #[andr_instantiate]
@@ -103,6 +103,8 @@ pub struct SaleStateResponse {
     pub coin_denom: String,
     pub price: Uint128,
     pub status: Status,
+    pub start_time: Expiration,
+    pub end_time: Expiration,
 }
 
 #[cw_serde]

--- a/packages/std/src/os/adodb.rs
+++ b/packages/std/src/os/adodb.rs
@@ -8,8 +8,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ado_base::{
-        ado_type::TypeResponse, kernel_address::KernelAddressResponse,
-        ownership::ContractOwnerResponse, version::VersionResponse,
+        ado_type::TypeResponse,
+        kernel_address::KernelAddressResponse,
+        ownership::{ContractOwnerResponse, OwnershipMessage},
+        version::VersionResponse,
     },
     error::ContractError,
 };
@@ -45,6 +47,8 @@ pub enum ExecuteMsg {
         ado_type: String,
         publisher: String,
     },
+    // Base message
+    Ownership(OwnershipMessage),
 }
 
 #[cw_serde]

--- a/packages/std/src/os/economics.rs
+++ b/packages/std/src/os/economics.rs
@@ -4,8 +4,10 @@ use cw20::Cw20ReceiveMsg;
 
 use crate::{
     ado_base::{
-        ado_type::TypeResponse, kernel_address::KernelAddressResponse,
-        ownership::ContractOwnerResponse, version::VersionResponse,
+        ado_type::TypeResponse,
+        kernel_address::KernelAddressResponse,
+        ownership::{ContractOwnerResponse, OwnershipMessage},
+        version::VersionResponse,
     },
     amp::AndrAddr,
 };
@@ -51,6 +53,8 @@ pub enum ExecuteMsg {
         asset: String,
     },
     Receive(Cw20ReceiveMsg),
+    // Base message
+    Ownership(OwnershipMessage),
 }
 
 #[cw_serde]

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -1,5 +1,6 @@
 use crate::ado_base::ado_type::TypeResponse;
 use crate::ado_base::ownership::ContractOwnerResponse;
+use crate::ado_base::ownership::OwnershipMessage;
 use crate::ado_base::version::VersionResponse;
 use crate::amp::messages::AMPMsg;
 use crate::amp::messages::AMPPkt;
@@ -65,6 +66,8 @@ pub enum ExecuteMsg {
     Recover {},
     // Only accessible to key contracts
     Internal(InternalMsg),
+    // Base message
+    Ownership(OwnershipMessage),
 }
 
 #[cw_serde]

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -1,7 +1,9 @@
 use crate::{
     ado_base::{
-        ado_type::TypeResponse, kernel_address::KernelAddressResponse,
-        ownership::ContractOwnerResponse, version::VersionResponse,
+        ado_type::TypeResponse,
+        kernel_address::KernelAddressResponse,
+        ownership::{ContractOwnerResponse, OwnershipMessage},
+        version::VersionResponse,
     },
     amp::AndrAddr,
     error::ContractError,
@@ -119,6 +121,8 @@ pub enum ExecuteMsg {
         chain: String,
         address: String,
     },
+    // Base message
+    Ownership(OwnershipMessage),
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation
This resolves issues #315 #316 and #319 

# Implementation
#315 : Added `Ownership(OwnershipMessage)` to each of the OS's `QueryMsg`, used `ADOContract::default().execute_ownership(deps, env, info, ownership_message)` in the contracts

#316: Replaced the line in the Lockdrop contract that was causing an infinite loop as stated in the issue.

#319: Added `start_time` and `end_time` to the `SaleStateResponse` struct in the Marketplace ADO

# Testing
No tests were created or adjusted.

# Notes
We could also include the actual duration alongside `start_time` and `end_time` if that's desirable.
