### PR TITLE
updated migrate functions to use common migrate function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -66,7 +65,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
  "prost 0.9.0",
- "semver",
 ]
 
 [[package]]
@@ -84,7 +82,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "cw721 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -101,7 +98,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "schemars",
- "semver",
  "serde",
 ]
 
@@ -120,7 +116,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -139,7 +134,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "cw20-base",
- "semver",
 ]
 
 [[package]]
@@ -157,7 +151,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -177,7 +170,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "cw20-base",
- "semver",
 ]
 
 [[package]]
@@ -193,7 +185,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -218,7 +209,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -278,7 +268,6 @@ dependencies = [
  "osmosis-std-derive 0.15.3",
  "prost 0.11.9",
  "schemars",
- "semver",
  "serde",
  "serde-cw-value",
  "serde-json-wasm 1.0.1",
@@ -301,7 +290,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -327,7 +315,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721 0.18.0",
- "semver",
 ]
 
 [[package]]
@@ -347,7 +334,6 @@ dependencies = [
  "cw2 1.1.2",
  "cw20",
  "hex",
- "semver",
  "serde",
  "sha2 0.10.8",
 ]
@@ -391,7 +377,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -409,7 +394,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -426,7 +410,6 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20",
- "semver",
 ]
 
 [[package]]
@@ -443,7 +426,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -510,7 +492,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -525,7 +506,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -542,7 +522,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]
@@ -555,7 +534,6 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "semver",
  "serde",
 ]
 
@@ -572,7 +550,6 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "semver",
 ]
 
 [[package]]

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -14,7 +14,6 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 andromeda-app = { path = "../../../packages/andromeda-app" }
 andromeda-std = { workspace = true }
 

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -1,15 +1,14 @@
 use crate::reply::on_component_instantiation;
 use crate::state::{add_app_component, create_cross_chain_message, ADO_ADDRESSES, APP_NAME};
-use andromeda_app::app::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_app::app::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::amp::AndrAddr;
 use andromeda_std::common::context::ExecuteContext;
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::common::reply::ReplyId;
 use andromeda_std::os::vfs::{convert_component_name, ExecuteMsg as VFSExecuteMsg};
 use andromeda_std::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg,
-    common::encode_binary,
-    error::{from_semver, ContractError},
+    ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary, error::ContractError,
 };
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -17,10 +16,8 @@ use cosmwasm_std::{
     ensure, wasm_execute, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
     SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
 
 use crate::{execute, query};
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-app-contract";
@@ -206,31 +203,7 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -30,7 +30,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw20 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["module_hooks"] }
 andromeda-data-storage = { workspace = true }

--- a/contracts/data-storage/andromeda-primitive/src/contract.rs
+++ b/contracts/data-storage/andromeda-primitive/src/contract.rs
@@ -1,16 +1,16 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{ensure, Binary, Deps, DepsMut, Env, MessageInfo, Response};
-use cw2::{get_contract_version, set_contract_version};
+use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cw2::set_contract_version;
 
