### PR TITLE
[1.0.rc-1] AndrAddr Recipient for SendNft in CW721

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -5,6 +5,7 @@ use andromeda_std::{
         InstantiateMsg as BaseInstantiateMsg,
     },
     ado_contract::ADOContract,
+    amp::AndrAddr,
     common::{actions::call_action, context::ExecuteContext, encode_binary, Funds},
     error::{from_semver, ContractError},
 };
@@ -202,7 +203,7 @@ fn execute_burn(ctx: ExecuteContext, amount: Uint128) -> Result<Response, Contra
 
 fn execute_send(
     ctx: ExecuteContext,
-    contract: String,
+    contract: AndrAddr,
     amount: Uint128,
     msg: Binary,
 ) -> Result<Response, ContractError> {
@@ -231,6 +232,7 @@ fn execute_send(
 
     let mut resp = filter_out_cw20_messages(msgs, deps.storage, deps.api, &info.sender)?;
 
+    let contract = contract.get_raw_address(&deps.as_ref())?.into_string();
     let cw20_resp = execute_cw20(
         deps,
         env,

--- a/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
@@ -48,7 +48,7 @@ pub fn mock_get_version() -> QueryMsg {
     QueryMsg::Version {}
 }
 
-pub fn mock_cw20_send(contract: String, amount: Uint128, msg: Binary) -> ExecuteMsg {
+pub fn mock_cw20_send(contract: AndrAddr, amount: Uint128, msg: Binary) -> ExecuteMsg {
     ExecuteMsg::Send {
         contract,
         amount,

--- a/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
@@ -154,7 +154,7 @@ fn test_send() {
     );
 
     let msg = ExecuteMsg::Send {
-        contract: "contract".into(),
+        contract: AndrAddr::from_string("contract".to_string()),
         amount: 100u128.into(),
         msg: to_json_binary(&"msg").unwrap(),
     };

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -14,6 +14,7 @@ use andromeda_non_fungible_tokens::cw721::{
 use andromeda_std::{
     ado_base::{AndromedaMsg, AndromedaQuery},
     ado_contract::{permissioning::is_context_permissioned_strict, ADOContract},
+    amp::AndrAddr,
     common::{actions::call_action, context::ExecuteContext},
 };
 use cw2::{get_contract_version, set_contract_version};
@@ -463,7 +464,7 @@ fn execute_burn(env: ExecuteContext, token_id: String) -> Result<Response, Contr
 fn execute_send_nft(
     ctx: ExecuteContext,
     token_id: String,
-    contract_addr: String,
+    contract_addr: AndrAddr,
     msg: Binary,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -472,7 +473,7 @@ fn execute_send_nft(
     let contract = AndrCW721Contract::default();
     TRANSFER_AGREEMENTS.remove(deps.storage, &token_id);
 
-    Ok(contract.send_nft(deps, env, info, contract_addr, token_id, msg)?)
+    Ok(contract.send_nft(deps, env, info, contract_addr.to_string(), token_id, msg)?)
 }
 
 #[cfg_attr(not(feature = "imported"), entry_point)]

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -472,8 +472,9 @@ fn execute_send_nft(
     } = ctx;
     let contract = AndrCW721Contract::default();
     TRANSFER_AGREEMENTS.remove(deps.storage, &token_id);
+    let contract_addr = contract_addr.get_raw_address(&deps.as_ref())?.into_string();
 
-    Ok(contract.send_nft(deps, env, info, contract_addr.to_string(), token_id, msg)?)
+    Ok(contract.send_nft(deps, env, info, contract_addr, token_id, msg)?)
 }
 
 #[cfg_attr(not(feature = "imported"), entry_point)]

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
@@ -66,7 +66,7 @@ pub fn mock_quick_mint_msg(amount: u32, owner: String) -> ExecuteMsg {
     ExecuteMsg::BatchMint { tokens: mint_msgs }
 }
 
-pub fn mock_send_nft(contract: String, token_id: String, msg: Binary) -> ExecuteMsg {
+pub fn mock_send_nft(contract: AndrAddr, token_id: String, msg: Binary) -> ExecuteMsg {
     ExecuteMsg::SendNft {
         contract,
         token_id,

--- a/packages/andromeda-fungible-tokens/src/cw20.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20.rs
@@ -1,4 +1,6 @@
-use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_query};
+use andromeda_std::{
+    amp::AndrAddr, andr_exec, andr_instantiate, andr_instantiate_modules, andr_query,
+};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Binary, Uint128};
 use cw20::{Cw20Coin, Logo, MinterResponse};
@@ -43,7 +45,7 @@ pub enum ExecuteMsg {
     /// Send is a base message to transfer tokens to a contract and trigger an action
     /// on the receiving contract.
     Send {
-        contract: String,
+        contract: AndrAddr,
         amount: Uint128,
         msg: Binary,
     },
@@ -110,7 +112,7 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
                 amount,
                 msg,
             } => Cw20ExecuteMsg::Send {
-                contract,
+                contract: contract.to_string(),
                 amount,
                 msg,
             },

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -87,7 +87,7 @@ pub enum ExecuteMsg {
     TransferNft { recipient: String, token_id: String },
     /// Sends a token to another contract
     SendNft {
-        contract: String,
+        contract: AndrAddr,
         token_id: String,
         msg: Binary,
     },
@@ -135,7 +135,7 @@ impl From<ExecuteMsg> for Cw721ExecuteMsg<TokenExtension, ExecuteMsg> {
                 token_id,
                 msg,
             } => Cw721ExecuteMsg::SendNft {
-                contract,
+                contract: contract.to_string(),
                 token_id,
                 msg,
             },

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -188,7 +188,7 @@ fn test_auction_app() {
         None,
     );
     let send_msg = mock_send_nft(
-        auction_addr.clone(),
+        AndrAddr::from_string(auction_addr.clone()),
         "0".to_string(),
         to_json_binary(&receive_msg).unwrap(),
     );

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -187,8 +187,9 @@ fn test_auction_app() {
         None,
         None,
     );
+
     let send_msg = mock_send_nft(
-        AndrAddr::from_string(auction_addr.clone()),
+        AndrAddr::from_string("./auction".to_string()),
         "0".to_string(),
         to_json_binary(&receive_msg).unwrap(),
     );

--- a/tests-integration/tests/cw20_staking.rs
+++ b/tests-integration/tests/cw20_staking.rs
@@ -13,7 +13,7 @@ use andromeda_cw20_staking::mock::{
 };
 use andromeda_fungible_tokens::cw20_staking::{AllocationConfig, StakerResponse};
 
-use andromeda_std::common::Milliseconds;
+use andromeda_std::{amp::AndrAddr, common::Milliseconds};
 
 use andromeda_std::ado_base::version::VersionResponse;
 use andromeda_testing::mock::{mock_app, MockAndromeda, MockApp};
@@ -164,7 +164,7 @@ fn test_cw20_staking_app() {
 
     // Stake Tokens
     let staking_msg_one = mock_cw20_send(
-        cw20_staking_addr.to_string(),
+        AndrAddr::from_string(cw20_staking_addr.to_string()),
         Uint128::from(1000u128),
         to_json_binary(&mock_cw20_stake()).unwrap(),
     );
@@ -173,7 +173,7 @@ fn test_cw20_staking_app() {
         .unwrap();
 
     let staking_msg_two = mock_cw20_send(
-        cw20_staking_addr.to_string(),
+        AndrAddr::from_string(cw20_staking_addr.to_string()),
         Uint128::from(2000u128),
         to_json_binary(&mock_cw20_stake()).unwrap(),
     );
@@ -300,7 +300,7 @@ fn test_cw20_staking_app_delayed() {
 
     // Stake Tokens
     let staking_msg_one = mock_cw20_send(
-        cw20_staking_addr.to_string(),
+        AndrAddr::from_string(cw20_staking_addr.to_string()),
         Uint128::from(1000u128),
         to_json_binary(&mock_cw20_stake()).unwrap(),
     );
@@ -309,7 +309,7 @@ fn test_cw20_staking_app_delayed() {
         .unwrap();
 
     let staking_msg_two = mock_cw20_send(
-        cw20_staking_addr.to_string(),
+        AndrAddr::from_string(cw20_staking_addr.to_string()),
         Uint128::from(2000u128),
         to_json_binary(&mock_cw20_stake()).unwrap(),
     );

--- a/tests-integration/tests/lockdrop.rs
+++ b/tests-integration/tests/lockdrop.rs
@@ -3,7 +3,7 @@ use andromeda_lockdrop::mock::{
     mock_andromeda_lockdrop, mock_claim_rewards, mock_cw20_hook_increase_incentives,
     mock_deposit_native, mock_enable_claims, mock_lockdrop_instantiate_msg, mock_withdraw_native,
 };
-use andromeda_std::common::Milliseconds;
+use andromeda_std::{amp::AndrAddr, common::Milliseconds};
 use andromeda_testing::mock::{mock_app, MockAndromeda, MockApp};
 use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Uint128};
 use cw20::Cw20Coin;
@@ -111,7 +111,7 @@ fn test_lockdrop() {
     .unwrap();
 
     let msg = mock_cw20_send(
-        lockdrop_addr.to_string(),
+        AndrAddr::from_string(lockdrop_addr.to_string()),
         100u128.into(),
         to_json_binary(&mock_cw20_hook_increase_incentives()).unwrap(),
     );

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -20,7 +20,7 @@ use andromeda_modules::rates::{Rate, RateInfo};
 use andromeda_rates::mock::{mock_andromeda_rates, mock_rates_instantiate_msg};
 use andromeda_std::ado_base::modules::Module;
 use andromeda_std::amp::messages::{AMPMsg, AMPPkt};
-use andromeda_std::amp::Recipient;
+use andromeda_std::amp::{AndrAddr, Recipient};
 use andromeda_testing::mock::{mock_app, MockAndromeda, MockApp};
 use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Uint128};
 use cw721::OwnerOfResponse;
@@ -192,7 +192,7 @@ fn test_marketplace_app() {
 
     // Send Token to Marketplace
     let send_nft_msg = mock_send_nft(
-        marketplace_addr.clone(),
+        AndrAddr::from_string(marketplace_addr.clone()),
         token_id.to_string(),
         to_json_binary(&mock_start_sale(Uint128::from(100u128), "uandr")).unwrap(),
     );


### PR DESCRIPTION
# Motivation
Resolves #373 

# Implementation
`ExecuteMsg::SendNft`'s `contract`field is now an `AndrAddr`.

 `execute_send_nft` fetches the recipient's raw address before calling `send_nft`.

# Testing
Changed addresses in tests from `String` to `AndrAddr`.