### PR TITLE
Albert/make open auction an option and add a query

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -63,6 +63,10 @@ pub fn instantiate(
         contract.register_modules(info.sender.as_str(), deps.storage, msg.modules)?;
 
     if let Some(authorized_token_addresses) = msg.authorized_token_addresses {
+        if !authorized_token_addresses.is_empty() {
+            ADOContract::default().permission_action(SEND_NFT_ACTION, deps.storage)?;
+        }
+
         for token_address in authorized_token_addresses {
             let addr = token_address.get_raw_address(&deps.as_ref())?;
             ADOContract::set_permission(
@@ -170,7 +174,7 @@ fn handle_receive_cw721(
     ctx: ExecuteContext,
     msg: Cw721ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    ADOContract::default().is_permissioned_strict(
+    ADOContract::default().is_permissioned(
         ctx.deps.storage,
         ctx.env.clone(),
         SEND_NFT_ACTION,

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -2,8 +2,9 @@ use crate::state::{
     auction_infos, read_auction_infos, read_bids, BIDS, NEXT_AUCTION_ID, TOKEN_AUCTION_STATE,
 };
 use andromeda_non_fungible_tokens::auction::{
-    AuctionIdsResponse, AuctionInfo, AuctionStateResponse, Bid, BidsResponse, Cw721HookMsg,
-    ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, TokenAuctionState,
+    AuctionIdsResponse, AuctionInfo, AuctionStateResponse, AuthorizedAddressesResponse, Bid,
+    BidsResponse, Cw721HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
+    TokenAuctionState,
 };
 use andromeda_std::{
     ado_base::{
@@ -738,6 +739,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             token_id,
             token_address,
         } => encode_binary(&query_is_closed(deps, env, token_id, token_address)?),
+        QueryMsg::AuthorizedAddresses {} => encode_binary(&query_authorized_addresses(deps)?),
         _ => ADOContract::default().query(deps, env, msg),
     }
 }
@@ -870,6 +872,10 @@ fn query_owner_of(
     Ok(res)
 }
 
+fn query_authorized_addresses(deps: Deps) -> Result<AuthorizedAddressesResponse, ContractError> {
+    let addresses = ADOContract::default().query_permissioned_actors(deps, SEND_NFT_ACTION)?;
+    Ok(AuthorizedAddressesResponse { addresses })
+}
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     // New version

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -93,6 +93,10 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u64>,
     },
+    /// Gets all of the authorized addresses for the auction
+    #[returns(AuthorizedAddressesResponse)]
+    AuthorizedAddresses {},
+
     /// Gets the bids for the given auction id. Start_after starts indexing at 0.
     #[returns(BidsResponse)]
     Bids {
@@ -190,6 +194,11 @@ pub struct AuctionStateResponse {
     pub whitelist: Option<Vec<Addr>>,
     pub min_bid: Option<Uint128>,
     pub is_cancelled: bool,
+}
+
+#[cw_serde]
+pub struct AuthorizedAddressesResponse {
+    pub addresses: Vec<String>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/259

# Implementation
- Auction is permissioned only if the contract is instantiated with authorized addresses.
- Used `is_permissioned` to validate the received nft address in `handle_receive_cw721` function
- Added `query_permissioned_actors` query to the permission contract and used it to get the authorized addresses.

# Testing

- Auction contract unit test is upgraded with permission/permissionless test cases.
- Unit test for `query_permissioned_actors` is added to permission crate unit tests

# Notes
`query_permissioned_actors` is iterating over the permissions key space which might not an optimized solution. It can be improved if the permission system is using different indices (for example tuple) instead of usign action + actor directly
