### PR TITLE
[1.0.rc-1] Crowdfund & Auction Adjustments

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -31,14 +31,14 @@ pub fn mock_auction_instantiate_msg(
 
 pub fn mock_start_auction(
     start_time: Option<Milliseconds>,
-    duration: Milliseconds,
+    end_time: Milliseconds,
     coin_denom: String,
     min_bid: Option<Uint128>,
     whitelist: Option<Vec<Addr>>,
 ) -> Cw721HookMsg {
     Cw721HookMsg::StartAuction {
         start_time,
-        duration,
+        end_time,
         coin_denom,
         min_bid,
         whitelist,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
@@ -8,7 +8,6 @@ use andromeda_non_fungible_tokens::{
 use andromeda_std::{ado_base::modules::Module, amp::AndrAddr};
 use andromeda_std::{amp::Recipient, common::Milliseconds};
 use cosmwasm_std::{Coin, Empty, Uint128};
-use cw721::Expiration;
 use cw_multi_test::{Contract, ContractWrapper};
 
 pub fn mock_andromeda_crowdfund() -> Box<dyn Contract<Empty>> {
@@ -34,7 +33,7 @@ pub fn mock_crowdfund_instantiate_msg(
 
 pub fn mock_start_crowdfund_msg(
     start_time: Option<Milliseconds>,
-    end_time: Expiration,
+    end_time: Milliseconds,
     price: Coin,
     min_tokens_sold: Uint128,
     max_amount_per_wallet: Option<u32>,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -28,8 +28,7 @@ use andromeda_testing::economics_msg::generate_economics_message;
 use cosmwasm_std::{
     coin, coins, from_json,
     testing::{mock_env, mock_info},
-    Addr, BankMsg, Coin, CosmosMsg, DepsMut, Response, StdError, SubMsg, Timestamp, Uint128,
-    WasmMsg,
+    Addr, BankMsg, Coin, CosmosMsg, DepsMut, Response, StdError, SubMsg, Uint128, WasmMsg,
 };
 use cw_utils::Expiration;
 
@@ -186,7 +185,7 @@ fn test_mint_sale_started() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: None,
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: Some(5),
@@ -372,7 +371,7 @@ fn test_mint_multiple_exceeds_limit() {
 }
 
 #[test]
-fn test_start_sale_end_time_never() {
+fn test_start_sale_end_time_zero() {
     let mut deps = mock_dependencies_custom(&[]);
     init(deps.as_mut(), None);
     let one_minute_in_future =
@@ -380,7 +379,7 @@ fn test_start_sale_end_time_never() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: Some(Milliseconds(one_minute_in_future)),
-        end_time: Expiration::Never {},
+        end_time: Milliseconds::zero(),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: None,
@@ -389,7 +388,7 @@ fn test_start_sale_end_time_never() {
 
     let info = mock_info("owner", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg);
-    assert_eq!(ContractError::ExpirationMustNotBeNever {}, res.unwrap_err());
+    assert_eq!(ContractError::StartTimeAfterEndTime {}, res.unwrap_err());
 }
 
 #[test]
@@ -400,7 +399,7 @@ fn test_start_sale_unauthorized() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: None,
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 1) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 1) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: None,
@@ -422,7 +421,7 @@ fn test_start_sale_start_time_in_past() {
     let one_minute_in_past = env.block.time.minus_minutes(1).seconds();
     let msg = ExecuteMsg::StartSale {
         start_time: Some(Milliseconds(one_minute_in_past)),
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: None,
@@ -450,9 +449,7 @@ fn test_start_sale_start_time_in_future() {
         env.block.time.plus_minutes(1).nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO;
     let msg = ExecuteMsg::StartSale {
         start_time: Some(Milliseconds(one_minute_in_future)),
-        end_time: Expiration::AtTime(Timestamp::from_nanos(
-            (one_minute_in_future + 2) * 1_000_000,
-        )),
+        end_time: Milliseconds::from_nanos((one_minute_in_future + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: None,
@@ -472,7 +469,7 @@ fn test_start_sale_max_default() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: None,
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: None,
@@ -526,7 +523,7 @@ fn test_start_sale_max_modified() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: None,
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(1u128),
         max_amount_per_wallet: Some(5),
@@ -1197,7 +1194,7 @@ fn test_integration_conditions_not_met() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: None,
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(5u128),
         max_amount_per_wallet: Some(2),
@@ -1376,7 +1373,7 @@ fn test_integration_conditions_met() {
 
     let msg = ExecuteMsg::StartSale {
         start_time: None,
-        end_time: Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        end_time: Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         price: coin(100, "uusd"),
         min_tokens_sold: Uint128::from(3u128),
         max_amount_per_wallet: Some(2),

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -32,7 +32,7 @@ pub enum ExecuteMsg {
         token_id: String,
         token_address: String,
         start_time: Option<Milliseconds>,
-        duration: Milliseconds,
+        end_time: Milliseconds,
         coin_denom: String,
         whitelist: Option<Vec<Addr>>,
         min_bid: Option<Uint128>,
@@ -60,7 +60,7 @@ pub enum Cw721HookMsg {
         /// Start time in milliseconds since epoch
         start_time: Option<Milliseconds>,
         /// Duration in milliseconds
-        duration: Milliseconds,
+        end_time: Milliseconds,
         coin_denom: String,
         min_bid: Option<Uint128>,
         whitelist: Option<Vec<Addr>>,

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -24,7 +24,7 @@ pub enum ExecuteMsg {
         /// When the sale start. Defaults to current time.
         start_time: Option<Milliseconds>,
         /// When the sale ends.
-        end_time: Expiration,
+        end_time: Milliseconds,
         /// The price per token.
         price: Coin,
         /// The minimum amount of tokens sold to go through with the sale.

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -182,7 +182,7 @@ fn test_auction_app() {
     let start_time = router.block_info().time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO + 100;
     let receive_msg = mock_start_auction(
         Some(Milliseconds(start_time)),
-        Milliseconds(1000),
+        Milliseconds(start_time + 2),
         "uandr".to_string(),
         None,
         None,

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -21,13 +21,11 @@ use andromeda_splitter::mock::{
     mock_andromeda_splitter, mock_splitter_instantiate_msg, mock_splitter_send_msg,
 };
 use andromeda_std::ado_base::modules::Module;
-use cw20::Expiration;
-use std::str::FromStr;
-
 use andromeda_testing::mock::{init_balances, mock_app, MockAndromeda, MockApp};
-use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal, Timestamp, Uint128};
+use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal, Uint128};
 use cw721::OwnerOfResponse;
 use cw_multi_test::Executor;
+use std::str::FromStr;
 
 fn mock_andromeda(app: &mut MockApp, admin_address: Addr) -> MockAndromeda {
     MockAndromeda::new(app, &admin_address)
@@ -212,7 +210,7 @@ fn test_crowdfund_app() {
 
     let start_msg = mock_start_crowdfund_msg(
         None,
-        Expiration::AtTime(Timestamp::from_nanos((current_time + 2) * 1_000_000)),
+        Milliseconds::from_nanos((current_time + 2) * 1_000_000),
         token_price.clone(),
         Uint128::from(3u128),
         Some(1),


### PR DESCRIPTION
# Motivation
Resolves #385 

# Implementation
Crowdfund's `end_time` now uses `Milliseconds` instead of `Expiration`.
Auction's `duration` is now `end_time`, and is implemented the same way as in the Crowdfund

# Testing
Made the necessary adjustments