### PR TITLE
[1.0.rc-1] Crowdfund End Sale

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -570,13 +570,14 @@ fn execute_end_sale(ctx: ExecuteContext, limit: Option<u32>) -> Result<Response,
     let number_of_tokens_available = NUMBER_OF_TOKENS_AVAILABLE.load(deps.storage)?;
     // In case the minimum sold tokens threshold is met, it has to be the owner who calls the function
     let contract = ADOContract::default();
-    let minimum_and_owner = state.min_tokens_sold <= state.amount_sold
-        && contract.is_contract_owner(deps.storage, info.sender.as_str())?;
+    let has_minimum_sold = state.min_tokens_sold <= state.amount_sold;
+    let is_owner = contract.is_contract_owner(deps.storage, info.sender.as_str())?;
+
     ensure!(
         // If all tokens have been sold the sale can be ended too.
         state.expiration.is_expired(&env.block)
             || number_of_tokens_available.is_zero()
-            || minimum_and_owner,
+            || (has_minimum_sold && is_owner),
         ContractError::SaleNotEnded {}
     );
     if state.amount_sold < state.min_tokens_sold {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -1698,7 +1698,7 @@ fn test_end_sale_some_tokens_sold_threshold_not_met() {
 
     let info = mock_info("owner", &[]);
     // Minimum sold is 2, actual sold is 0
-    let err = execute(deps.as_mut(), mock_env(), info, msg.clone()).unwrap_err();
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
     assert_eq!(err, ContractError::SaleNotEnded {});
 }
 


### PR DESCRIPTION
# Motivation
Reaching the minimum tokens sold threshold wasn't considered in allowing the ending of a sale in the Crowdfund ADO.

# Implementation
Alongside checking the expiration and if the number of tokens available is zero, I added a check to see if the minimum tokens sold threshold is met AND that the contract owner is the one calling the function.
The function doesn't check who's calling it, and that wasn't a problem while we only checked for expiration or zero tokens. But with minimum tokens sold, there's a real decision to be made i.e: the sale could continue and still sell more tokens.
Only the owner should be able to make that decision, otherwise if one of the two original conditions are met, anyone can end the sale.

# Testing
Added two unit tests that check for authorization, unmet thresholds, and working conditions.

# Notes
We could create new `ContractErrors` to be more precise in the owner-minimum tokens sold situation.
