### PR TITLE
[1.0.rc-1] Query App Contract for Non-OS ADOs

### DIFF
--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -167,6 +167,8 @@ pub fn andr_query(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                 Type {},
                 #[returns(andromeda_std::ado_base::kernel_address::KernelAddressResponse)]
                 KernelAddress {},
+                #[returns(andromeda_std::ado_base::app_contract::AppContractResponse)]
+                AppContract {},
                 #[returns(andromeda_std::ado_base::ownership::PublisherResponse)]
                 OriginalPublisher {},
                 #[returns(andromeda_std::ado_base::block_height::BlockHeightResponse)]

--- a/packages/std/src/ado_base/app_contract.rs
+++ b/packages/std/src/ado_base/app_contract.rs
@@ -1,0 +1,7 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Addr;
+
+#[cw_serde]
+pub struct AppContractResponse {
+    pub app_contract: Addr,
+}

--- a/packages/std/src/ado_base/mod.rs
+++ b/packages/std/src/ado_base/mod.rs
@@ -1,4 +1,5 @@
 pub mod ado_type;
+pub mod app_contract;
 pub mod block_height;
 #[cfg(any(feature = "module_hooks", feature = "modules"))]
 pub mod hooks;
@@ -70,7 +71,7 @@ pub enum AndromedaQuery {
     BlockHeightUponCreation {},
     #[returns(self::version::VersionResponse)]
     Version {},
-    #[returns(Option<::cosmwasm_std::Addr>)]
+    #[returns(self::app_contract::AppContractResponse)]
     AppContract {},
     #[cfg(feature = "modules")]
     #[returns(Module)]


### PR DESCRIPTION
# Motivation
Resolves #328 

# Implementation
As stated in the issue, with the addition of 
```rust
#[cw_serde]
pub struct AppContractResponse {
    pub app_contract: Addr,
}
```

# Testing
No tests were created nor adjusted.

# Notes
The `QueryMsg` for getting the kernel address is `KernelAddress` whereas to get the app contract is `AppContract`. Should we make the naming consistent? like `Kernel` or `AppContractAddress`.

