### PR TITLE
[RC] Ownership Request Query Response Object

### DIFF
--- a/contracts/finance/andromeda-rate-limiting-withdrawals/schema/andromeda-rate-limiting-withdrawals.json
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/schema/andromeda-rate-limiting-withdrawals.json
@@ -42,7 +42,7 @@
       "AndrAddr": {
         "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
         "type": "string",
-        "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,40}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
+        "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,80}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,80}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,80}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
       },
       "CoinAndLimit": {
         "type": "object",
@@ -65,19 +65,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "AndrAddr": {
-        "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
-        "type": "string",
-        "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,80}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,80}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,80}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
-      },
-      "Binary": {
-        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-        "type": "string"
-      },
-      "Decimal": {
-        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-        "type": "string"
       },
       "Milliseconds": {
         "description": "Represents time in milliseconds.",
@@ -1452,35 +1439,6 @@
       },
       "additionalProperties": false,
       "definitions": {
-        "AddressPercent": {
-          "type": "object",
-          "required": [
-            "percent",
-            "recipient"
-          ],
-          "properties": {
-            "percent": {
-              "$ref": "#/definitions/Decimal"
-            },
-            "recipient": {
-              "$ref": "#/definitions/Recipient"
-            }
-          },
-          "additionalProperties": false
-        },
-        "AndrAddr": {
-          "description": "An address that can be used within the Andromeda ecosystem. Inspired by the cosmwasm-std `Addr` type. https://github.com/CosmWasm/cosmwasm/blob/2a1c698520a1aacedfe3f4803b0d7d653892217a/packages/std/src/addresses.rs#L33\n\nThis address can be one of two things: 1. A valid human readable address e.g. `cosmos1...` 2. A valid Andromeda VFS path e.g. `/home/user/app/component`\n\nVFS paths can be local in the case of an app and can be done by referencing `./component` they can also contain protocols for cross chain communication. A VFS path is usually structured as so:\n\n`<protocol>://<chain (required if ibc used)>/<path>` or `ibc://cosmoshub-4/user/app/component`",
-          "type": "string",
-          "pattern": "(^((([A-Za-z0-9]+://)?([A-Za-z0-9.\\-_]{2,80}/)))?((~[a-z0-9]{2,}|(lib|home))(/[A-Za-z0-9.\\-_]{2,80}?)*(/)?)$)|(^(~[a-z0-9]{2,}|/(lib|home))(/[A-Za-z0-9.\\-_]{2,80}?)*(/)?$)|(^[a-z0-9]{2,}$)|(^\\.(/[A-Za-z0-9.\\-_]{2,40}?)*(/)?$)"
-        },
-        "Binary": {
-          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-          "type": "string"
-        },
-        "Decimal": {
-          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-          "type": "string"
-        },
         "Milliseconds": {
           "description": "Represents time in milliseconds.",
           "type": "integer",

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/schema/cw20receive.json
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/schema/cw20receive.json
@@ -25,12 +25,14 @@
               ]
             },
             "duration": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "exchange_rate": {
               "description": "The amount of the above asset required to purchase a single token",
@@ -48,12 +50,14 @@
               ]
             },
             "start_time": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -118,6 +122,12 @@
           "additionalProperties": false
         }
       ]
+    },
+    "Milliseconds": {
+      "description": "Represents time in milliseconds.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/andromeda-auction.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/andromeda-auction.json
@@ -157,9 +157,7 @@
                 "type": "string"
               },
               "duration": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "$ref": "#/definitions/Milliseconds"
               },
               "min_bid": {
                 "anyOf": [
@@ -172,12 +170,14 @@
                 ]
               },
               "start_time": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Milliseconds"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "token_address": {
                 "type": "string"
@@ -681,6 +681,12 @@
           }
         },
         "additionalProperties": false
