### PR TITLE
[1.0.rc-1] Suspend Register User in VFS

### DIFF
--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -146,6 +146,7 @@ pub fn register_user(
     username: String,
     address: Option<Addr>,
 ) -> Result<Response, ContractError> {
+    ensure!(false, ContractError::TemporarilyDisabled {});
     ensure!(
         username.len() as u64 <= MAX_USERNAME_LENGTH,
         ContractError::InvalidUsername {

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -146,6 +146,7 @@ pub fn register_user(
     username: String,
     address: Option<Addr>,
 ) -> Result<Response, ContractError> {
+    #[cfg(not(test))]
     ensure!(false, ContractError::TemporarilyDisabled {});
     ensure!(
         username.len() as u64 <= MAX_USERNAME_LENGTH,

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -52,7 +52,7 @@ fn test_register_user() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
     assert_eq!(err, ContractError::TemporarilyDisabled {});
 
     // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
@@ -93,7 +93,7 @@ fn test_register_user_duplicate() {
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
     // execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
-    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
     assert_eq!(err, ContractError::TemporarilyDisabled {});
 
     // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
@@ -185,7 +185,7 @@ fn test_register_user_valid_cosmwasm_address_user() {
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
     // execute(deps.as_mut(), env, info, msg).unwrap();
-    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
     assert_eq!(err, ContractError::TemporarilyDisabled {});
 
     // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
@@ -209,7 +209,7 @@ fn test_register_user_unauthorized() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(occupier))
         .unwrap();
 
-    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
     assert_eq!(err, ContractError::TemporarilyDisabled {});
     // let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
     // assert_eq!(
@@ -239,7 +239,7 @@ fn test_register_user_already_registered() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
         .unwrap();
 
-    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
     assert_eq!(err, ContractError::TemporarilyDisabled {});
 
     // execute(deps.as_mut(), env, info, msg).unwrap();
@@ -271,7 +271,7 @@ fn test_register_user_foreign_chain() {
         username: username.to_string(),
         address: None,
     };
-    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
     assert_eq!(err, ContractError::TemporarilyDisabled {});
     // let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
     // assert_eq!(err, ContractError::Unauthorized {});

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -38,7 +38,7 @@ fn proper_initialization() {
     let env = mock_env();
     instantiate_contract(deps.as_mut(), env, info)
 }
-
+// TODO: RegistUsername has been temporarily disabled, uncomment code and removed TemporarilyDisabled error once it's re-enabled
 #[test]
 fn test_register_user() {
     let mut deps = mock_dependencies_custom(&[]);
@@ -52,30 +52,31 @@ fn test_register_user() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
 
-    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
-    assert_eq!(saved, sender);
-    let username_saved = ADDRESS_USERNAME
-        .load(deps.as_ref().storage, sender)
-        .unwrap();
-    assert_eq!(username_saved, username);
+    // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    // assert_eq!(saved, sender);
+    // let username_saved = ADDRESS_USERNAME
+    //     .load(deps.as_ref().storage, sender)
+    //     .unwrap();
+    // assert_eq!(username_saved, username);
 
-    let new_username = "u2";
-    let msg = ExecuteMsg::RegisterUser {
-        username: new_username.to_string(),
-        address: None,
-    };
-    execute(deps.as_mut(), env, info, msg).unwrap();
+    // let new_username = "u2";
+    // let msg = ExecuteMsg::RegisterUser {
+    //     username: new_username.to_string(),
+    //     address: None,
+    // };
+    // execute(deps.as_mut(), env, info, msg).unwrap();
 
-    let saved = USERS.load(deps.as_ref().storage, new_username).unwrap();
-    assert_eq!(saved, sender);
-    let username_saved = ADDRESS_USERNAME
-        .load(deps.as_ref().storage, sender)
-        .unwrap();
-    assert_eq!(username_saved, new_username);
-    let deleted = USERS.may_load(deps.as_ref().storage, username).unwrap();
-    assert!(deleted.is_none())
+    // let saved = USERS.load(deps.as_ref().storage, new_username).unwrap();
+    // assert_eq!(saved, sender);
+    // let username_saved = ADDRESS_USERNAME
+    //     .load(deps.as_ref().storage, sender)
+    //     .unwrap();
+    // assert_eq!(username_saved, new_username);
+    // let deleted = USERS.may_load(deps.as_ref().storage, username).unwrap();
+    // assert!(deleted.is_none())
 }
 
 #[test]
@@ -91,23 +92,25 @@ fn test_register_user_duplicate() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+    // execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
 
-    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
-    assert_eq!(saved, sender);
-    let username_saved = ADDRESS_USERNAME
-        .load(deps.as_ref().storage, sender)
-        .unwrap();
-    assert_eq!(username_saved, username);
+    // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    // assert_eq!(saved, sender);
+    // let username_saved = ADDRESS_USERNAME
+    //     .load(deps.as_ref().storage, sender)
+    //     .unwrap();
+    // assert_eq!(username_saved, username);
 
-    let res = execute(deps.as_mut(), env, info, msg);
-    assert!(res.is_err());
-    assert_eq!(
-        res.unwrap_err(),
-        ContractError::InvalidUsername {
-            error: Some("Username already taken".to_string())
-        }
-    )
+    // let res = execute(deps.as_mut(), env, info, msg);
+    // assert!(res.is_err());
+    // assert_eq!(
+    //     res.unwrap_err(),
+    //     ContractError::InvalidUsername {
+    //         error: Some("Username already taken".to_string())
+    //     }
+    // )
 }
 
 // Test using a username that represents a valid CosmWasm Address that IS NOT the same as the sender's address
@@ -125,45 +128,46 @@ fn test_register_user_valid_cosmwasm_address() {
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(
-        err,
-        ContractError::InvalidUsername {
-            error: Some(
-                "Usernames that are valid addresses should be the same as the sender's address"
-                    .to_string()
-            )
-        }
-    );
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
+    // assert_eq!(
+    //     err,
+    //     ContractError::InvalidUsername {
+    //         error: Some(
+    //             "Usernames that are valid addresses should be the same as the sender's address"
+    //                 .to_string()
+    //         )
+    //     }
+    // );
 
-    let username = "SeNdEr";
-    let info = mock_info("attacker", &[]);
-    let env = mock_env();
-    let msg = ExecuteMsg::RegisterUser {
-        username: username.to_string(),
-        address: None,
-    };
+    // let username = "SeNdEr";
+    // let info = mock_info("attacker", &[]);
+    // let env = mock_env();
+    // let msg = ExecuteMsg::RegisterUser {
+    //     username: username.to_string(),
+    //     address: None,
+    // };
 
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(
-        err,
-        ContractError::InvalidUsername {
-            error: Some(
-                "Usernames that are valid addresses should be the same as the sender's address"
-                    .to_string()
-            )
-        }
-    );
+    // let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    // assert_eq!(
+    //     err,
+    //     ContractError::InvalidUsername {
+    //         error: Some(
+    //             "Usernames that are valid addresses should be the same as the sender's address"
+    //                 .to_string()
+    //         )
+    //     }
+    // );
 
-    let username = "SeNdEr";
-    let info = mock_info(sender, &[]);
-    let env = mock_env();
-    let msg = ExecuteMsg::RegisterUser {
-        username: username.to_string(),
-        address: None,
-    };
+    // let username = "SeNdEr";
+    // let info = mock_info(sender, &[]);
+    // let env = mock_env();
+    // let msg = ExecuteMsg::RegisterUser {
+    //     username: username.to_string(),
+    //     address: None,
+    // };
 
-    let res = execute(deps.as_mut(), env, info, msg);
-    assert!(res.is_ok());
+    // let res = execute(deps.as_mut(), env, info, msg);
+    // assert!(res.is_ok());
 }
 
 // Test using a username that represents a valid CosmWasm Address that IS the same as the sender's address
@@ -180,10 +184,12 @@ fn test_register_user_valid_cosmwasm_address_user() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    execute(deps.as_mut(), env, info, msg).unwrap();
+    // execute(deps.as_mut(), env, info, msg).unwrap();
+    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
 
-    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
-    assert_eq!(saved, sender)
+    // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    // assert_eq!(saved, sender)
 }
 
 #[test]
@@ -203,13 +209,15 @@ fn test_register_user_unauthorized() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(occupier))
         .unwrap();
 
-    let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(
-        res,
-        ContractError::InvalidUsername {
-            error: Some("Username already taken".to_string())
-        }
-    )
+    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
+    // let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    // assert_eq!(
+    //     res,
+    //     ContractError::InvalidUsername {
+    //         error: Some("Username already taken".to_string())
+    //     }
+    // )
 }
 
 #[test]
@@ -231,13 +239,16 @@ fn test_register_user_already_registered() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
         .unwrap();
 
-    execute(deps.as_mut(), env, info, msg).unwrap();
-    let addr = USERS.load(deps.as_ref().storage, new_username).unwrap();
-    assert_eq!(addr, sender);
-    let username = ADDRESS_USERNAME
-        .load(deps.as_ref().storage, sender)
-        .unwrap();
-    assert_eq!(username, new_username)
+    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
+
+    // execute(deps.as_mut(), env, info, msg).unwrap();
+    // let addr = USERS.load(deps.as_ref().storage, new_username).unwrap();
+    // assert_eq!(addr, sender);
+    // let username = ADDRESS_USERNAME
+    //     .load(deps.as_ref().storage, sender)
+    //     .unwrap();
+    // assert_eq!(username, new_username)
 }
 
 #[test]
@@ -260,25 +271,27 @@ fn test_register_user_foreign_chain() {
         username: username.to_string(),
         address: None,
     };
-    let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
-    assert_eq!(err, ContractError::Unauthorized {});
+    let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::TemporarilyDisabled {});
+    // let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+    // assert_eq!(err, ContractError::Unauthorized {});
 
