### PR TITLE
[1.0.rc-1] VFS SubDir Query Change to Struct from Tuple

### DIFF
--- a/contracts/os/andromeda-vfs/schema/andromeda-vfs.json
+++ b/contracts/os/andromeda-vfs/schema/andromeda-vfs.json
@@ -384,7 +384,7 @@
               "max": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/AddressString"
+                    "$ref": "#/definitions/SubDirBound"
                   },
                   {
                     "type": "null"
@@ -394,7 +394,7 @@
               "min": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/AddressString"
+                    "$ref": "#/definitions/SubDirBound"
                   },
                   {
                     "type": "null"
@@ -552,26 +552,26 @@
         "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
         "type": "string"
       },
-      "AddressString": {
+      "AndrAddr": {
+        "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+        "type": "string",
+        "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,40}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
+      },
+      "SubDirBound": {
         "type": "object",
         "required": [
           "address",
-          "string"
+          "name"
         ],
         "properties": {
           "address": {
             "$ref": "#/definitions/Addr"
           },
-          "string": {
+          "name": {
             "type": "string"
           }
         },
         "additionalProperties": false
-      },
-      "AndrAddr": {
-        "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
-        "type": "string",
-        "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,40}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
       }
     }
   },

--- a/contracts/os/andromeda-vfs/schema/andromeda-vfs.json
+++ b/contracts/os/andromeda-vfs/schema/andromeda-vfs.json
@@ -382,36 +382,24 @@
                 "minimum": 0.0
               },
               "max": {
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": [
+                "anyOf": [
                   {
-                    "$ref": "#/definitions/Addr"
+                    "$ref": "#/definitions/AddressString"
                   },
                   {
-                    "type": "string"
+                    "type": "null"
                   }
-                ],
-                "maxItems": 2,
-                "minItems": 2
+                ]
               },
               "min": {
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": [
+                "anyOf": [
                   {
-                    "$ref": "#/definitions/Addr"
+                    "$ref": "#/definitions/AddressString"
                   },
                   {
-                    "type": "string"
+                    "type": "null"
                   }
-                ],
-                "maxItems": 2,
-                "minItems": 2
+                ]
               },
               "path": {
                 "$ref": "#/definitions/AndrAddr"
@@ -563,6 +551,22 @@
       "Addr": {
         "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
         "type": "string"
+      },
+      "AddressString": {
+        "type": "object",
+        "required": [
+          "address",
+          "string"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/definitions/Addr"
+          },
+          "string": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "AndrAddr": {
         "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",

--- a/contracts/os/andromeda-vfs/schema/raw/query.json
+++ b/contracts/os/andromeda-vfs/schema/raw/query.json
@@ -46,7 +46,7 @@
             "max": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/AddressString"
+                  "$ref": "#/definitions/SubDirBound"
                 },
                 {
                   "type": "null"
@@ -56,7 +56,7 @@
             "min": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/AddressString"
+                  "$ref": "#/definitions/SubDirBound"
                 },
                 {
                   "type": "null"
@@ -214,26 +214,26 @@
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
     },
-    "AddressString": {
+    "AndrAddr": {
+      "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
+      "type": "string",
+      "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,40}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
+    },
+    "SubDirBound": {
       "type": "object",
       "required": [
         "address",
-        "string"
+        "name"
       ],
       "properties": {
         "address": {
           "$ref": "#/definitions/Addr"
         },
-        "string": {
+        "name": {
           "type": "string"
         }
       },
       "additionalProperties": false
-    },
-    "AndrAddr": {
-      "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
-      "type": "string",
-      "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,40}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
     }
   }
 }

--- a/contracts/os/andromeda-vfs/schema/raw/query.json
+++ b/contracts/os/andromeda-vfs/schema/raw/query.json
@@ -44,36 +44,24 @@
               "minimum": 0.0
             },
             "max": {
-              "type": [
-                "array",
-                "null"
-              ],
-              "items": [
+              "anyOf": [
                 {
-                  "$ref": "#/definitions/Addr"
+                  "$ref": "#/definitions/AddressString"
                 },
                 {
-                  "type": "string"
+                  "type": "null"
                 }
-              ],
-              "maxItems": 2,
-              "minItems": 2
+              ]
             },
             "min": {
-              "type": [
-                "array",
-                "null"
-              ],
-              "items": [
+              "anyOf": [
                 {
-                  "$ref": "#/definitions/Addr"
+                  "$ref": "#/definitions/AddressString"
                 },
                 {
-                  "type": "string"
+                  "type": "null"
                 }
-              ],
-              "maxItems": 2,
-              "minItems": 2
+              ]
             },
             "path": {
               "$ref": "#/definitions/AndrAddr"
@@ -225,6 +213,22 @@
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
+    },
+    "AddressString": {
+      "type": "object",
+      "required": [
+        "address",
+        "string"
+      ],
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Addr"
+        },
+        "string": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "AndrAddr": {
       "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",

--- a/contracts/os/andromeda-vfs/src/query.rs
+++ b/contracts/os/andromeda-vfs/src/query.rs
@@ -1,4 +1,4 @@
-use andromeda_std::os::vfs::{validate_path_name, AddressString};
+use andromeda_std::os::vfs::{validate_path_name, SubDirBound};
 use andromeda_std::{amp::AndrAddr, error::ContractError};
 use cosmwasm_std::{Addr, Deps};
 
@@ -14,8 +14,8 @@ pub fn resolve_path(deps: Deps, path: AndrAddr) -> Result<Addr, ContractError> {
 pub fn subdir(
     deps: Deps,
     path: AndrAddr,
-    min: Option<AddressString>,
-    max: Option<AddressString>,
+    min: Option<SubDirBound>,
+    max: Option<SubDirBound>,
     limit: Option<u32>,
 ) -> Result<Vec<PathInfo>, ContractError> {
     validate_path_name(deps.api, path.to_string())?;

--- a/contracts/os/andromeda-vfs/src/query.rs
+++ b/contracts/os/andromeda-vfs/src/query.rs
@@ -1,4 +1,4 @@
-use andromeda_std::os::vfs::validate_path_name;
+use andromeda_std::os::vfs::{validate_path_name, AddressString};
 use andromeda_std::{amp::AndrAddr, error::ContractError};
 use cosmwasm_std::{Addr, Deps};
 
@@ -14,8 +14,8 @@ pub fn resolve_path(deps: Deps, path: AndrAddr) -> Result<Addr, ContractError> {
 pub fn subdir(
     deps: Deps,
     path: AndrAddr,
-    min: Option<(Addr, String)>,
-    max: Option<(Addr, String)>,
+    min: Option<AddressString>,
+    max: Option<AddressString>,
     limit: Option<u32>,
 ) -> Result<Vec<PathInfo>, ContractError> {
     validate_path_name(deps.api, path.to_string())?;

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -1,4 +1,8 @@
-use andromeda_std::{amp::AndrAddr, error::ContractError, os::vfs::validate_path_name};
+use andromeda_std::{
+    amp::AndrAddr,
+    error::ContractError,
+    os::vfs::{validate_path_name, AddressString},
+};
 use cosmwasm_std::{ensure, Addr, Api, Storage};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Map, MultiIndex};
 use serde::{Deserialize, Serialize};
@@ -210,8 +214,8 @@ pub fn get_subdir(
     storage: &dyn Storage,
     api: &dyn Api,
     pathname: AndrAddr,
-    min: Option<(Addr, String)>,
-    max: Option<(Addr, String)>,
+    min: Option<AddressString>,
+    max: Option<AddressString>,
     limit: Option<u32>,
 ) -> Result<Vec<PathInfo>, ContractError> {
     let address = resolve_pathname(storage, api, pathname, &mut vec![])?;

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -1,7 +1,7 @@
 use andromeda_std::{
     amp::AndrAddr,
     error::ContractError,
-    os::vfs::{validate_path_name, AddressString},
+    os::vfs::{validate_path_name, SubDirBound},
 };
 use cosmwasm_std::{ensure, Addr, Api, Storage};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Map, MultiIndex};
@@ -214,8 +214,8 @@ pub fn get_subdir(
     storage: &dyn Storage,
     api: &dyn Api,
     pathname: AndrAddr,
-    min: Option<AddressString>,
-    max: Option<AddressString>,
+    min: Option<SubDirBound>,
+    max: Option<SubDirBound>,
     limit: Option<u32>,
 ) -> Result<Vec<PathInfo>, ContractError> {
     let address = resolve_pathname(storage, api, pathname, &mut vec![])?;

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -209,13 +209,13 @@ pub enum ExecuteMsg {
 pub struct MigrateMsg {}
 
 #[cw_serde]
-pub struct AddressString {
+pub struct SubDirBound {
     address: Addr,
-    string: String,
+    name: String,
 }
-impl From<AddressString> for (Addr, String) {
-    fn from(val: AddressString) -> Self {
-        (val.address, val.string)
+impl From<SubDirBound> for (Addr, String) {
+    fn from(val: SubDirBound) -> Self {
+        (val.address, val.name)
     }
 }
 
@@ -227,8 +227,8 @@ pub enum QueryMsg {
     #[returns(Vec<PathDetails>)]
     SubDir {
         path: AndrAddr,
-        min: Option<AddressString>,
-        max: Option<AddressString>,
+        min: Option<SubDirBound>,
+        max: Option<SubDirBound>,
         limit: Option<u32>,
     },
     #[returns(Vec<String>)]

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -209,6 +209,17 @@ pub enum ExecuteMsg {
 pub struct MigrateMsg {}
 
 #[cw_serde]
+pub struct AddressString {
+    address: Addr,
+    string: String,
+}
+impl From<AddressString> for (Addr, String) {
+    fn from(val: AddressString) -> Self {
+        (val.address, val.string)
+    }
+}
+
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(Addr)]
@@ -216,8 +227,8 @@ pub enum QueryMsg {
     #[returns(Vec<PathDetails>)]
     SubDir {
         path: AndrAddr,
-        min: Option<(Addr, String)>,
-        max: Option<(Addr, String)>,
+        min: Option<AddressString>,
+        max: Option<AddressString>,
         limit: Option<u32>,
     },
     #[returns(Vec<String>)]


### PR DESCRIPTION
# Motivation
Resolves #360 

# Implementation
Replaced tuple of `Addr` and `String` in `QueryMsg::SubDir` to this custom struct:
```rust
pub struct SubDirBound {
    address: Addr,
    name: String,
}
```
Created implementation for the struct to work with `.map`
Updated VFS schema

# Testing
No tests were affected 
