### PR TITLE
[1.0.rc-1] Timestamp Query Removal from CW20-Staking

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -653,7 +653,6 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         QueryMsg::Stakers { start_after, limit } => {
             encode_binary(&query_stakers(deps, env, start_after, limit)?)
         }
-        QueryMsg::Timestamp {} => encode_binary(&query_timestamp(env)),
         _ => ADOContract::default().query(deps, env, msg),
     }
 }
@@ -727,10 +726,6 @@ fn query_stakers(
 ) -> Result<Vec<StakerResponse>, ContractError> {
     let start = start_after.as_deref();
     get_stakers(deps, &deps.querier, deps.api, &env, start, limit)
-}
-
-fn query_timestamp(env: Env) -> u64 {
-    env.block.time.seconds()
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -71,9 +71,6 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    /// Queries the current timestamp.
-    #[returns(u64)]
-    Timestamp {},
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation
Resolves #363 

# Implementation
Removed `QueryMsg::Timestamp` and its corresponding function from the CW20-Staking ADO.

# Testing
No tests were affected by this change.