### PR TITLE
added UpdateChainName and GetChainName methods

### DIFF
--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -178,7 +178,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         }
         QueryMsg::ChannelInfo { chain } => encode_binary(&query::channel_info(deps, chain)?),
         QueryMsg::Recoveries { addr } => encode_binary(&query::recoveries(deps, addr)?),
-        QueryMsg::GetChainName {} => encode_binary(&query::get_chain_name(deps)?),
+        QueryMsg::ChainName {} => encode_binary(&query::get_chain_name(deps)?),
         // Base queries
         QueryMsg::Version {} => encode_binary(&ADOContract::default().query_version(deps)?),
         QueryMsg::Type {} => encode_binary(&ADOContract::default().query_type(deps)?),

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -107,6 +107,9 @@ pub fn execute(
             kernel_address,
         ),
         ExecuteMsg::Recover {} => execute::recover(execute_env),
+        ExecuteMsg::UpdateChainName { chain_name } => {
+            execute::update_chain_name(execute_env, chain_name)
+        }
         ExecuteMsg::Internal(msg) => execute::internal(execute_env, msg),
         // Base message
         ExecuteMsg::Ownership(ownership_message) => ADOContract::default().execute_ownership(
@@ -175,6 +178,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         }
         QueryMsg::ChannelInfo { chain } => encode_binary(&query::channel_info(deps, chain)?),
         QueryMsg::Recoveries { addr } => encode_binary(&query::recoveries(deps, addr)?),
+        QueryMsg::GetChainName {} => encode_binary(&query::get_chain_name(deps)?),
         // Base queries
         QueryMsg::Version {} => encode_binary(&ADOContract::default().query_version(deps)?),
         QueryMsg::Type {} => encode_binary(&ADOContract::default().query_type(deps)?),

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -178,7 +178,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         }
         QueryMsg::ChannelInfo { chain } => encode_binary(&query::channel_info(deps, chain)?),
         QueryMsg::Recoveries { addr } => encode_binary(&query::recoveries(deps, addr)?),
-        QueryMsg::ChainName {} => encode_binary(&query::get_chain_name(deps)?),
+        QueryMsg::ChainName {} => encode_binary(&query::chain_name(deps)?),
         // Base queries
         QueryMsg::Version {} => encode_binary(&ADOContract::default().query_version(deps)?),
         QueryMsg::Type {} => encode_binary(&ADOContract::default().query_type(deps)?),

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -5,7 +5,7 @@ use andromeda_std::{
 };
 use cosmwasm_std::{Addr, Coin, Deps};
 
-use crate::state::{CHAIN_TO_CHANNEL, IBC_FUND_RECOVERY, KERNEL_ADDRESSES};
+use crate::state::{CHAIN_TO_CHANNEL, CURR_CHAIN, IBC_FUND_RECOVERY, KERNEL_ADDRESSES};
 
 pub fn key_address(deps: Deps, key: String) -> Result<Addr, ContractError> {
     Ok(KERNEL_ADDRESSES.load(deps.storage, &key)?)
@@ -47,4 +47,8 @@ pub fn recoveries(deps: Deps, addr: Addr) -> Result<Vec<Coin>, ContractError> {
     Ok(IBC_FUND_RECOVERY
         .may_load(deps.storage, &addr)?
         .unwrap_or_default())
+}
+
+pub fn get_chain_name(deps: Deps) -> Result<String, ContractError> {
+    Ok(CURR_CHAIN.may_load(deps.storage)?.unwrap_or_default())
 }

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -1,7 +1,10 @@
 use andromeda_std::{
     amp::ADO_DB_KEY,
     error::ContractError,
-    os::{aos_querier::AOSQuerier, kernel::ChannelInfoResponse},
+    os::{
+        aos_querier::AOSQuerier,
+        kernel::{ChainNameResponse, ChannelInfoResponse},
+    },
 };
 use cosmwasm_std::{Addr, Coin, Deps};
 
@@ -49,6 +52,8 @@ pub fn recoveries(deps: Deps, addr: Addr) -> Result<Vec<Coin>, ContractError> {
         .unwrap_or_default())
 }
 
-pub fn get_chain_name(deps: Deps) -> Result<String, ContractError> {
-    Ok(CURR_CHAIN.may_load(deps.storage)?.unwrap_or_default())
+pub fn get_chain_name(deps: Deps) -> Result<ChainNameResponse, ContractError> {
+    Ok(ChainNameResponse {
+        chain_name: CURR_CHAIN.may_load(deps.storage)?.unwrap_or_default(),
+    })
 }

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -52,7 +52,7 @@ pub fn recoveries(deps: Deps, addr: Addr) -> Result<Vec<Coin>, ContractError> {
         .unwrap_or_default())
 }
 
-pub fn get_chain_name(deps: Deps) -> Result<ChainNameResponse, ContractError> {
+pub fn chain_name(deps: Deps) -> Result<ChainNameResponse, ContractError> {
     Ok(ChainNameResponse {
         chain_name: CURR_CHAIN.may_load(deps.storage)?.unwrap_or_default(),
     })

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -64,6 +64,10 @@ pub enum ExecuteMsg {
     },
     /// Recovers funds from failed IBC messages
     Recover {},
+    /// Update Current Chain
+    UpdateChainName {
+        chain_name: String,
+    },
     // Only accessible to key contracts
     Internal(InternalMsg),
     // Base message
@@ -102,6 +106,8 @@ pub enum QueryMsg {
     ChannelInfo { chain: String },
     #[returns(Vec<::cosmwasm_std::Coin>)]
     Recoveries { addr: Addr },
+    #[returns(String)]
+    GetChainName {},
     // Base queries
     #[returns(VersionResponse)]
     Version {},

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -96,6 +96,11 @@ pub struct ChannelInfoResponse {
 }
 
 #[cw_serde]
+pub struct ChainNameResponse {
+    pub chain_name: String,
+}
+
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(cosmwasm_std::Addr)]
@@ -106,8 +111,8 @@ pub enum QueryMsg {
     ChannelInfo { chain: String },
     #[returns(Vec<::cosmwasm_std::Coin>)]
     Recoveries { addr: Addr },
-    #[returns(String)]
-    GetChainName {},
+    #[returns(ChainNameResponse)]
+    ChainName {},
     // Base queries
     #[returns(VersionResponse)]
     Version {},


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/333

# Implementation

- Added `UpdateChainName` execute message and `GetChainName` query message to `packages/std/src/os/kernel.rs`
- Added `update_chain_name` function to `contracts/os/andromeda-kernel/src/execute.rs` for updating `CURR_CHAIN` state
   - Before updating `CURR_CHAIN`, message sender is validated so that only owner can update the `CURR_CHAIN`
- Added `get_chain_name` function to `contracts/os/andromeda-kernel/src/query.rs` for querying `CURR_CHAIN` state

# Testing

Created `test_update_chain_name` for testing `UpdateChainName` message. `UpdateChainName` message is sent from two senders, first sender is not the owner and next one is the owner.

# Notes

Kernel query messages are defined as nouns like `ChannelInfo` and `KeyAddress`. It might be better to name the message as `ChainName` for consistency.