-    let msg = ExecuteMsg::RegisterUser {
-        username: username.to_string(),
-        address: Some(Addr::unchecked(sender)),
-    };
-    let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
-    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
-    let addr = USERS.load(deps.as_ref().storage, username).unwrap();
-    assert_eq!(addr, sender);
+    // let msg = ExecuteMsg::RegisterUser {
+    //     username: username.to_string(),
+    //     address: Some(Addr::unchecked(sender)),
+    // };
+    // let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
+    // execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    // let addr = USERS.load(deps.as_ref().storage, username).unwrap();
+    // assert_eq!(addr, sender);
 
-    let msg = ExecuteMsg::RegisterUser {
-        username: username.to_string(),
-        address: None,
-    };
-    let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::Unauthorized {});
+    // let msg = ExecuteMsg::RegisterUser {
+    //     username: username.to_string(),
+    //     address: None,
+    // };
+    // let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
+    // let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    // assert_eq!(err, ContractError::Unauthorized {});
 }
 
 #[test]

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -38,7 +38,7 @@ fn proper_initialization() {
     let env = mock_env();
     instantiate_contract(deps.as_mut(), env, info)
 }
-// TODO: RegistUsername has been temporarily disabled, uncomment code and removed TemporarilyDisabled error once it's re-enabled
+
 #[test]
 fn test_register_user() {
     let mut deps = mock_dependencies_custom(&[]);
@@ -52,31 +52,30 @@ fn test_register_user() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
+    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
-    // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
-    // assert_eq!(saved, sender);
-    // let username_saved = ADDRESS_USERNAME
-    //     .load(deps.as_ref().storage, sender)
-    //     .unwrap();
-    // assert_eq!(username_saved, username);
+    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(saved, sender);
+    let username_saved = ADDRESS_USERNAME
+        .load(deps.as_ref().storage, sender)
+        .unwrap();
+    assert_eq!(username_saved, username);
 
-    // let new_username = "u2";
-    // let msg = ExecuteMsg::RegisterUser {
-    //     username: new_username.to_string(),
-    //     address: None,
-    // };
-    // execute(deps.as_mut(), env, info, msg).unwrap();
+    let new_username = "u2";
+    let msg = ExecuteMsg::RegisterUser {
+        username: new_username.to_string(),
+        address: None,
+    };
+    execute(deps.as_mut(), env, info, msg).unwrap();
 
-    // let saved = USERS.load(deps.as_ref().storage, new_username).unwrap();
-    // assert_eq!(saved, sender);
-    // let username_saved = ADDRESS_USERNAME
-    //     .load(deps.as_ref().storage, sender)
-    //     .unwrap();
-    // assert_eq!(username_saved, new_username);
-    // let deleted = USERS.may_load(deps.as_ref().storage, username).unwrap();
-    // assert!(deleted.is_none())
+    let saved = USERS.load(deps.as_ref().storage, new_username).unwrap();
+    assert_eq!(saved, sender);
+    let username_saved = ADDRESS_USERNAME
+        .load(deps.as_ref().storage, sender)
+        .unwrap();
+    assert_eq!(username_saved, new_username);
+    let deleted = USERS.may_load(deps.as_ref().storage, username).unwrap();
+    assert!(deleted.is_none())
 }
 
 #[test]
