### PR TITLE
[1.0.rc-1] Cw721 extension removal

### DIFF
--- a/contracts/data-storage/andromeda-primitive/src/contract.rs
+++ b/contracts/data-storage/andromeda-primitive/src/contract.rs
@@ -38,7 +38,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "primitive".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/ecosystem/andromeda-vault/src/contract.rs
+++ b/contracts/ecosystem/andromeda-vault/src/contract.rs
@@ -44,7 +44,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "vault".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             owner: msg.owner,
             kernel_address: msg.kernel_address,
         },

--- a/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
+++ b/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
@@ -46,7 +46,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "andromeda-cross-chain-swap".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -77,7 +77,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "rate-limiting-withdrawals".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -77,7 +77,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "splitter".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/finance/andromeda-timelock/src/contract.rs
+++ b/contracts/finance/andromeda-timelock/src/contract.rs
@@ -41,7 +41,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "timelock".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -56,7 +56,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "vesting".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -77,7 +77,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "weighted-distribution-splitter".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -55,7 +55,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "cw20-exchange".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -173,7 +173,6 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
         },
         ExecuteMsg::UnstakeTokens { amount } => execute_unstake_tokens(ctx, amount),
         ExecuteMsg::ClaimRewards {} => execute_claim_rewards(ctx),
-        // _ => ADOContract::default().execute(ctx, msg),
         _ => ADOContract::default().execute(ctx, msg),
     }
 }

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -100,7 +100,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "cw20-staking".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -82,7 +82,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "lockdrop".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
@@ -60,7 +60,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "merkle-airdrop".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -37,7 +37,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "address-list".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -45,7 +45,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "rates".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -51,7 +51,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "auction".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -64,7 +64,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "crowdfund".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -67,7 +67,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "cw721".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -51,7 +51,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "marketplace".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/os/andromeda-adodb/src/contract.rs
+++ b/contracts/os/andromeda-adodb/src/contract.rs
@@ -31,7 +31,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "adodb".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/os/andromeda-economics/src/contract.rs
+++ b/contracts/os/andromeda-economics/src/contract.rs
@@ -36,7 +36,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "economics".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -40,7 +40,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "kernel".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: env.contract.address.to_string(),
             owner: msg.owner,
         },

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -31,7 +31,6 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: "vfs".to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-
             kernel_address: msg.kernel_address,
             owner: msg.owner,
         },

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -286,7 +286,6 @@ impl From<QueryMsg> for Cw721QueryMsg<QueryMsg> {
             QueryMsg::AllTokens { start_after, limit } => {
                 Cw721QueryMsg::AllTokens { start_after, limit }
             }
-            QueryMsg::Extension { msg } => Cw721QueryMsg::Extension { msg: *msg },
             QueryMsg::Minter {} => Cw721QueryMsg::Minter {},
             QueryMsg::Approval {
                 token_id,

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -224,8 +224,6 @@ pub enum QueryMsg {
     /// The current config of the contract
     #[returns(cw721::ContractInfoResponse)]
     ContractInfo {},
-    #[returns(TokenExtension)]
-    Extension { msg: Box<QueryMsg> },
     #[returns(cw721_base::MinterResponse)]
     Minter {},
     #[returns(cw721::ApprovalResponse)]

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -84,10 +84,7 @@ pub enum ExecuteMsg {
         extension: TokenExtension,
     },
     /// Transfers ownership of a token
-    TransferNft {
-        recipient: String,
-        token_id: String,
-    },
+    TransferNft { recipient: String, token_id: String },
     /// Sends a token to another contract
     SendNft {
         contract: String,
@@ -102,39 +99,25 @@ pub enum ExecuteMsg {
         expires: Option<Expiration>,
     },
     /// Remove previously granted Approval
-    Revoke {
-        spender: String,
-        token_id: String,
-    },
+    Revoke { spender: String, token_id: String },
     /// Approves an address for all tokens owned by the sender
     ApproveAll {
         operator: String,
         expires: Option<Expiration>,
     },
     /// Remove previously granted ApproveAll permission
-    RevokeAll {
-        operator: String,
-    },
+    RevokeAll { operator: String },
     /// Burns a token, removing all data related to it. The ID of the token is still reserved.
-    Burn {
-        token_id: String,
-    },
+    Burn { token_id: String },
     /// Archives a token, causing it to be immutable but readable
-    Archive {
-        token_id: String,
-    },
+    Archive { token_id: String },
     /// Assigns a `TransferAgreement` for a token
     TransferAgreement {
         token_id: String,
         agreement: Option<TransferAgreement>,
     },
     /// Mint multiple tokens at a time
-    BatchMint {
-        tokens: Vec<MintMsg>,
-    },
-    Extension {
-        msg: Box<ExecuteMsg>,
-    },
+    BatchMint { tokens: Vec<MintMsg> },
 }
 
 impl From<ExecuteMsg> for Cw721ExecuteMsg<TokenExtension, ExecuteMsg> {
@@ -184,7 +167,6 @@ impl From<ExecuteMsg> for Cw721ExecuteMsg<TokenExtension, ExecuteMsg> {
                 owner,
             },
             ExecuteMsg::Burn { token_id } => Cw721ExecuteMsg::Burn { token_id },
-            ExecuteMsg::Extension { msg } => Cw721ExecuteMsg::Extension { msg: *msg },
             _ => panic!("Unsupported message"),
         }
     }


### PR DESCRIPTION
# Motivation
Closes: #325  

# Implementation
Removed `ExecuteMsg::Extension` and `QueryMsg::Extension` from the Cw721 ADO

# Testing
No tests were made nor adjusted.