### PR TITLE
update migrate functions to use common migrate function:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -83,7 +82,6 @@ dependencies = [
  "cw2 1.1.2",
  "enum-repr",
  "prost 0.9.0",
- "semver",
 ]
 
 [[package]]
@@ -102,7 +100,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "cw721 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -119,7 +116,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "schemars",
- "semver",
  "serde",
 ]
 
@@ -138,7 +134,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -156,7 +151,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "cw20-base",
- "semver",
 ]
 
 [[package]]
@@ -174,7 +168,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -193,7 +186,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "cw20-base",
- "semver",
 ]
 
 [[package]]
@@ -210,7 +202,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -235,7 +226,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -297,7 +287,6 @@ dependencies = [
  "osmosis-std-derive 0.15.3",
  "prost 0.11.9",
  "schemars",
- "semver",
  "serde",
  "serde-cw-value",
  "serde-json-wasm 1.0.1",
@@ -319,7 +308,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -346,7 +334,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -365,7 +352,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "hex",
- "semver",
  "serde",
  "sha2 0.10.8",
 ]
@@ -409,7 +395,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -426,7 +411,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -443,7 +427,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -479,7 +462,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -492,6 +474,7 @@ dependencies = [
  "cw-asset",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20",
  "cw20-base",
  "cw721 0.18.0",
@@ -542,7 +525,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -574,7 +556,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -591,7 +572,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -604,7 +584,6 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "semver",
  "serde",
 ]
 
@@ -621,7 +600,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -14,7 +14,6 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 andromeda-app = { path = "../../../packages/andromeda-app" }
 andromeda-std = { workspace = true, features = ["instantiate"] }
 enum-repr = { workspace = true }

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -33,7 +33,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw20 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["module_hooks"] }
 andromeda-data-storage = { workspace = true }

--- a/contracts/data-storage/andromeda-primitive/src/contract.rs
+++ b/contracts/data-storage/andromeda-primitive/src/contract.rs
@@ -1,16 +1,16 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{ensure, Binary, Deps, DepsMut, Env, MessageInfo, Response};
-use cw2::{get_contract_version, set_contract_version};
+use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cw2::set_contract_version;
 