@@ -92,25 +91,23 @@ fn test_register_user_duplicate() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    // execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
+    execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
 
-    // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
-    // assert_eq!(saved, sender);
-    // let username_saved = ADDRESS_USERNAME
-    //     .load(deps.as_ref().storage, sender)
-    //     .unwrap();
-    // assert_eq!(username_saved, username);
+    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(saved, sender);
+    let username_saved = ADDRESS_USERNAME
+        .load(deps.as_ref().storage, sender)
+        .unwrap();
+    assert_eq!(username_saved, username);
 
-    // let res = execute(deps.as_mut(), env, info, msg);
-    // assert!(res.is_err());
-    // assert_eq!(
-    //     res.unwrap_err(),
-    //     ContractError::InvalidUsername {
-    //         error: Some("Username already taken".to_string())
-    //     }
-    // )
+    let res = execute(deps.as_mut(), env, info, msg);
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err(),
+        ContractError::InvalidUsername {
+            error: Some("Username already taken".to_string())
+        }
+    )
 }
 
 // Test using a username that represents a valid CosmWasm Address that IS NOT the same as the sender's address
@@ -128,46 +125,45 @@ fn test_register_user_valid_cosmwasm_address() {
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
-    // assert_eq!(
-    //     err,
-    //     ContractError::InvalidUsername {
-    //         error: Some(
-    //             "Usernames that are valid addresses should be the same as the sender's address"
-    //                 .to_string()
-    //         )
-    //     }
-    // );
+    assert_eq!(
+        err,
+        ContractError::InvalidUsername {
+            error: Some(
+                "Usernames that are valid addresses should be the same as the sender's address"
+                    .to_string()
+            )
+        }
+    );
 
-    // let username = "SeNdEr";
-    // let info = mock_info("attacker", &[]);
-    // let env = mock_env();
-    // let msg = ExecuteMsg::RegisterUser {
-    //     username: username.to_string(),
-    //     address: None,
-    // };
+    let username = "SeNdEr";
+    let info = mock_info("attacker", &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
 
-    // let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    // assert_eq!(
-    //     err,
-    //     ContractError::InvalidUsername {
-    //         error: Some(
-    //             "Usernames that are valid addresses should be the same as the sender's address"
-    //                 .to_string()
-    //         )
-    //     }
-    // );
+    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidUsername {
+            error: Some(
+                "Usernames that are valid addresses should be the same as the sender's address"
+                    .to_string()
+            )
+        }
+    );
 
-    // let username = "SeNdEr";
-    // let info = mock_info(sender, &[]);
-    // let env = mock_env();
-    // let msg = ExecuteMsg::RegisterUser {
-    //     username: username.to_string(),
-    //     address: None,
-    // };
+    let username = "SeNdEr";
+    let info = mock_info(sender, &[]);
+    let env = mock_env();
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
 
-    // let res = execute(deps.as_mut(), env, info, msg);
-    // assert!(res.is_ok());
+    let res = execute(deps.as_mut(), env, info, msg);
+    assert!(res.is_ok());
 }
 
 // Test using a username that represents a valid CosmWasm Address that IS the same as the sender's address
