### PR TITLE
[1.0.rc-1] Unique Recipients for Splitter

### DIFF
--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -34,14 +34,8 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    msg.validate()?;
+    msg.validate(deps.as_ref())?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Max 100 recipients
-    ensure!(
-        msg.recipients.len() <= 100,
-        ContractError::ReachedRecipientLimit {}
-    );
 
     let current_time = env.block.time.seconds();
     let splitter = match msg.lock_time {
@@ -212,7 +206,7 @@ fn execute_update_recipients(
         ContractError::Unauthorized {}
     );
 
-    validate_recipient_list(recipients.clone())?;
+    validate_recipient_list(deps.as_ref(), recipients.clone())?;
 
     let mut splitter = SPLITTER.load(deps.storage)?;
     // Can't call this function while the lock isn't expired

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -110,11 +110,11 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: duplicate_recipients.clone(),
+        recipients: duplicate_recipients,
     };
 
     let info = mock_info(OWNER, &[]);
-    let res = execute(deps.as_mut(), env.clone(), info, msg.clone());
+    let res = execute(deps.as_mut(), env.clone(), info, msg);
     assert_eq!(ContractError::DuplicateRecipient {}, res.unwrap_err());
 
     let recipients = vec![

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -91,7 +91,15 @@ fn test_execute_update_recipients() {
     let env = mock_env();
     let _res = init(deps.as_mut());
 
-    let recipient = vec![
+    let splitter = Splitter {
+        recipients: vec![],
+        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
+    };
+
+    SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+
+    // Duplicate recipients
+    let duplicate_recipients = vec![
         AddressPercent {
             recipient: Recipient::from_string(String::from("addr1")),
             percent: Decimal::percent(40),
@@ -102,15 +110,26 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: duplicate_recipients.clone(),
     };
 
-    let splitter = Splitter {
-        recipients: vec![],
-        lock: Expiration::AtTime(Timestamp::from_seconds(0)),
-    };
+    let info = mock_info(OWNER, &[]);
+    let res = execute(deps.as_mut(), env.clone(), info, msg.clone());
+    assert_eq!(ContractError::DuplicateRecipient {}, res.unwrap_err());
 
-    SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    let recipients = vec![
+        AddressPercent {
+            recipient: Recipient::from_string(String::from("addr1")),
+            percent: Decimal::percent(40),
+        },
+        AddressPercent {
+            recipient: Recipient::from_string(String::from("addr2")),
+            percent: Decimal::percent(60),
+        },
+    ];
+    let msg = ExecuteMsg::UpdateRecipients {
+        recipients: recipients.clone(),
+    };
 
     let info = mock_info("incorrect_owner", &[]);
     let res = execute(deps.as_mut(), env.clone(), info, msg.clone());
@@ -125,7 +144,7 @@ fn test_execute_update_recipients() {
 
     //check result
     let splitter = SPLITTER.load(deps.as_ref().storage).unwrap();
-    assert_eq!(splitter.recipients, recipient);
+    assert_eq!(splitter.recipients, recipients);
 }
 
 #[test]

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -104,6 +104,10 @@ pub fn validate_recipient_list(
 
     for rec in recipients {
         percent_sum = percent_sum.checked_add(rec.percent)?;
+        ensure!(
+            percent_sum <= Decimal::one(),
+            ContractError::AmountExceededHundredPrecent {}
+        );
 
         let recipient_address = rec.recipient.address.get_raw_address(&deps)?;
         ensure!(
@@ -112,11 +116,6 @@ pub fn validate_recipient_list(
         );
         recipient_address_set.insert(recipient_address);
     }
-
-    ensure!(
-        percent_sum <= Decimal::one(),
-        ContractError::AmountExceededHundredPrecent {}
-    );
 
     Ok(())
 }

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -102,7 +102,7 @@ pub fn validate_recipient_list(
     let mut percent_sum: Decimal = Decimal::zero();
     let mut recipient_address_set = HashSet::new();
 
-    for rec in recipients.clone() {
+    for rec in recipients {
         percent_sum = percent_sum.checked_add(rec.percent)?;
 
         let recipient_address = rec.recipient.address.get_raw_address(&deps)?;

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -1,8 +1,10 @@
+use std::collections::HashSet;
+
 use andromeda_std::{
     amp::recipient::Recipient, andr_exec, andr_instantiate, andr_query, error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Decimal, ReplyOn};
+use cosmwasm_std::{ensure, Decimal, Deps, ReplyOn};
 use cw_utils::Expiration;
 
 #[cw_serde]
@@ -36,9 +38,8 @@ pub struct InstantiateMsg {
 }
 
 impl InstantiateMsg {
-    pub fn validate(&self) -> Result<bool, ContractError> {
-        validate_recipient_list(self.recipients.clone())?;
-        Ok(true)
+    pub fn validate(&self, deps: Deps) -> Result<(), ContractError> {
+        validate_recipient_list(deps, self.recipients.clone())
     }
 }
 
@@ -81,16 +82,35 @@ pub struct GetSplitterConfigResponse {
 /// Ensures that a given list of recipients for a `splitter` contract is valid:
 ///
 /// * Must include at least one recipient
+/// * The number of recipients must not exceed 100
 /// * The combined percentage of the recipients must not exceed 100
-pub fn validate_recipient_list(recipients: Vec<AddressPercent>) -> Result<bool, ContractError> {
+/// * The recipient addresses must be unique
+pub fn validate_recipient_list(
+    deps: Deps,
+    recipients: Vec<AddressPercent>,
+) -> Result<(), ContractError> {
     ensure!(
         !recipients.is_empty(),
         ContractError::EmptyRecipientsList {}
     );
 
+    ensure!(
+        recipients.len() <= 100,
+        ContractError::ReachedRecipientLimit {}
+    );
+
     let mut percent_sum: Decimal = Decimal::zero();
-    for rec in recipients {
+    let mut recipient_address_set = HashSet::new();
+
+    for rec in recipients.clone() {
         percent_sum = percent_sum.checked_add(rec.percent)?;
+
+        let recipient_address = rec.recipient.address.get_raw_address(&deps)?;
+        ensure!(
+            !recipient_address_set.contains(&recipient_address),
+            ContractError::DuplicateRecipient {}
+        );
+        recipient_address_set.insert(recipient_address);
     }
 
     ensure!(
@@ -98,38 +118,63 @@ pub fn validate_recipient_list(recipients: Vec<AddressPercent>) -> Result<bool, 
         ContractError::AmountExceededHundredPrecent {}
     );
 
-    Ok(true)
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use cosmwasm_std::testing::mock_dependencies;
+
     use super::*;
 
     #[test]
     fn test_validate_recipient_list() {
+        let deps = mock_dependencies();
         let empty_recipients = vec![];
-        let res = validate_recipient_list(empty_recipients).unwrap_err();
+        let res = validate_recipient_list(deps.as_ref(), empty_recipients).unwrap_err();
         assert_eq!(res, ContractError::EmptyRecipientsList {});
 
         let inadequate_recipients = vec![AddressPercent {
-            recipient: Recipient::from_string(String::from("Some Address")),
+            recipient: Recipient::from_string(String::from("abc")),
             percent: Decimal::percent(150),
         }];
-        let res = validate_recipient_list(inadequate_recipients).unwrap_err();
+        let res = validate_recipient_list(deps.as_ref(), inadequate_recipients).unwrap_err();
         assert_eq!(res, ContractError::AmountExceededHundredPrecent {});
 
-        let valid_recipients = vec![
+        let duplicate_recipients = vec![
             AddressPercent {
-                recipient: Recipient::from_string(String::from("Some Address")),
+                recipient: Recipient::from_string(String::from("abc")),
                 percent: Decimal::percent(50),
             },
             AddressPercent {
-                recipient: Recipient::from_string(String::from("Some Address")),
+                recipient: Recipient::from_string(String::from("abc")),
                 percent: Decimal::percent(50),
             },
         ];
 
-        let res = validate_recipient_list(valid_recipients).unwrap();
-        assert!(res);
+        let err = validate_recipient_list(deps.as_ref(), duplicate_recipients).unwrap_err();
+        assert_eq!(err, ContractError::DuplicateRecipient {});
+
+        let valid_recipients = vec![
+            AddressPercent {
+                recipient: Recipient::from_string(String::from("abc")),
+                percent: Decimal::percent(50),
+            },
+            AddressPercent {
+                recipient: Recipient::from_string(String::from("xyz")),
+                percent: Decimal::percent(50),
+            },
+        ];
+
+        let res = validate_recipient_list(deps.as_ref(), valid_recipients);
+        assert!(res.is_ok());
+
+        let one_valid_recipient = vec![AddressPercent {
+            recipient: Recipient::from_string(String::from("abc")),
+            percent: Decimal::percent(50),
+        }];
+
+        let res = validate_recipient_list(deps.as_ref(), one_valid_recipient);
+        assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
# Motivation
Resolves #337 

# Implementation
`validate_recipient_list` now checks for duplicate addresses and the number of recipients. 

The checks related to the number of recipients list are done first to avoid looping through vectors of invalid length.

`validate_recipient_list` now returns `()` instead of `bool` since the boolean result was never used.

The check for the sum of percentages exceeding 100 is conducted through every iteration of the loop going through the recipients.

# Testing
Added test case to check for duplicate recipients

