### PR TITLE
[RC] Removed Balance Query from ADO Contracts

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_std::{ado_base::modules::Module, amp::AndrAddr};
+use andromeda_std::ado_base::modules::Module;
 use cosmwasm_std::{Binary, Empty, Uint128};
 use cw20::MinterResponse;
 use cw_multi_test::{Contract, ContractWrapper};
@@ -41,8 +41,9 @@ pub fn mock_cw20_instantiate_msg(
 }
 
 pub fn mock_get_cw20_balance(address: impl Into<String>) -> QueryMsg {
-    let address = AndrAddr::from_string(address.into());
-    QueryMsg::Balance { address }
+    QueryMsg::Balance {
+        address: address.into(),
+    }
 }
 pub fn mock_get_version() -> QueryMsg {
     QueryMsg::Version {}

--- a/packages/andromeda-fungible-tokens/src/cw20.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20.rs
@@ -225,14 +225,14 @@ pub enum QueryMsg {
     /// Return type: DownloadLogoResponse.
     #[returns(cw20::DownloadLogoResponse)]
     DownloadLogo {},
+    #[returns(cw20::BalanceResponse)]
+    Balance { address: String },
 }
 
 impl From<QueryMsg> for Cw20QueryMsg {
     fn from(msg: QueryMsg) -> Self {
         match msg {
-            QueryMsg::Balance { address } => Cw20QueryMsg::Balance {
-                address: address.to_string(),
-            },
+            QueryMsg::Balance { address } => Cw20QueryMsg::Balance { address },
             QueryMsg::TokenInfo {} => Cw20QueryMsg::TokenInfo {},
             QueryMsg::Minter {} => Cw20QueryMsg::Minter {},
             QueryMsg::Allowance { owner, spender } => Cw20QueryMsg::Allowance { owner, spender },

--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -177,10 +177,6 @@ pub fn andr_query(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                 BlockHeightUponCreation {},
                 #[returns(andromeda_std::ado_base::version::VersionResponse)]
                 Version {},
-                #[returns(::cosmwasm_std::BalanceResponse)]
-                Balance {
-                    address: ::andromeda_std::amp::AndrAddr,
-                },
                 #[returns(Vec<::andromeda_std::ado_base::permissioning::PermissionInfo>)]
                 Permissions { actor: String, limit: Option<u32>, start_after: Option<String> },
                 #[returns(Vec<String>)]


### PR DESCRIPTION
Closes: #378 

# Motivation
A remnant from our withdraw feature was a `Balance` query in all ADOs. These changes remove that query.

# Implementation

Removed the query from our message macro.
