### PR TITLE
fixed add app component error

### DIFF
--- a/contracts/app/andromeda-app-contract/src/execute.rs
+++ b/contracts/app/andromeda-app-contract/src/execute.rs
@@ -79,6 +79,12 @@ pub fn handle_add_app_component(
     if let ComponentType::Symlink(ref val) = component.component_type {
         let component_address: Addr = val.get_raw_address(&ctx.deps.as_ref())?;
         ADO_ADDRESSES.save(ctx.deps.storage, &component.name, &component_address)?;
+    } else {
+        ADO_ADDRESSES.save(
+            ctx.deps.storage,
+            &component.name,
+            &new_addr.clone().unwrap(),
+        )?;
     }
 
     let event = component.generate_event(new_addr);

--- a/tests-integration/tests/app.rs
+++ b/tests-integration/tests/app.rs
@@ -62,10 +62,10 @@ fn test_app() {
     );
 
     // Create App
-    let app_components = vec![cw721_component];
+    let app_components = vec![cw721_component.clone()];
     let app_init_msg = mock_app_instantiate_msg(
         "SimpleApp".to_string(),
-        app_components.clone(),
+        vec![],
         andr.kernel_address.clone(),
         None,
     );
@@ -78,6 +78,15 @@ fn test_app() {
             &[],
             "Simple App",
             Some(owner.to_string()),
+        )
+        .unwrap();
+
+    router
+        .execute_contract(
+            owner.clone(),
+            app_addr.clone(),
+            &mock_add_app_component_msg(cw721_component),
+            &[],
         )
         .unwrap();
 


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/372

# Implementation

The error was thrown by the `reply` entry point that is triggered when `handle_add_app_component` is called with new component. The address of the newly generated component was not saved to `ADO_ADDRESSES`

- Updated `handle_add_app_component` function to save generated address to `ADO_ADDRESSES`

# Testing
- App integration test is updated to be initialized with no components and components are added after init process for testing purpose

# Notes
I accidently forked from development branch before and found that the origin version was saving empty address to the ADO_ADDRESSES and the new address was saved on the `reply` entry point. Would love to know if new component address should be saved in similar approach so that we can ensure that component address is updated after sub messages are handled successfully.