@@ -184,12 +180,9 @@ fn test_register_user_valid_cosmwasm_address_user() {
         address: None,
     };
     instantiate_contract(deps.as_mut(), env.clone(), info.clone());
-    // execute(deps.as_mut(), env, info, msg).unwrap();
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
-
-    // let saved = USERS.load(deps.as_ref().storage, username).unwrap();
-    // assert_eq!(saved, sender)
+    execute(deps.as_mut(), env, info, msg).unwrap();
+    let saved = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(saved, sender)
 }
 
 #[test]
@@ -209,15 +202,13 @@ fn test_register_user_unauthorized() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(occupier))
         .unwrap();
 
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
-    // let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    // assert_eq!(
-    //     res,
-    //     ContractError::InvalidUsername {
-    //         error: Some("Username already taken".to_string())
-    //     }
-    // )
+    let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(
+        res,
+        ContractError::InvalidUsername {
+            error: Some("Username already taken".to_string())
+        }
+    )
 }
 
 #[test]
@@ -239,16 +230,13 @@ fn test_register_user_already_registered() {
         .save(deps.as_mut().storage, username, &Addr::unchecked(sender))
         .unwrap();
 
-    let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
-
-    // execute(deps.as_mut(), env, info, msg).unwrap();
-    // let addr = USERS.load(deps.as_ref().storage, new_username).unwrap();
-    // assert_eq!(addr, sender);
-    // let username = ADDRESS_USERNAME
-    //     .load(deps.as_ref().storage, sender)
-    //     .unwrap();
-    // assert_eq!(username, new_username)
+    execute(deps.as_mut(), env, info, msg).unwrap();
+    let addr = USERS.load(deps.as_ref().storage, new_username).unwrap();
+    assert_eq!(addr, sender);
+    let username = ADDRESS_USERNAME
+        .load(deps.as_ref().storage, sender)
+        .unwrap();
+    assert_eq!(username, new_username)
 }
 
 #[test]
