### PR TITLE
[1.0.rc-1] WithdrawableBalance Removal from AndromedaQuery

### DIFF
--- a/contracts/ecosystem/andromeda-vault/src/contract.rs
+++ b/contracts/ecosystem/andromeda-vault/src/contract.rs
@@ -10,7 +10,7 @@ use andromeda_std::amp::{AndrAddr, Recipient};
 use andromeda_std::common::context::ExecuteContext;
 use andromeda_std::{
     ado_base::withdraw::{Withdrawal, WithdrawalType},
-    ado_base::{AndromedaQuery, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::InstantiateMsg as BaseInstantiateMsg,
     error::{from_semver, ContractError},
 };
 
@@ -435,10 +435,16 @@ fn query_balance(
 ) -> Result<Binary, ContractError> {
     if let Some(strategy) = strategy {
         let strategy_addr = STRATEGY_CONTRACT_ADDRESSES.load(deps.storage, strategy.to_string())?;
+        ensure!(false, ContractError::TemporarilyDisabled {});
         // DEV NOTE: Why does this ensure! a generic type when not using custom query?
+        // let query: QueryRequest<Empty> = QueryRequest::Wasm(WasmQuery::Smart {
+        //     contract_addr: strategy_addr,
+        //     msg: to_json_binary(&AndromedaQuery::WithdrawableBalance { address })?,
+        // });
+        // TODO: Below code to be replaced with above code once WithdrawableBalance is re-enabled
         let query: QueryRequest<Empty> = QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: strategy_addr,
-            msg: to_json_binary(&AndromedaQuery::WithdrawableBalance { address })?,
+            msg: to_json_binary(&Binary::default())?,
         });
         match deps.querier.raw_query(&to_json_binary(&query)?) {
             SystemResult::Ok(ContractResult::Ok(value)) => Ok(value),

--- a/contracts/ecosystem/andromeda-vault/src/testing/mock_querier.rs
+++ b/contracts/ecosystem/andromeda-vault/src/testing/mock_querier.rs
@@ -1,18 +1,15 @@
-use andromeda_std::ado_base::ownership::ContractOwnerResponse;
 //use andromeda_ecosystem::anchor_earn::PositionResponse;
 use andromeda_std::testing::mock_querier::MockAndromedaQuerier;
 use andromeda_std::{
-    ado_base::{AndromedaQuery, InstantiateMsg},
-    ado_contract::ADOContract,
-    amp::Recipient,
+    ado_base::InstantiateMsg, ado_contract::ADOContract, amp::Recipient,
     testing::mock_querier::MOCK_KERNEL_CONTRACT,
 };
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
-    to_json_binary, Binary, Coin, ContractResult, OwnedDeps, Querier, QuerierResult, QueryRequest,
-    SystemError, SystemResult, Uint128, WasmQuery,
+    Coin, OwnedDeps, Querier, QuerierResult, QueryRequest, SystemError, SystemResult, Uint128,
+    WasmQuery,
 };
 
 // This is here since anchor_earn is defunct now.
@@ -79,34 +76,35 @@ impl Querier for WasmMockQuerier {
 impl WasmMockQuerier {
     pub fn handle_query(&self, request: &QueryRequest<cosmwasm_std::Empty>) -> QuerierResult {
         match &request {
-            QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
-                match contract_addr.as_str() {
-                    MOCK_ANCHOR_CONTRACT => self.handle_anchor_balance_query(msg),
-                    _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
-                }
+            QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr,
+                msg: _,
+            }) => {
+                let _ = contract_addr.as_str();
+                MockAndromedaQuerier::default().handle_query(&self.base, request)
             }
             _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
         }
     }
 
-    fn handle_anchor_balance_query(&self, msg: &Binary) -> QuerierResult {
-        match from_json(msg).unwrap() {
-            AndromedaQuery::WithdrawableBalance { address } => {
-                let msg_response = PositionResponse {
-                    recipient: Recipient::from_string(address),
-                    aust_amount: Uint128::from(10u128),
-                };
-                SystemResult::Ok(ContractResult::Ok(to_json_binary(&msg_response).unwrap()))
-            }
-            AndromedaQuery::Owner {} => {
-                let msg_response = ContractOwnerResponse {
-                    owner: MOCK_VAULT_CONTRACT.to_owned(),
-                };
-                SystemResult::Ok(ContractResult::Ok(to_json_binary(&msg_response).unwrap()))
-            }
-            _ => panic!("Unsupported Query"),
-        }
-    }
+    // fn handle_anchor_balance_query(&self, msg: &Binary) -> QuerierResult {
+    //     match from_json(msg).unwrap() {
+    //         AndromedaQuery::WithdrawableBalance { address } => {
+    //             let msg_response = PositionResponse {
+    //                 recipient: Recipient::from_string(address),
+    //                 aust_amount: Uint128::from(10u128),
+    //             };
+    //             SystemResult::Ok(ContractResult::Ok(to_json_binary(&msg_response).unwrap()))
+    //         }
+    //         AndromedaQuery::Owner {} => {
+    //             let msg_response = ContractOwnerResponse {
+    //                 owner: MOCK_VAULT_CONTRACT.to_owned(),
+    //             };
+    //             SystemResult::Ok(ContractResult::Ok(to_json_binary(&msg_response).unwrap()))
+    //         }
+    //         _ => panic!("Unsupported Query"),
+    //     }
+    // }
 
     pub fn new(base: MockQuerier) -> Self {
         WasmMockQuerier { base }

--- a/contracts/ecosystem/andromeda-vault/src/testing/mod.rs
+++ b/contracts/ecosystem/andromeda-vault/src/testing/mod.rs
@@ -2,7 +2,7 @@ mod mock_querier;
 
 use self::mock_querier::{MOCK_ANCHOR_CONTRACT, MOCK_VAULT_CONTRACT};
 use crate::contract::*;
-use crate::testing::mock_querier::{mock_dependencies_custom, PositionResponse};
+use crate::testing::mock_querier::mock_dependencies_custom;
 use andromeda_ecosystem::vault::{
     DepositMsg, ExecuteMsg, InstantiateMsg, QueryMsg, StrategyAddressResponse, StrategyType,
     YieldStrategy, BALANCES, STRATEGY_CONTRACT_ADDRESSES,

--- a/contracts/ecosystem/andromeda-vault/src/testing/mod.rs
+++ b/contracts/ecosystem/andromeda-vault/src/testing/mod.rs
@@ -847,18 +847,21 @@ fn test_query_strategy_balance() {
         strategy: Some(StrategyType::Anchor),
         denom: None,
     };
+    let resp = query(deps.as_ref(), env, single_query).unwrap_err();
+    assert_eq!(resp, ContractError::TemporarilyDisabled {});
 
-    let resp = query(deps.as_ref(), env, single_query).unwrap();
-    let balance: PositionResponse = from_json(resp).unwrap();
-    assert_eq!(Uint128::from(10u128), balance.aust_amount);
-    assert_eq!(
-        "depositor".to_string(),
-        balance
-            .recipient
-            .address
-            .get_raw_address(&deps.as_ref())
-            .unwrap()
-    );
+    // let resp = query(deps.as_ref(), env, single_query).unwrap();
+
+    // let balance: PositionResponse = from_json(resp).unwrap();
+    // assert_eq!(Uint128::from(10u128), balance.aust_amount);
+    // assert_eq!(
+    //     "depositor".to_string(),
+    //     balance
+    //         .recipient
+    //         .address
+    //         .get_raw_address(&deps.as_ref())
+    //         .unwrap()
+    // );
 }
 
 #[test]

--- a/packages/std/src/ado_base/mod.rs
+++ b/packages/std/src/ado_base/mod.rs
@@ -81,14 +81,12 @@ pub enum AndromedaQuery {
     #[cfg(feature = "modules")]
     #[returns(Vec<String>)]
     ModuleIds {},
-    #[returns(::cosmwasm_std::BalanceResponse)]
-    WithdrawableBalance { address: AndrAddr },
     #[returns(Vec<self::permissioning::PermissionInfo>)]
     Permissions {
         actor: AndrAddr,
         limit: Option<u32>,
         start_after: Option<String>,
     },
-    #[returns(Vec<String>)]
+    #[returns(Vec<self::permissioning::PermissionedActionsResponse>)]
     PermissionedActions {},
 }

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -32,6 +32,11 @@ pub struct PermissionInfo {
     pub actor: String,
 }
 
+#[cw_serde]
+pub struct PermissionedActionsResponse {
+    pub actions: Vec<String>,
+}
+
 /// An enum to represent a user's permission for an action
 ///
 /// - **Blacklisted** - The user cannot perform the action until after the provided expiration


### PR DESCRIPTION
# Motivation
Resolves #349 

# Implementation
The `withdraw` feature was removed in #321, and it was required to enable `WithdrawableBalance` in `AndromedaQuery`. The query was no longer implemented, so I removed it.
Disabled providing a strategy while querying the balance in the vault contract since it depends on `WithdrawableBalance`.


# Testing
Adjusted a unit test that used `WithdrawableBalance` in the Vault ADO, it now expects`ContractError::TemporarilyDisbaled`