-use andromeda_data_storage::primitive::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_data_storage::primitive::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     ado_contract::ADOContract,
     common::{context::ExecuteContext, encode_binary},
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
-use semver::Version;
 
 use crate::{
     execute::handle_execute,
@@ -65,36 +65,7 @@ pub fn execute(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/ecosystem/andromeda-vault/Cargo.toml
+++ b/contracts/ecosystem/andromeda-vault/Cargo.toml
@@ -14,7 +14,6 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 cw-utils = { workspace = true }
 
 andromeda-ecosystem = { workspace = true }

--- a/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
+++ b/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw2 = { workspace = true }
 schemars = { version = "0.8.10" }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
+++ b/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
@@ -1,5 +1,5 @@
 use andromeda_finance::cross_chain_swap::{
-    ExecuteMsg, InstantiateMsg, MigrateMsg, OsmosisSwapResponse, QueryMsg,
+    ExecuteMsg, InstantiateMsg, OsmosisSwapResponse, QueryMsg,
 };
 
 use andromeda_std::{
@@ -8,17 +8,23 @@ use andromeda_std::{
         messages::{AMPMsg, AMPPkt},
         AndrAddr,
     },
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
-use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
+use andromeda_std::{
+    ado_contract::ADOContract,
+    common::{
+        context::ExecuteContext,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
+};
+
 use cosmwasm_std::{
-    attr, ensure, entry_point, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Reply,
-    Response, StdError, SubMsg,
+    attr, entry_point, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdError, SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 
 use cw_utils::one_coin;
-use semver::Version;
 
 use crate::{
     dex::{execute_swap_osmo, parse_swap_reply, MSG_FORWARD_ID, MSG_SWAP_ID},
@@ -218,36 +224,7 @@ fn execute_swap_and_forward(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw20 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -1,25 +1,24 @@
 use crate::state::{ACCOUNTS, ALLOWED_COIN};
 
 use andromeda_finance::rate_limiting_withdrawals::{
-    AccountDetails, CoinAllowance, ExecuteMsg, InstantiateMsg, MigrateMsg, MinimumFrequency,
-    QueryMsg,
+    AccountDetails, CoinAllowance, ExecuteMsg, InstantiateMsg, MinimumFrequency, QueryMsg,
 };
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::common::context::ExecuteContext;
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     common::encode_binary,
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 
 use cosmwasm_std::{
     ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, Uint128,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 
 use cw_utils::{nonpayable, one_coin};
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-rate-limiting-withdrawals";
@@ -278,36 +277,7 @@ fn execute_withdraw(ctx: ExecuteContext, amount: Uint128) -> Result<Response, Co
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[entry_point]

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-timelock/src/contract.rs
+++ b/contracts/finance/andromeda-timelock/src/contract.rs
@@ -1,23 +1,20 @@
 use andromeda_finance::timelock::{
     Escrow, EscrowCondition, ExecuteMsg, GetLockedFundsForRecipientResponse,
-    GetLockedFundsResponse, InstantiateMsg, MigrateMsg, QueryMsg,
+    GetLockedFundsResponse, InstantiateMsg, QueryMsg,
 };
 
 use andromeda_std::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg,
-    amp::Recipient,
-    common::encode_binary,
-    error::{from_semver, ContractError},
+    ado_base::InstantiateMsg as BaseInstantiateMsg, amp::Recipient, common::encode_binary,
+    error::ContractError,
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
     attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
-
-use semver::Version;
+use cw2::set_contract_version;
 
 use crate::state::{escrows, get_key, get_keys_for_recipient};
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-timelock";
@@ -197,36 +194,7 @@ fn execute_release_specific_funds(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -10,6 +10,7 @@ use cw2::set_contract_version;
 use andromeda_finance::validator_staking::{
     is_validator, ExecuteMsg, InstantiateMsg, QueryMsg, UnstakingTokens,
 };
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
@@ -309,6 +310,11 @@ fn query_unstaked_tokens(deps: Deps) -> Result<Vec<UnstakingTokens>, ContractErr
         res.push(data.unwrap());
     }
     Ok(res)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw-asset = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -9,23 +9,19 @@ use cosmwasm_std::{
     ensure, Binary, Coin, CosmosMsg, Deps, DepsMut, DistributionMsg, Env, GovMsg, MessageInfo,
     QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw_asset::AssetInfo;
 
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use cw_utils::nonpayable;
-use semver::Version;
 use std::cmp;
 
 use crate::state::{
     batches, get_all_batches_with_ids, get_claimable_batches_with_ids, save_new_batch, Batch,
     CONFIG,
 };
-use andromeda_finance::vesting::{
-    BatchResponse, Config, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-};
-use andromeda_std::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary, error::from_semver,
-};
+use andromeda_finance::vesting::{BatchResponse, Config, ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::{ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary};
 
 const CONTRACT_NAME: &str = "crates.io:andromeda-vesting";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -526,36 +522,7 @@ fn get_set_withdraw_address_msg(address: String) -> CosmosMsg {
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw-asset = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -24,7 +24,6 @@ cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw20-base = { workspace = true }
 cw-asset = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw20-base = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -1,26 +1,29 @@
-use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
     ado_base::{
         hooks::AndromedaHook, AndromedaMsg, AndromedaQuery, InstantiateMsg as BaseInstantiateMsg,
     },
     ado_contract::ADOContract,
     common::Funds,
-    common::{context::ExecuteContext, encode_binary},
-    error::{from_semver, ContractError},
+    common::{
+        context::ExecuteContext,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
+    error::ContractError,
 };
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, from_json, to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env,
-    MessageInfo, Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
+    from_json, to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
 };
 
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw20::{Cw20Coin, Cw20ExecuteMsg};
 use cw20_base::{
     contract::{execute as execute_cw20, instantiate as cw20_instantiate, query as cw20_query},
     state::BALANCES,
 };
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-cw20";
@@ -280,36 +283,7 @@ fn filter_out_cw20_messages(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw-asset = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw-asset = { workspace = true }
-semver = { workspace = true }
 sha2 = "0.10.6"
 hex = "0.4.3"
 serde = "1.0.163"

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["module_hooks"] }
 andromeda-modules = { workspace = true }

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -1,18 +1,21 @@
 #[cfg(not(feature = "library"))]
-use andromeda_modules::address_list::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_modules::address_list::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_modules::address_list::{IncludesAddressResponse, IsInclusiveResponse};
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     ado_contract::ADOContract,
-    common::{context::ExecuteContext, encode_binary},
-    error::{from_semver, ContractError},
+    common::{
+        context::ExecuteContext,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
+    error::ContractError,
 };
 
 use cosmwasm_std::{attr, ensure, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError};
 use cosmwasm_std::{entry_point, to_json_binary};
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw_utils::nonpayable;
-use semver::Version;
 
 use crate::state::{add_address, includes_address, remove_address, IS_INCLUSIVE};
 // version info for migration info
@@ -142,36 +145,7 @@ fn execute_add_addresses(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw20 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["module_hooks"] }
 andromeda-modules = { workspace = true }

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use crate::state::{Config, CONFIG};
 use andromeda_modules::rates::{
-    calculate_fee, ExecuteMsg, InstantiateMsg, MigrateMsg, PaymentAttribute, PaymentsResponse,
-    QueryMsg, RateInfo,
+    calculate_fee, ExecuteMsg, InstantiateMsg, PaymentAttribute, PaymentsResponse, QueryMsg,
+    RateInfo,
 };
 use andromeda_std::{
     ado_base::{
@@ -10,18 +10,22 @@ use andromeda_std::{
         InstantiateMsg as BaseInstantiateMsg,
     },
     ado_contract::ADOContract,
-    common::{context::ExecuteContext, deduct_funds, encode_binary, Funds},
-    error::{from_semver, ContractError},
+    common::{
+        context::ExecuteContext,
+        deduct_funds, encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        Funds,
+    },
+    error::ContractError,
 };
 
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     attr, coin, ensure, Binary, Coin, Deps, DepsMut, Env, Event, MessageInfo, Response, SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw20::Cw20Coin;
 use cw_utils::nonpayable;
-use semver::Version;
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-rates";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -98,36 +102,7 @@ fn execute_update_rates(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/modules/andromeda-shunting/src/contract.rs
+++ b/contracts/modules/andromeda-shunting/src/contract.rs
@@ -6,7 +6,11 @@ use andromeda_modules::shunting::{
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     ado_contract::ADOContract,
-    common::{context::ExecuteContext, encode_binary},
+    common::{
+        context::ExecuteContext,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
     error::ContractError,
 };
 use cosmwasm_std::{
@@ -93,6 +97,11 @@ fn execute_update_expression(
     EXPRESSIONS.save(deps.storage, &expressions)?;
 
     Ok(Response::new().add_attributes(vec![attr("action", "update_expression")]))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw721 = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw721 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -30,7 +30,6 @@ cw-storage-plus = { workspace = true }
 cw721-base = { workspace = true }
 cw721 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-non-fungible-tokens = { workspace = true }
 andromeda-std = { workspace = true, features = ["modules"] }

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw721 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -3,8 +3,7 @@ use crate::state::{
 };
 
 use andromeda_non_fungible_tokens::marketplace::{
-    Cw721HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, SaleIdsResponse,
-    SaleStateResponse, Status,
+    Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, SaleIdsResponse, SaleStateResponse, Status,
 };
 use andromeda_std::ado_contract::ADOContract;
 
@@ -14,12 +13,16 @@ use andromeda_std::common::expiration::{
 };
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
-    common::{encode_binary, rates::get_tax_amount, Funds},
-    error::{from_semver, ContractError},
+    common::{
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        rates::get_tax_amount,
+        Funds,
+    },
+    error::ContractError,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, OwnerOfResponse};
-use semver::Version;
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -574,36 +577,7 @@ fn query_owner_of(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 // #[cfg(test)]

--- a/contracts/os/andromeda-adodb/src/contract.rs
+++ b/contracts/os/andromeda-adodb/src/contract.rs
@@ -4,16 +4,19 @@ use crate::state::{
 };
 use andromeda_std::ado_base::InstantiateMsg as BaseInstantiateMsg;
 use andromeda_std::ado_contract::ADOContract;
-use andromeda_std::common::encode_binary;
-use andromeda_std::error::{from_semver, ContractError};
+use andromeda_std::common::{
+    encode_binary,
+    migrate::{migrate as do_migrate, MigrateMsg},
+};
+use andromeda_std::error::ContractError;
 use andromeda_std::os::adodb::{
-    ADOMetadata, ADOVersion, ActionFee, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
+    ADOMetadata, ADOVersion, ActionFee, ExecuteMsg, InstantiateMsg, QueryMsg,
 };
 use cosmwasm_std::{
     attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Order, Reply, Response,
     StdError, StdResult, Storage,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use semver::Version;
 
@@ -264,36 +267,7 @@ fn execute_update_publisher(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -28,7 +28,6 @@ cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 andromeda-std = { workspace = true }
-semver = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -26,7 +26,6 @@ cosmwasm-std = { workspace = true, features = ["ibc3"] }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 enum-repr = { workspace = true }
 serde-json-wasm = "1.0.0"
 serde-cw-value = "0.7.0"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -27,7 +27,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -1,14 +1,15 @@
 use andromeda_std::ado_contract::ADOContract;
 
-use andromeda_std::os::vfs::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
+use andromeda_std::os::vfs::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary, error::ContractError,
 };
+
 use cosmwasm_std::{
-    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
 };
-use cw2::{get_contract_version, set_contract_version};
-use semver::Version;
+use cw2::set_contract_version;
 
 use crate::{execute, query};
 
@@ -89,40 +90,7 @@ pub fn execute(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    let contract = ADOContract::default();
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // Update the ADOContract's version
-    contract.execute_update_version(deps)?;
-
-    Ok(Response::default())
-}
-
-fn from_semver(err: semver::Error) -> StdError {
-    StdError::generic_err(format!("Semver: {err}"))
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -116,9 +116,6 @@ pub enum ExecuteMsg {
     AssignAppToComponents {},
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -25,10 +25,6 @@ pub enum ExecuteMsg {
     },
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-ecosystem/src/vault.rs
+++ b/packages/andromeda-ecosystem/src/vault.rs
@@ -131,6 +131,3 @@ pub struct StrategyAddressResponse {
     pub strategy: StrategyType,
     pub address: String,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-finance/src/cross_chain_swap.rs
+++ b/packages/andromeda-finance/src/cross_chain_swap.rs
@@ -19,10 +19,6 @@ pub enum ExecuteMsg {
     },
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
+++ b/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
@@ -56,10 +56,6 @@ pub enum ExecuteMsg {
     Withdraws { amount: Uint128 },
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -60,10 +60,6 @@ pub enum ExecuteMsg {
     Send {},
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/timelock.rs
+++ b/packages/andromeda-finance/src/timelock.rs
@@ -140,9 +140,6 @@ pub enum ExecuteMsg {
         recipient_addr: Option<String>,
     },
 }
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
 
 #[andr_query]
 #[cw_serde]

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -123,7 +123,3 @@ pub struct BatchResponse {
     /// The time at which the last claim took place in seconds.
     pub last_claimed_release_time: u64,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -47,10 +47,6 @@ pub enum ExecuteMsg {
     Send {},
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-fungible-tokens/src/airdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/airdrop.rs
@@ -76,6 +76,3 @@ pub struct IsClaimedResponse {
 pub struct TotalClaimedResponse {
     pub total_claimed: Uint128,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-fungible-tokens/src/cw20.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20.rs
@@ -169,10 +169,6 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
     }
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
@@ -98,6 +98,3 @@ pub struct TokenAddressResponse {
     /// The address of the token being sold
     pub address: String,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -224,6 +224,3 @@ pub struct StakerResponse {
     /// The staker's pending rewards represented as [(token_1, amount_1), ..., (token_n, amount_n)]
     pub pending_rewards: Vec<(String, Uint128)>,
 }
-
-#[cw_serde]
-pub enum MigrateMsg {}

--- a/packages/andromeda-fungible-tokens/src/lockdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/lockdrop.rs
@@ -102,6 +102,3 @@ pub struct UserInfoResponse {
     pub is_lockdrop_claimed: bool,
     pub withdrawal_flag: bool,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -18,9 +18,6 @@ pub enum ExecuteMsg {
     AddAddresses { addresses: Vec<String> },
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-modules/src/rates.rs
+++ b/packages/andromeda-modules/src/rates.rs
@@ -16,9 +16,6 @@ pub enum ExecuteMsg {
     UpdateRates { rates: Vec<RateInfo> },
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-modules/src/shunting.rs
+++ b/packages/andromeda-modules/src/shunting.rs
@@ -14,9 +14,6 @@ pub enum ExecuteMsg {
     UpdateExpressions { expressions: Vec<String> },
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -206,7 +206,3 @@ pub struct IsClosedResponse {
 pub struct IsClaimedResponse {
     pub is_claimed: bool,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -106,7 +106,3 @@ pub struct CrowdfundMintMsg {
     /// Any custom extension used by this contract
     pub extension: TokenExtension,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -330,7 +330,3 @@ impl From<QueryMsg> for Cw721QueryMsg<QueryMsg> {
         }
     }
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -109,7 +109,3 @@ pub struct SaleStateResponse {
 pub struct SaleIdsResponse {
     pub sale_ids: Vec<Uint128>,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -24,6 +24,7 @@ schemars = "0.8.10"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 semver = { workspace = true }
 cw20 = { version = "1.0.1"}
+cw2 = { workspace = true }
 cw20-base = { workspace = true, features = ["library"] }
 cw721-base = { workspace = true }
 cw-utils = { workspace = true }

--- a/packages/std/src/common/migrate.rs
+++ b/packages/std/src/common/migrate.rs
@@ -1,0 +1,50 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{ensure, DepsMut, Response};
+use cw2::{get_contract_version, set_contract_version};
+use semver::Version;
+
+use crate::{
+    ado_contract::ADOContract,
+    error::{from_semver, ContractError},
+};
+
+#[cw_serde]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {}
+
+pub fn migrate(
+    deps: DepsMut,
+    contract_name: &str,
+    contract_version: &str,
+) -> Result<Response, ContractError> {
+    // New version
+    let version: Version = contract_version.parse().map_err(from_semver)?;
+
+    // Old version
+    let stored = get_contract_version(deps.storage)?;
+    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
+
+    let contract = ADOContract::default();
+
+    ensure!(
+        stored.contract == contract_name,
+        ContractError::CannotMigrate {
+            previous_contract: stored.contract,
+        }
+    );
+
+    // New version has to be newer/greater than the old version
+    ensure!(
+        storage_version < version,
+        ContractError::CannotMigrate {
+            previous_contract: stored.version,
+        }
+    );
+
+    set_contract_version(deps.storage, contract_name, contract_version)?;
+
+    // Update the ADOContract's version
+    contract.execute_update_version(deps)?;
+
+    Ok(Response::default())
+}

--- a/packages/std/src/common/mod.rs
+++ b/packages/std/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod expiration;
+pub mod migrate;
 pub mod queries;
 pub mod rates;
 pub mod response;

--- a/packages/std/src/os/adodb.rs
+++ b/packages/std/src/os/adodb.rs
@@ -61,9 +61,6 @@ impl ActionFee {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 pub struct ADOMetadata {
     pub publisher: String,
     pub latest_version: String,

--- a/packages/std/src/os/economics.rs
+++ b/packages/std/src/os/economics.rs
@@ -56,9 +56,6 @@ pub enum Cw20HookMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Queries the current balance for a given AndrAddr and asset tuple

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -64,9 +64,6 @@ pub enum InternalMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 pub struct ChannelInfoResponse {
     pub ics20: Option<String>,
     pub direct: Option<String>,

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -109,9 +109,6 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(Addr)]


### PR DESCRIPTION
# Motivation
Resolves https://github.com/andromedaprotocol/andromeda-core/issues/259

# Implementation
- Added `migrate` function to `packages/std/src/common/migrate.rs`.
- Imported `migrate` function as `do_migrate` and updated all migrate functions to use it
- Removed duplicated `MigrateMsg` from packages.