### PR TITLE
[1.0.rc-1] AddressAndKey Removal from Rate Limiting Withdrawals

### DIFF
--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -47,14 +47,14 @@ pub fn instantiate(
             },
         )?,
         //NOTE temporary until a replacement for primitive is implemented
-        _ => ALLOWED_COIN.save(
-            deps.storage,
-            &CoinAllowance {
-                coin: msg.allowed_coin.coin,
-                limit: msg.allowed_coin.limit,
-                minimal_withdrawal_frequency: Milliseconds::zero(),
-            },
-        )?,
+        // _ => ALLOWED_COIN.save(
+        //     deps.storage,
+        //     &CoinAllowance {
+        //         coin: msg.allowed_coin.coin,
+        //         limit: msg.allowed_coin.limit,
+        //         minimal_withdrawal_frequency: Milliseconds::zero(),
+        //     },
+        // )?,
         // MinimumFrequency::AddressAndKey { address_and_key } => ALLOWED_COIN.save(
         //     deps.storage,
         //     &CoinAllowance {

--- a/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
+++ b/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
@@ -47,7 +47,7 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum MinimumFrequency {
     Time { time: Milliseconds },
-    AddressAndKey { address_and_key: ContractAndKey },
+    // AddressAndKey { address_and_key: ContractAndKey },
 }
 
 #[andr_exec]


### PR DESCRIPTION
# Motivation
Resolves #356 

# Implementation
Commented out `AddressAndKey` from the `MinimumFrequency` enum in the Rate Limiting Withdrawals ADO. This made the following code unreachable:
```rust
        _ => ALLOWED_COIN.save(
            deps.storage,
            &CoinAllowance {
                coin: msg.allowed_coin.coin,
                limit: msg.allowed_coin.limit,
                minimal_withdrawal_frequency: Milliseconds::zero(),
            },
        )?,
```
So I commented it out as well.

# Testing
No tests were affected