-use andromeda_data_storage::primitive::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_data_storage::primitive::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     ado_contract::ADOContract,
     common::{context::ExecuteContext, encode_binary},
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
-use semver::Version;
 
 use crate::{
     execute::handle_execute,
@@ -65,31 +65,7 @@ pub fn execute(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/ecosystem/andromeda-vault/Cargo.toml
+++ b/contracts/ecosystem/andromeda-vault/Cargo.toml
@@ -14,7 +14,6 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 cw-utils = { workspace = true }
 
 andromeda-ecosystem = { workspace = true  }

--- a/contracts/ecosystem/andromeda-vault/src/contract.rs
+++ b/contracts/ecosystem/andromeda-vault/src/contract.rs
@@ -1,6 +1,6 @@
 use andromeda_ecosystem::vault::{
-    DepositMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StrategyAddressResponse,
-    StrategyType, BALANCES, STRATEGY_CONTRACT_ADDRESSES,
+    DepositMsg, ExecuteMsg, InstantiateMsg, QueryMsg, StrategyAddressResponse, StrategyType,
+    BALANCES, STRATEGY_CONTRACT_ADDRESSES,
 };
 use andromeda_std::ado_base::ownership::ContractOwnerResponse;
 use andromeda_std::ado_contract::ADOContract;
@@ -8,10 +8,11 @@ use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::amp::{AndrAddr, Recipient};
 
 use andromeda_std::common::context::ExecuteContext;
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::{
     ado_base::withdraw::{Withdrawal, WithdrawalType},
     ado_base::InstantiateMsg as BaseInstantiateMsg,
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 
 use cosmwasm_std::{
@@ -19,9 +20,8 @@ use cosmwasm_std::{
     ContractResult, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Order, QueryRequest, Reply,
     ReplyOn, Response, StdError, SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw_utils::nonpayable;
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-vault";
@@ -388,31 +388,7 @@ fn execute_update_strategy(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
+++ b/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true}
 cw2 = { workspace = true }
 schemars = { version = "0.8.10" }
 serde = {version = "1.0.127", default-features = false, features = ["derive"] }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
+++ b/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
@@ -1,5 +1,5 @@
 use andromeda_finance::cross_chain_swap::{
-    ExecuteMsg, InstantiateMsg, MigrateMsg, OsmosisSwapResponse, QueryMsg,
+    ExecuteMsg, InstantiateMsg, OsmosisSwapResponse, QueryMsg,
 };
 
 use andromeda_std::{
@@ -8,17 +8,22 @@ use andromeda_std::{
         messages::{AMPMsg, AMPPkt},
         AndrAddr,
     },
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
-use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
+use andromeda_std::{
+    ado_contract::ADOContract,
+    common::{
+        context::ExecuteContext,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
+};
 use cosmwasm_std::{
-    attr, ensure, entry_point, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Reply,
-    Response, StdError, SubMsg,
+    attr, entry_point, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdError, SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 
 use cw_utils::one_coin;
-use semver::Version;
 
 use crate::{
     dex::{execute_swap_osmo, parse_swap_reply, MSG_FORWARD_ID, MSG_SWAP_ID},
@@ -218,31 +223,7 @@ fn execute_swap_and_forward(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw20 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -1,28 +1,27 @@
 use crate::state::{ACCOUNTS, ALLOWED_COIN};
 
 use andromeda_finance::rate_limiting_withdrawals::{
-    AccountDetails, CoinAllowance, ExecuteMsg, InstantiateMsg, MigrateMsg, MinimumFrequency,
-    QueryMsg,
+    AccountDetails, CoinAllowance, ExecuteMsg, InstantiateMsg, MinimumFrequency, QueryMsg,
 };
 use andromeda_std::ado_base::ownership::OwnershipMessage;
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::common::actions::call_action;
 use andromeda_std::common::context::ExecuteContext;
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::common::Milliseconds;
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     common::encode_binary,
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 
 use cosmwasm_std::{
     ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, Uint128,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 
 use cw_utils::{nonpayable, one_coin};
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-rate-limiting-withdrawals";
@@ -294,31 +293,7 @@ fn execute_withdraw(ctx: ExecuteContext, amount: Uint128) -> Result<Response, Co
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[entry_point]

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -1,23 +1,28 @@
 use crate::state::SPLITTER;
 use andromeda_finance::splitter::{
     validate_recipient_list, AddressPercent, ExecuteMsg, GetSplitterConfigResponse, InstantiateMsg,
-    MigrateMsg, QueryMsg, Splitter,
+    QueryMsg, Splitter,
 };
 
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     amp::messages::AMPPkt,
-    common::{actions::call_action, encode_binary, Milliseconds},
-    error::{from_semver, ContractError},
+    common::{
+        actions::call_action,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        Milliseconds,
+    },
+    error::ContractError,
 };
+
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
     attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Reply, Response, StdError, SubMsg, Uint128,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw_utils::nonpayable;
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-splitter";
@@ -297,31 +302,7 @@ fn execute_update_lock(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-timelock/src/contract.rs
+++ b/contracts/finance/andromeda-timelock/src/contract.rs
@@ -1,21 +1,20 @@
 use andromeda_finance::timelock::{
     Escrow, EscrowCondition, ExecuteMsg, GetLockedFundsForRecipientResponse,
-    GetLockedFundsResponse, InstantiateMsg, MigrateMsg, QueryMsg,
+    GetLockedFundsResponse, InstantiateMsg, QueryMsg,
 };
 
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     amp::Recipient,
     common::{actions::call_action, encode_binary},
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
     attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
-
-use semver::Version;
+use cw2::set_contract_version;
 
 use crate::state::{escrows, get_key, get_keys_for_recipient};
 
@@ -208,31 +207,7 @@ fn execute_release_specific_funds(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw-asset = { workspace = true}
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -9,23 +9,19 @@ use cosmwasm_std::{
     ensure, Binary, Coin, CosmosMsg, Deps, DepsMut, DistributionMsg, Env, GovMsg, MessageInfo,
     QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw_asset::AssetInfo;
 
 use cw_utils::nonpayable;
-use semver::Version;
 use std::cmp;
 
 use crate::state::{
     batches, get_all_batches_with_ids, get_claimable_batches_with_ids, save_new_batch, Batch,
     CONFIG,
 };
-use andromeda_finance::vesting::{
-    BatchResponse, Config, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-};
-use andromeda_std::{
-    ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary, error::from_semver,
-};
+use andromeda_finance::vesting::{BatchResponse, Config, ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
+use andromeda_std::{ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary};
 
 const CONTRACT_NAME: &str = "crates.io:andromeda-vesting";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -542,31 +538,7 @@ fn get_set_withdraw_address_msg(address: String) -> CosmosMsg {
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-finance = { workspace = true }

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -1,14 +1,18 @@
 use crate::state::SPLITTER;
 use andromeda_finance::weighted_splitter::{
     AddressWeight, ExecuteMsg, GetSplitterConfigResponse, GetUserWeightResponse, InstantiateMsg,
-    MigrateMsg, QueryMsg, Splitter,
+    QueryMsg, Splitter,
 };
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     ado_contract::ADOContract,
     amp::Recipient,
-    common::{context::ExecuteContext, encode_binary},
-    error::{from_semver, ContractError},
+    common::{
+        context::ExecuteContext,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
+    error::ContractError,
 };
 
 use cosmwasm_std::{
@@ -17,9 +21,8 @@ use cosmwasm_std::{
 };
 
 use cw_utils::{nonpayable, Expiration};
-use semver::Version;
 
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-weighted-distribution-splitter";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -447,31 +450,7 @@ fn execute_update_lock(ctx: ExecuteContext, lock_time: u64) -> Result<Response, 
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[entry_point]

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true}
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw-asset = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -1,6 +1,6 @@
 use andromeda_fungible_tokens::cw20_exchange::{
-    Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, Sale, SaleAssetsResponse,
-    SaleResponse, TokenAddressResponse,
+    Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, Sale, SaleAssetsResponse, SaleResponse,
+    TokenAddressResponse,
 };
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
@@ -9,20 +9,20 @@ use andromeda_std::{
         actions::call_action,
         context::ExecuteContext,
         expiration::{expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO},
+        migrate::{migrate as do_migrate, MigrateMsg},
     },
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 use cosmwasm_std::{
     attr, coin, ensure, entry_point, from_json, to_json_binary, wasm_execute, BankMsg, Binary,
     BlockInfo, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg,
     Uint128,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
 use cw_storage_plus::Bound;
 use cw_utils::{nonpayable, one_coin, Expiration};
-use semver::Version;
 
 use crate::state::{SALE, TOKEN_ADDRESS};
 
@@ -442,31 +442,7 @@ fn block_to_expiration(block: &BlockInfo, model: Expiration) -> Option<Expiratio
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -24,7 +24,6 @@ cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw20-base = { workspace = true }
 cw-asset = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true}
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw20-base = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -1,26 +1,30 @@
-use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
     ado_base::{
         hooks::AndromedaHook, ownership::OwnershipMessage, AndromedaMsg, AndromedaQuery,
         InstantiateMsg as BaseInstantiateMsg,
     },
     ado_contract::ADOContract,
-    common::{actions::call_action, context::ExecuteContext, encode_binary, Funds},
-    error::{from_semver, ContractError},
+    common::{
+        actions::call_action,
+        context::ExecuteContext,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        Funds,
+    },
+    error::ContractError,
 };
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, from_json, to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env,
-    MessageInfo, Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
+    from_json, to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
 };
 
-use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20Coin, Cw20ExecuteMsg};
 use cw20_base::{
     contract::{execute as execute_cw20, instantiate as cw20_instantiate, query as cw20_query},
     state::BALANCES,
 };
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-cw20";
@@ -294,31 +298,7 @@ fn filter_out_cw20_messages(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true }
 cw-asset = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-fungible-tokens = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -2,7 +2,7 @@
 // https://github.com/mars-protocol/mars-periphery/tree/main/contracts/lockdrop
 
 use andromeda_fungible_tokens::lockdrop::{
-    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StateResponse,
+    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, StateResponse,
     UserInfoResponse,
 };
 use andromeda_std::{
@@ -11,21 +11,24 @@ use andromeda_std::{
     },
     ado_contract::ADOContract,
     common::{
-        actions::call_action, context::ExecuteContext, encode_binary,
-        expiration::MILLISECONDS_TO_NANOSECONDS_RATIO, Milliseconds,
+        actions::call_action,
+        context::ExecuteContext,
+        encode_binary,
+        expiration::MILLISECONDS_TO_NANOSECONDS_RATIO,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        Milliseconds,
     },
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 use cosmwasm_std::{ensure, from_json, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
 use cosmwasm_std::{entry_point, Decimal};
 use cw_asset::Asset;
 
 use crate::state::{Config, State, CONFIG, STATE, USER_INFO};
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
 
 use cw_utils::nonpayable;
-use semver::Version;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-lockdrop";
@@ -153,31 +156,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 pub fn receive_cw20(

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true}
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw-asset = { workspace = true }
-semver = { workspace = true }
 sha2 = "0.10.6"
 hex = "0.4.3"
 serde = "1.0.163"

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
     attr, ensure, to_json_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty,
     Env, MessageInfo, Response, StdResult, Uint128, WasmMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw20::Cw20ExecuteMsg;
 use cw_asset::AssetInfoBase;
 use cw_utils::{nonpayable, Expiration};
@@ -19,16 +19,19 @@ use crate::state::{
 };
 use andromeda_fungible_tokens::airdrop::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, IsClaimedResponse, LatestStageResponse,
-    MerkleRootResponse, MigrateMsg, QueryMsg, TotalClaimedResponse,
+    MerkleRootResponse, QueryMsg, TotalClaimedResponse,
 };
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg,
     ado_contract::ADOContract,
-    common::{actions::call_action, context::ExecuteContext, encode_binary},
-    error::{from_semver, ContractError},
+    common::{
+        actions::call_action,
+        context::ExecuteContext,
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
+    error::ContractError,
 };
-
-use semver::Version;
 
 // Version info, for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-merkle-airdrop";
@@ -358,29 +361,5 @@ pub fn query_total_claimed(deps: Deps, stage: u8) -> Result<TotalClaimedResponse
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["module_hooks"] }
 andromeda-modules = { workspace = true }

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw20 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["module_hooks"] }
 andromeda-modules = { workspace = true }

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use crate::state::{Config, CONFIG};
 use andromeda_modules::rates::{
-    calculate_fee, ExecuteMsg, InstantiateMsg, MigrateMsg, PaymentAttribute, PaymentsResponse,
-    QueryMsg, RateInfo,
+    calculate_fee, ExecuteMsg, InstantiateMsg, PaymentAttribute, PaymentsResponse, QueryMsg,
+    RateInfo,
 };
 use andromeda_std::{
     ado_base::{
@@ -10,18 +10,22 @@ use andromeda_std::{
         InstantiateMsg as BaseInstantiateMsg,
     },
     ado_contract::ADOContract,
-    common::{context::ExecuteContext, deduct_funds, encode_binary, Funds},
-    error::{from_semver, ContractError},
+    common::{
+        context::ExecuteContext,
+        deduct_funds, encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        Funds,
+    },
+    error::ContractError,
 };
 
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     attr, coin, ensure, Binary, Coin, Deps, DepsMut, Env, Event, MessageInfo, Response, SubMsg,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw20::Cw20Coin;
 use cw_utils::nonpayable;
-use semver::Version;
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-rates";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -98,31 +102,7 @@ fn execute_update_rates(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -23,7 +23,6 @@ cw-utils = { workspace = true}
 cw721 = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -3,7 +3,7 @@ use crate::state::{
 };
 use andromeda_non_fungible_tokens::auction::{
     AuctionIdsResponse, AuctionInfo, AuctionStateResponse, Bid, BidsResponse, Cw721HookMsg,
-    ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, TokenAuctionState,
+    ExecuteMsg, InstantiateMsg, QueryMsg, TokenAuctionState,
 };
 use andromeda_std::{
     ado_base::{
@@ -15,10 +15,11 @@ use andromeda_std::{
         actions::call_action,
         encode_binary,
         expiration::{expiration_from_milliseconds, MILLISECONDS_TO_NANOSECONDS_RATIO},
+        migrate::{migrate as do_migrate, MigrateMsg},
         rates::get_tax_amount,
         Funds, OrderBy,
     },
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 
@@ -27,10 +28,9 @@ use cosmwasm_std::{
     Deps, DepsMut, Env, MessageInfo, QuerierWrapper, QueryRequest, Response, Storage, SubMsg,
     Uint128, WasmMsg, WasmQuery,
 };
-use cw2::{get_contract_version, set_contract_version};
+use cw2::set_contract_version;
 use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, Expiration, OwnerOfResponse};
 use cw_utils::nonpayable;
-use semver::Version;
 
 const CONTRACT_NAME: &str = "crates.io:andromeda_auction";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -869,29 +869,5 @@ fn query_owner_of(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw721 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -30,7 +30,6 @@ cw-storage-plus = { workspace = true }
 cw721-base = { workspace = true }
 cw721 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-non-fungible-tokens = { workspace = true }
 andromeda-std = { workspace = true, features = ["modules"] }

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -9,22 +9,25 @@ use crate::state::{
     is_archived, ANDR_MINTER, ARCHIVED, BATCH_MINT_ACTION, MINT_ACTION, TRANSFER_AGREEMENTS,
 };
 use andromeda_non_fungible_tokens::cw721::{
-    ExecuteMsg, InstantiateMsg, MigrateMsg, MintMsg, QueryMsg, TokenExtension, TransferAgreement,
+    ExecuteMsg, InstantiateMsg, MintMsg, QueryMsg, TokenExtension, TransferAgreement,
 };
 use andromeda_std::{
     ado_base::{AndromedaMsg, AndromedaQuery},
     ado_contract::{permissioning::is_context_permissioned_strict, ADOContract},
-    common::{actions::call_action, context::ExecuteContext},
+    common::{
+        actions::call_action,
+        context::ExecuteContext,
+        migrate::{migrate as do_migrate, MigrateMsg},
+    },
 };
-use cw2::{get_contract_version, set_contract_version};
-use semver::Version;
+use cw2::set_contract_version;
 
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
     common::encode_binary,
     common::rates::get_tax_amount,
     common::Funds,
-    error::{from_semver, ContractError},
+    error::ContractError,
 };
 use cw721::{ContractInfoResponse, Cw721Execute};
 use cw721_base::{state::TokenInfo, Cw721Contract, ExecuteMsg as Cw721ExecuteMsg};
@@ -509,29 +512,5 @@ pub fn query_minter(deps: Deps) -> Result<String, ContractError> {
 
 #[cfg_attr(not(feature = "imported"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -22,7 +22,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true}
 cw721 = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -3,8 +3,7 @@ use crate::state::{
 };
 
 use andromeda_non_fungible_tokens::marketplace::{
-    Cw721HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, SaleIdsResponse,
-    SaleStateResponse, Status,
+    Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, SaleIdsResponse, SaleStateResponse, Status,
 };
 use andromeda_std::ado_base::ownership::OwnershipMessage;
 use andromeda_std::ado_contract::ADOContract;
@@ -16,12 +15,15 @@ use andromeda_std::common::expiration::{
 };
 use andromeda_std::{
     ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
-    common::{encode_binary, rates::get_tax_amount, Funds},
-    error::{from_semver, ContractError},
+    common::{
+        encode_binary,
+        migrate::{migrate as do_migrate, MigrateMsg},
+        rates::get_tax_amount,
+        Funds,
+    },
+    error::ContractError,
 };
-use cw2::{get_contract_version, set_contract_version};
 use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, OwnerOfResponse};
-use semver::Version;
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -590,31 +592,7 @@ fn query_owner_of(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 // #[cfg(test)]

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -28,7 +28,6 @@ cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 andromeda-std = { workspace = true }
-semver = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { version = "1.0.0", optional = true }

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -26,7 +26,6 @@ cosmwasm-std = { workspace = true, features = ["ibc3"] }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
-semver = { workspace = true }
 serde-json-wasm = "1.0.0"
 serde-cw-value = "0.7.0"
 sha256 = "1.1.4"

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -2,15 +2,14 @@ use andromeda_std::ado_base::InstantiateMsg as BaseInstantiateMsg;
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::common::context::ExecuteContext;
 use andromeda_std::common::encode_binary;
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
 use andromeda_std::common::reply::ReplyId;
 use andromeda_std::error::ContractError;
 
-use andromeda_std::os::kernel::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_std::os::kernel::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use cosmwasm_std::{
-    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
 };
-use cw2::{get_contract_version, set_contract_version};
-use semver::Version;
 
 use crate::ibc::{IBCLifecycleComplete, SudoMsg};
 use crate::reply::{on_reply_create_ado, on_reply_ibc_hooks_packet_send};
@@ -137,35 +136,7 @@ pub fn sudo(deps: DepsMut, _env: Env, msg: SudoMsg) -> Result<Response, Contract
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
-}
-
-fn from_semver(err: semver::Error) -> StdError {
-    StdError::generic_err(format!("Semver: {err}"))
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -27,7 +27,6 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 cw2 = { workspace = true }
-semver = { workspace = true }
 
 andromeda-std = { workspace = true, features=["modules"]}
 

--- a/contracts/os/andromeda-vfs/src/contract.rs
+++ b/contracts/os/andromeda-vfs/src/contract.rs
@@ -1,13 +1,13 @@
 use andromeda_std::ado_contract::ADOContract;
-use andromeda_std::os::vfs::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use andromeda_std::common::migrate::{migrate as do_migrate, MigrateMsg};
+use andromeda_std::os::vfs::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
     ado_base::InstantiateMsg as BaseInstantiateMsg, common::encode_binary, error::ContractError,
 };
 use cosmwasm_std::{
-    ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
 };
-use cw2::{get_contract_version, set_contract_version};
-use semver::Version;
+use cw2::set_contract_version;
 
 use crate::{execute, query};
 
@@ -95,35 +95,7 @@ pub fn execute(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // New version
-    let version: Version = CONTRACT_VERSION.parse().map_err(from_semver)?;
-
-    // Old version
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
-
-    ensure!(
-        stored.contract == CONTRACT_NAME,
-        ContractError::CannotMigrate {
-            previous_contract: stored.contract,
-        }
-    );
-
-    // New version has to be newer/greater than the old version
-    ensure!(
-        storage_version < version,
-        ContractError::CannotMigrate {
-            previous_contract: stored.version,
-        }
-    );
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    Ok(Response::default())
-}
-
-fn from_semver(err: semver::Error) -> StdError {
-    StdError::generic_err(format!("Semver: {err}"))
+    do_migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -305,9 +305,6 @@ pub enum ExecuteMsg {
     AssignAppToComponents {},
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -25,10 +25,6 @@ pub enum ExecuteMsg {
     },
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-ecosystem/src/vault.rs
+++ b/packages/andromeda-ecosystem/src/vault.rs
@@ -141,6 +141,3 @@ pub struct StrategyAddressResponse {
     pub strategy: StrategyType,
     pub address: String,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-finance/src/cross_chain_swap.rs
+++ b/packages/andromeda-finance/src/cross_chain_swap.rs
@@ -19,10 +19,6 @@ pub enum ExecuteMsg {
     },
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
+++ b/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
@@ -58,10 +58,6 @@ pub enum ExecuteMsg {
     WithdrawFunds { amount: Uint128 },
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -57,10 +57,6 @@ pub enum ExecuteMsg {
     Send {},
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/timelock.rs
+++ b/packages/andromeda-finance/src/timelock.rs
@@ -137,10 +137,6 @@ pub enum ExecuteMsg {
         recipient_addr: Option<String>,
     },
 }
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -123,7 +123,3 @@ pub struct BatchResponse {
     /// The time at which the last claim took place in seconds.
     pub last_claimed_release_time: u64,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -47,10 +47,6 @@ pub enum ExecuteMsg {
     Send {},
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-fungible-tokens/src/airdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/airdrop.rs
@@ -76,6 +76,3 @@ pub struct IsClaimedResponse {
 pub struct TotalClaimedResponse {
     pub total_claimed: Uint128,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-fungible-tokens/src/cw20.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20.rs
@@ -169,10 +169,6 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
     }
 }
 
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
@@ -97,6 +97,3 @@ pub struct TokenAddressResponse {
     /// The address of the token being sold
     pub address: String,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -227,6 +227,3 @@ pub struct StakerResponse {
     /// The staker's pending rewards represented as [(token_1, amount_1), ..., (token_n, amount_n)]
     pub pending_rewards: Vec<(String, Uint128)>,
 }
-
-#[cw_serde]
-pub enum MigrateMsg {}

--- a/packages/andromeda-fungible-tokens/src/lockdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/lockdrop.rs
@@ -103,6 +103,3 @@ pub struct UserInfoResponse {
     pub is_lockdrop_claimed: bool,
     pub withdrawal_flag: bool,
 }
-
-#[cw_serde]
-pub struct MigrateMsg {}

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -18,9 +18,6 @@ pub enum ExecuteMsg {
     AddAddresses { addresses: Vec<String> },
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-modules/src/rates.rs
+++ b/packages/andromeda-modules/src/rates.rs
@@ -16,9 +16,6 @@ pub enum ExecuteMsg {
     UpdateRates { rates: Vec<RateInfo> },
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[andr_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -201,7 +201,3 @@ pub struct AuctionIdsResponse {
 pub struct BidsResponse {
     pub bids: Vec<Bid>,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -104,7 +104,3 @@ pub struct CrowdfundMintMsg {
     /// Any custom extension used by this contract
     pub extension: TokenExtension,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -305,7 +305,3 @@ impl From<QueryMsg> for Cw721QueryMsg<QueryMsg> {
         }
     }
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -111,7 +111,3 @@ pub struct SaleStateResponse {
 pub struct SaleIdsResponse {
     pub sale_ids: Vec<Uint128>,
 }
-
-#[cw_serde]
-#[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}

--- a/packages/std/src/common/migrate.rs
+++ b/packages/std/src/common/migrate.rs
@@ -1,0 +1,42 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{ensure, DepsMut, Response};
+use cw2::{get_contract_version, set_contract_version};
+use semver::Version;
+
+use crate::error::{from_semver, ContractError};
+
+#[cw_serde]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {}
+
+pub fn migrate(
+    deps: DepsMut,
+    contract_name: &str,
+    contract_version: &str,
+) -> Result<Response, ContractError> {
+    // New version
+    let version: Version = contract_version.parse().map_err(from_semver)?;
+
+    // Old version
+    let stored = get_contract_version(deps.storage)?;
+    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
+
+    ensure!(
+        stored.contract == contract_name,
+        ContractError::CannotMigrate {
+            previous_contract: stored.contract,
+        }
+    );
+
+    // New version has to be newer/greater than the old version
+    ensure!(
+        storage_version < version,
+        ContractError::CannotMigrate {
+            previous_contract: stored.version,
+        }
+    );
+
+    set_contract_version(deps.storage, contract_name, contract_version)?;
+
+    Ok(Response::default())
+}

--- a/packages/std/src/common/mod.rs
+++ b/packages/std/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod actions;
 pub mod context;
 pub mod expiration;
+pub mod migrate;
 pub mod milliseconds;
 pub mod rates;
 pub mod reply;

--- a/packages/std/src/os/adodb.rs
+++ b/packages/std/src/os/adodb.rs
@@ -127,9 +127,6 @@ impl ActionFee {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 pub struct ADOMetadata {
     pub publisher: String,
     pub latest_version: String,

--- a/packages/std/src/os/economics.rs
+++ b/packages/std/src/os/economics.rs
@@ -66,9 +66,6 @@ pub enum Cw20HookMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Queries the current balance for a given AndrAddr and asset tuple

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -85,9 +85,6 @@ pub enum InternalMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 pub struct ChannelInfoResponse {
     pub ics20: Option<String>,
     pub direct: Option<String>,

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -206,9 +206,6 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
-
-#[cw_serde]
 pub struct SubDirBound {
     address: Addr,
     name: String,


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/259

# Implementation

- Added `migrate` function to `packages/std/src/common/migrate.rs`.
- Imported `migrate` function as `do_migrate` and updated all migrate functions to use it
- Removed duplicated `MigrateMsg` from packages.