### PR TITLE
[1.0.rc-1] CW20 Version Fix

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
@@ -44,6 +44,9 @@ pub fn mock_get_cw20_balance(address: impl Into<String>) -> QueryMsg {
     let address = AndrAddr::from_string(address.into());
     QueryMsg::Balance { address }
 }
+pub fn mock_get_version() -> QueryMsg {
+    QueryMsg::Version {}
+}
 
 pub fn mock_cw20_send(contract: String, amount: Uint128, msg: Binary) -> ExecuteMsg {
     ExecuteMsg::Send {

--- a/tests-integration/tests/cw20_staking.rs
+++ b/tests-integration/tests/cw20_staking.rs
@@ -5,7 +5,7 @@ use andromeda_app_contract::mock::{
 };
 use andromeda_cw20::mock::{
     mock_andromeda_cw20, mock_cw20_instantiate_msg, mock_cw20_send, mock_cw20_transfer,
-    mock_get_cw20_balance, mock_minter,
+    mock_get_cw20_balance, mock_get_version, mock_minter,
 };
 use andromeda_cw20_staking::mock::{
     mock_andromeda_cw20_staking, mock_cw20_get_staker, mock_cw20_stake,
@@ -13,6 +13,7 @@ use andromeda_cw20_staking::mock::{
     mock_cw20_staking_update_global_indexes,
 };
 use andromeda_fungible_tokens::cw20_staking::{AllocationConfig, StakerResponse};
+use andromeda_std::ado_base::version::VersionResponse;
 use andromeda_testing::mock::MockAndromeda;
 use cosmwasm_std::{coin, to_binary, Addr, BlockInfo, Timestamp, Uint128};
 use cw20::{BalanceResponse, Cw20Coin};
@@ -190,6 +191,13 @@ fn test_cw20_staking_app() {
             &mock_get_cw20_balance(staker_one.to_string()),
         )
         .unwrap();
+
+    let version: VersionResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_addr.clone(), &mock_get_version())
+        .unwrap();
+    assert_eq!(version.version, "1.0.0-rc.1");
+
     assert_eq!(balance_one.balance, Uint128::from(1000u128));
     let balance_two: BalanceResponse = router
         .wrap()


### PR DESCRIPTION
# Motivation
Resolves #347 

# Implementation
`cw20_instantiate` was overwriting `set_contract_version`, so now `set_contract_version` is being called after `cw20_instantiate`.
Used `deps.branch()` in `cw20_instantiate` to avoid moving `deps`

# Testing
Added a version check for the cw20 contract in the `cw20staking` integration test 
