### PR TITLE
Update lockdrop incentive token

### DIFF
--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -462,7 +462,7 @@ pub fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractEr
 
     let amount_to_transfer = total_incentives - user_info.delegated_incentives;
     let token = Asset::cw20(
-        deps.api.addr_validate(&config.incentive_token.to_string())?,
+        deps.api.addr_validate(config.incentive_token.as_ref())?,
         amount_to_transfer,
     );
     let transfer_msg = token.transfer_msg(user_address.clone())?;

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -67,7 +67,7 @@ pub fn instantiate(
         deposit_window: msg.deposit_window,
         withdrawal_window: msg.withdrawal_window,
         lockdrop_incentives: Uint128::zero(),
-        incentive_token: msg.incentive_token.get_raw_address(&deps.as_ref())?,
+        incentive_token: msg.incentive_token,
         native_denom: msg.native_denom,
     };
 
@@ -226,7 +226,7 @@ pub fn execute_increase_incentives(
     let mut config = CONFIG.load(deps.storage)?;
 
     ensure!(
-        info.sender == config.incentive_token,
+        info.sender == config.incentive_token.get_raw_address(&deps.as_ref())?,
         ContractError::InvalidFunds {
             msg: "Only incentive tokens are valid".to_string(),
         }

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -462,7 +462,7 @@ pub fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractEr
 
     let amount_to_transfer = total_incentives - user_info.delegated_incentives;
     let token = Asset::cw20(
-        deps.api.addr_validate(config.incentive_token.as_ref())?,
+        config.incentive_token.get_raw_address(&deps.as_ref())?,
         amount_to_transfer,
     );
     let transfer_msg = token.transfer_msg(user_address.clone())?;

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -67,7 +67,7 @@ pub fn instantiate(
         deposit_window: msg.deposit_window,
         withdrawal_window: msg.withdrawal_window,
         lockdrop_incentives: Uint128::zero(),
-        incentive_token: msg.incentive_token,
+        incentive_token: msg.incentive_token.get_raw_address(&deps.as_ref())?,
         native_denom: msg.native_denom,
     };
 
@@ -462,7 +462,7 @@ pub fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractEr
 
     let amount_to_transfer = total_incentives - user_info.delegated_incentives;
     let token = Asset::cw20(
-        deps.api.addr_validate(&config.incentive_token)?,
+        deps.api.addr_validate(&config.incentive_token.to_string())?,
         amount_to_transfer,
     );
     let transfer_msg = token.transfer_msg(user_address.clone())?;

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::lockdrop::{Cw20HookMsg, ExecuteMsg, InstantiateMsg};
-use andromeda_std::{ado_base::modules::Module, common::Milliseconds};
+use andromeda_std::{ado_base::modules::Module, common::Milliseconds, amp::AndrAddr};
 use cosmwasm_std::{Empty, Uint128};
 use cw_multi_test::{Contract, ContractWrapper};
 
@@ -16,7 +16,7 @@ pub fn mock_lockdrop_instantiate_msg(
     init_timestamp: Milliseconds,
     deposit_window: Milliseconds,
     withdrawal_window: Milliseconds,
-    incentive_token: String,
+    incentive_token: AndrAddr,
     native_denom: String,
     owner: Option<String>,
     modules: Option<Vec<Module>>,

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::lockdrop::{Cw20HookMsg, ExecuteMsg, InstantiateMsg};
-use andromeda_std::{ado_base::modules::Module, common::Milliseconds, amp::AndrAddr};
+use andromeda_std::{ado_base::modules::Module, amp::AndrAddr, common::Milliseconds};
 use cosmwasm_std::{Empty, Uint128};
 use cw_multi_test::{Contract, ContractWrapper};
 

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/state.rs
@@ -1,4 +1,4 @@
-use andromeda_std::common::Milliseconds;
+use andromeda_std::{amp::AndrAddr, common::Milliseconds};
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
 
@@ -26,7 +26,7 @@ pub struct Config {
     /// Total Token lockdrop incentives to be distributed among the users
     pub lockdrop_incentives: Uint128,
     /// The token being given as incentive.
-    pub incentive_token: Addr,
+    pub incentive_token: AndrAddr,
     /// The native token being deposited.
     pub native_denom: String,
 }

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/state.rs
@@ -26,7 +26,7 @@ pub struct Config {
     /// Total Token lockdrop incentives to be distributed among the users
     pub lockdrop_incentives: Uint128,
     /// The token being given as incentive.
-    pub incentive_token: String,
+    pub incentive_token: Addr,
     /// The native token being deposited.
     pub native_denom: String,
 }

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
@@ -8,6 +8,7 @@ use andromeda_fungible_tokens::lockdrop::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, StateResponse,
     UserInfoResponse,
 };
+use andromeda_std::amp::AndrAddr;
 use andromeda_std::{
     common::{expiration::MILLISECONDS_TO_NANOSECONDS_RATIO, Milliseconds},
     error::ContractError,
@@ -35,7 +36,7 @@ fn init(deps: DepsMut) -> Result<Response, ContractError> {
         init_timestamp: Milliseconds::from_seconds(env.block.time.seconds()),
         deposit_window: Milliseconds::from_seconds(DEPOSIT_WINDOW),
         withdrawal_window: Milliseconds::from_seconds(WITHDRAWAL_WINDOW),
-        incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+        incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
         native_denom: "uusd".to_string(),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
@@ -71,7 +72,7 @@ fn test_instantiate() {
             deposit_window: Milliseconds::from_seconds(DEPOSIT_WINDOW),
             withdrawal_window: Milliseconds::from_seconds(WITHDRAWAL_WINDOW),
             lockdrop_incentives: Uint128::zero(),
-            incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+            incentive_token: Addr::unchecked(MOCK_INCENTIVE_TOKEN),
             native_denom: "uusd".to_string()
         },
         config_res
@@ -101,7 +102,7 @@ fn test_instantiate_init_timestamp_past() {
         init_timestamp: Milliseconds::from_seconds(env.block.time.seconds() - 1),
         deposit_window: Milliseconds::from_seconds(5),
         withdrawal_window: Milliseconds::from_seconds(2),
-        incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+        incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
         native_denom: "uusd".to_string(),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
@@ -130,7 +131,7 @@ fn test_instantiate_init_deposit_window_zero() {
         init_timestamp: Milliseconds::from_seconds(env.block.time.seconds() + 1),
         deposit_window: Milliseconds::from_seconds(0),
         withdrawal_window: Milliseconds::from_seconds(2),
-        incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+        incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
         native_denom: "uusd".to_string(),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
@@ -153,7 +154,7 @@ fn test_instantiate_init_withdrawal_window_zero() {
         init_timestamp: Milliseconds::from_seconds(env.block.time.seconds() + 1),
         deposit_window: Milliseconds::from_seconds(5),
         withdrawal_window: Milliseconds::from_seconds(0),
-        incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+        incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
         native_denom: "uusd".to_string(),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
@@ -176,7 +177,7 @@ fn test_instantiate_init_deposit_window_less_than_withdrawal_window() {
         init_timestamp: Milliseconds::from_seconds(env.block.time.seconds() + 1),
         deposit_window: Milliseconds::from_seconds(2),
         withdrawal_window: Milliseconds::from_seconds(5),
-        incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+        incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
         native_denom: "uusd".to_string(),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
@@ -735,7 +736,7 @@ fn test_enable_claims_no_bootstrap_specified() {
 //         init_timestamp: mock_env().block.time.seconds(),
 //         deposit_window: DEPOSIT_WINDOW,
 //         withdrawal_window: WITHDRAWAL_WINDOW,
-//         incentive_token: MOCK_INCENTIVE_TOKEN.to_owned(),
+//         incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
 //         native_denom: "uusd".to_string(),
 //     };
 
@@ -854,7 +855,7 @@ fn test_claim_rewards() {
             .add_attribute("action", "claim_rewards")
             .add_attribute("amount", "75")
             .add_message(WasmMsg::Execute {
-                contract_addr: MOCK_INCENTIVE_TOKEN.to_owned(),
+                contract_addr: MOCK_INCENTIVE_TOKEN.to_string(),
                 funds: vec![],
                 msg: to_json_binary(&Cw20ExecuteMsg::Transfer {
                     recipient: "user1".to_string(),
@@ -893,7 +894,7 @@ fn test_claim_rewards() {
             .add_attribute("action", "claim_rewards")
             .add_attribute("amount", "25")
             .add_message(WasmMsg::Execute {
-                contract_addr: MOCK_INCENTIVE_TOKEN.to_owned(),
+                contract_addr: MOCK_INCENTIVE_TOKEN.to_string(),
                 funds: vec![],
                 msg: to_json_binary(&Cw20ExecuteMsg::Transfer {
                     recipient: "user2".to_string(),

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/testing/tests.rs
@@ -72,7 +72,7 @@ fn test_instantiate() {
             deposit_window: Milliseconds::from_seconds(DEPOSIT_WINDOW),
             withdrawal_window: Milliseconds::from_seconds(WITHDRAWAL_WINDOW),
             lockdrop_incentives: Uint128::zero(),
-            incentive_token: Addr::unchecked(MOCK_INCENTIVE_TOKEN),
+            incentive_token: AndrAddr::from_string(MOCK_INCENTIVE_TOKEN),
             native_denom: "uusd".to_string()
         },
         config_res

--- a/packages/andromeda-fungible-tokens/src/lockdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/lockdrop.rs
@@ -3,7 +3,7 @@ use andromeda_std::andr_instantiate_modules;
 use andromeda_std::common::Milliseconds;
 use andromeda_std::{andr_exec, andr_instantiate, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::Uint128;
 use cw20::Cw20ReceiveMsg;
 
 #[andr_instantiate]
@@ -84,7 +84,7 @@ pub struct ConfigResponse {
     /// Total token lockdrop incentives to be distributed among the users.
     pub lockdrop_incentives: Uint128,
     /// The token being given as incentive.
-    pub incentive_token: Addr,
+    pub incentive_token: AndrAddr,
     /// The native token being deposited.
     pub native_denom: String,
 }

--- a/packages/andromeda-fungible-tokens/src/lockdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/lockdrop.rs
@@ -3,7 +3,7 @@ use andromeda_std::andr_instantiate_modules;
 use andromeda_std::common::Milliseconds;
 use andromeda_std::{andr_exec, andr_instantiate, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Uint128, Addr};
+use cosmwasm_std::{Addr, Uint128};
 use cw20::Cw20ReceiveMsg;
 
 #[andr_instantiate]

--- a/packages/andromeda-fungible-tokens/src/lockdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/lockdrop.rs
@@ -1,8 +1,9 @@
+use andromeda_std::amp::AndrAddr;
 use andromeda_std::andr_instantiate_modules;
 use andromeda_std::common::Milliseconds;
 use andromeda_std::{andr_exec, andr_instantiate, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Uint128, Addr};
 use cw20::Cw20ReceiveMsg;
 
 #[andr_instantiate]
@@ -18,7 +19,7 @@ pub struct InstantiateMsg {
     /// Number of milliseconds for which lockup withdrawals will be allowed
     pub withdrawal_window: Milliseconds,
     /// The token being given as incentive.
-    pub incentive_token: String,
+    pub incentive_token: AndrAddr,
     /// The native token being deposited.
     pub native_denom: String,
 }
@@ -83,7 +84,7 @@ pub struct ConfigResponse {
     /// Total token lockdrop incentives to be distributed among the users.
     pub lockdrop_incentives: Uint128,
     /// The token being given as incentive.
-    pub incentive_token: String,
+    pub incentive_token: Addr,
     /// The native token being deposited.
     pub native_denom: String,
 }

--- a/tests-integration/tests/lockdrop.rs
+++ b/tests-integration/tests/lockdrop.rs
@@ -69,7 +69,7 @@ fn test_lockdrop() {
         Milliseconds::from_seconds(current_timestamp),
         Milliseconds::from_seconds(100u64),
         Milliseconds::from_seconds(50u64),
-        cw20_incentives_address.to_string(),
+        AndrAddr::from_string(cw20_incentives_address.to_string()),
         "uusd".to_string(),
         None,
         None,

--- a/tests-integration/tests/lockdrop.rs
+++ b/tests-integration/tests/lockdrop.rs
@@ -69,7 +69,7 @@ fn test_lockdrop() {
         Milliseconds::from_seconds(current_timestamp),
         Milliseconds::from_seconds(100u64),
         Milliseconds::from_seconds(50u64),
-        AndrAddr::from_string(cw20_incentives_address.to_string()),
+        AndrAddr::from_string(format!("~{0}", cw20_incentives_address)),
         "uusd".to_string(),
         None,
         None,


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/387

# Implementation

- Updated `InstantiateMsg` msg to use `AndrAddr` for `incentive_token`
- Updated the state to save `incentive_token` as `Addr` in `CONFIG`

# Testing

- Updated test cases to use `AndrAddr` in instantiation