### PR TITLE
Fixx/auction cosmwasm 1 3

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -16,10 +16,10 @@ testing = ["cw-multi-test"]
 
 
 [dependencies]
-cosmwasm-std = { workspace = true, features=["cosmwasm_1_3"] }
+cosmwasm-std = { workspace = true, features = ["cosmwasm_1_1"] }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
-cw-utils = { workspace = true}
+cw-utils = { workspace = true }
 cw721 = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }


### PR DESCRIPTION
# Motivation

Auction contract upload was failing on andromeda devnet with error
```
Uploading auction@1.0.0-rc.1 - ./contracts/andromeda_auction@1.0.0-rc.1.wasm...
Error: Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: Error calling the VM: Error during static Wasm validation: Wasm contract requires unavailable capabilities: {"cosmwasm_1_3"}: create wasm contract failed [CosmWasm/wasmd@v0.41.0/x/wasm/keeper/keeper.go:177] With gas wanted: '18446744073709551615' and gas used: '4255909' : unknown request
```

Changing cosmwasm_1_3 -> cosmwasm_1_1 seems to fix the issue - suggested by @crnbarr93 

# Implementation

Change cosmwasm_1_3 -> cosmwasm_1_1

# Testing

- [x] Test upload on andromeda devnet and stargaze