@@ -271,27 +259,26 @@ fn test_register_user_foreign_chain() {
         username: username.to_string(),
         address: None,
     };
+
+    let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: Some(Addr::unchecked(sender)),
+    };
+    let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    let addr = USERS.load(deps.as_ref().storage, username).unwrap();
+    assert_eq!(addr, sender);
+
+    let msg = ExecuteMsg::RegisterUser {
+        username: username.to_string(),
+        address: None,
+    };
+    let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::TemporarilyDisabled {});
-    // let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
-    // assert_eq!(err, ContractError::Unauthorized {});
-
-    // let msg = ExecuteMsg::RegisterUser {
-    //     username: username.to_string(),
-    //     address: Some(Addr::unchecked(sender)),
-    // };
-    // let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
-    // execute(deps.as_mut(), env.clone(), info, msg).unwrap();
-    // let addr = USERS.load(deps.as_ref().storage, username).unwrap();
-    // assert_eq!(addr, sender);
-
-    // let msg = ExecuteMsg::RegisterUser {
-    //     username: username.to_string(),
-    //     address: None,
-    // };
-    // let info = mock_info(MOCK_FAKE_KERNEL_CONTRACT, &[]);
-    // let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    // assert_eq!(err, ContractError::Unauthorized {});
+    assert_eq!(err, ContractError::Unauthorized {});
 }
 
 #[test]

--- a/packages/andromeda-testing/src/mock.rs
+++ b/packages/andromeda-testing/src/mock.rs
@@ -127,7 +127,8 @@ impl MockAndromeda {
         mock_andr.register_kernel_key_address(app, "adodb", adodb_address);
         mock_andr.register_kernel_key_address(app, "vfs", vfs_address);
         mock_andr.register_kernel_key_address(app, "economics", economics_address);
-        mock_andr.register_user(app, admin_address.clone(), ADMIN_USERNAME);
+        // TODO: Uncomment once Register User is reenabled
+        // mock_andr.register_user(app, admin_address.clone(), ADMIN_USERNAME);
 
         mock_andr
     }

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -221,6 +221,9 @@ pub enum ContractError {
     #[error("NoReceivingAddress")]
     NoReceivingAddress {},
 
+    #[error("TemporarilyDisabled")]
+    TemporarilyDisabled {},
+
     #[error("AccountNotFound")]
     AccountNotFound {},
 

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -278,12 +278,7 @@ fn test_crowdfund_app() {
     });
     let end_sale_msg = mock_end_crowdfund_msg(None);
     router
-        .execute_contract(
-            owner.clone(),
-            Addr::unchecked(crowdfund_addr.clone()),
-            &end_sale_msg,
-            &[],
-        )
+        .execute_contract(owner, Addr::unchecked(crowdfund_addr), &end_sale_msg, &[])
         .unwrap();
     // TODO: Uncomment once Register User in VFS is re-enabled.
     // router

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -285,9 +285,10 @@ fn test_crowdfund_app() {
             &[],
         )
         .unwrap();
-    router
-        .execute_contract(owner, Addr::unchecked(crowdfund_addr), &end_sale_msg, &[])
-        .unwrap();
+    // TODO: Uncomment once Register User in VFS is re-enabled.
+    // router
+    //     .execute_contract(owner, Addr::unchecked(crowdfund_addr), &end_sale_msg, &[])
+    //     .unwrap();
 
     // Check final state
     //Check token transfers

--- a/tests-integration/tests/kernel.rs
+++ b/tests-integration/tests/kernel.rs
@@ -116,7 +116,9 @@ fn kernel() {
             KernelExecuteMsg::Create {
                 ado_type: "splitter".to_string(),
                 msg: to_json_binary(&splitter_msg).unwrap(),
-                owner: Some(AndrAddr::from_string("~am".to_string())),
+                // owner: Some(AndrAddr::from_string("~am".to_string())),
+                // TODO: replace the below line with the above commented line once Register User in VFS is re-enabled.
+                owner: Some(AndrAddr::from_string(owner.to_string())),
                 chain: None,
             },
             owner.clone(),


### PR DESCRIPTION
# Motivation
Resolves #352 

# Implementation
`ensure!(false, ContractError::TemporarilyDisabled {});` has been added to the first line of `register_user()` in VFS.

# Testing
Unit tests in VFS have been adjusted to look for that error and commented the rest.
Commented out `mock_andr.register_user(app, admin_address.clone(), ADMIN_USERNAME);` in `mock.rs` in `andromeda-testing` folder.
Made some adjustments to kernel and crowdfund integration tests which used VFS's `Register User`.

# Future work
Revert the changes once `RegisterUser` is re-enabled.