+      },
+      "Milliseconds": {
+        "description": "Represents time in milliseconds.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
       },
       "Module": {
         "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/cw721receive.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/cw721receive.json
@@ -21,9 +21,11 @@
             },
             "duration": {
               "description": "Duration in milliseconds",
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                }
+              ]
             },
             "min_bid": {
               "anyOf": [
@@ -37,12 +39,14 @@
             },
             "start_time": {
               "description": "Start time in milliseconds since epoch",
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "whitelist": {
               "type": [
@@ -64,6 +68,12 @@
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
+    },
+    "Milliseconds": {
+      "description": "Represents time in milliseconds.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/non-fungible-tokens/andromeda-auction/schema/raw/execute.json
+++ b/contracts/non-fungible-tokens/andromeda-auction/schema/raw/execute.json
@@ -85,9 +85,7 @@
               "type": "string"
             },
             "duration": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
+              "$ref": "#/definitions/Milliseconds"
             },
             "min_bid": {
               "anyOf": [
@@ -100,12 +98,14 @@
               ]
             },
             "start_time": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "token_address": {
               "type": "string"
@@ -609,6 +609,12 @@
         }
       },
       "additionalProperties": false
+    },
+    "Milliseconds": {
+      "description": "Represents time in milliseconds.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "Module": {
       "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/schema/andromeda-crowdfund.json
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/schema/andromeda-crowdfund.json
@@ -148,12 +148,14 @@
               },
               "start_time": {
                 "description": "When the sale start. Defaults to current time.",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Milliseconds"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -684,6 +686,12 @@
           }
         },
         "additionalProperties": false
+      },
+      "Milliseconds": {
+        "description": "Represents time in milliseconds.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
       },
       "Module": {
         "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/schema/raw/execute.json
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/schema/raw/execute.json
@@ -77,12 +77,14 @@
             },
             "start_time": {
               "description": "When the sale start. Defaults to current time.",
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -613,6 +615,12 @@
         }
       },
       "additionalProperties": false
+    },
+    "Milliseconds": {
+      "description": "Represents time in milliseconds.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "Module": {
       "description": "A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",

--- a/contracts/non-fungible-tokens/andromeda-marketplace/schema/cw721receive.json
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/schema/cw721receive.json
@@ -20,23 +20,27 @@
               "type": "string"
             },
             "duration": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "price": {
               "$ref": "#/definitions/Uint128"
             },
             "start_time": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Milliseconds"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -46,6 +50,12 @@
     }
   ],
   "definitions": {
+    "Milliseconds": {
+      "description": "Represents time in milliseconds.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"

--- a/packages/std/src/ado_base/ownership.rs
+++ b/packages/std/src/ado_base/ownership.rs
@@ -10,6 +10,7 @@ pub struct ContractOwnerResponse {
 #[cw_serde]
 pub struct ContractPotentialOwnerResponse {
     pub potential_owner: Option<Addr>,
+    pub expiration: Option<Expiration>,
 }
 
 #[cw_serde]

--- a/packages/std/src/ado_contract/ownership.rs
+++ b/packages/std/src/ado_contract/ownership.rs
@@ -1,5 +1,8 @@
 use crate::error::ContractError;
-use crate::{ado_base::ownership::OwnershipMessage, ado_contract::ADOContract};
+use crate::{
+    ado_base::ownership::{ContractPotentialOwnerResponse, OwnershipMessage},
+    ado_contract::ADOContract,
+};
 use cosmwasm_std::{attr, ensure, Addr, DepsMut, Env, MessageInfo, Response, Storage};
 use cw_storage_plus::Item;
 use cw_utils::Expiration;
@@ -140,9 +143,12 @@ impl<'a> ADOContract<'a> {
         self.is_contract_owner(storage, addr)
     }
 
-    pub fn ownership_request(&self, storage: &dyn Storage) -> Result<Option<Addr>, ContractError> {
+    pub fn ownership_request(
+        &self,
+        storage: &dyn Storage,
+    ) -> Result<ContractPotentialOwnerResponse, ContractError> {
         let potential_owner = POTENTIAL_OWNER.may_load(storage)?;
-        Ok(potential_owner)
+        Ok(ContractPotentialOwnerResponse { potential_owner })
     }
 }
 

--- a/packages/std/src/ado_contract/ownership.rs
+++ b/packages/std/src/ado_contract/ownership.rs
@@ -148,7 +148,11 @@ impl<'a> ADOContract<'a> {
         storage: &dyn Storage,
     ) -> Result<ContractPotentialOwnerResponse, ContractError> {
         let potential_owner = POTENTIAL_OWNER.may_load(storage)?;
-        Ok(ContractPotentialOwnerResponse { potential_owner })
+        let expiration = POTENTIAL_OWNER_EXPIRATION.may_load(storage)?;
+        Ok(ContractPotentialOwnerResponse {
+            potential_owner,
+            expiration,
+        })
     }
 }
 


### PR DESCRIPTION
Closes: #377 

# Motivation
The schema for our ownership request did not match the response object. These changes fix that issue by altering the respones object.

# Implementation
Adjusted the ownership query to return `ContractPotentialOwnerResponse` instead of `Option<Addr>`.
