### PR TITLE
[Fix]: Local AMP Message Recipient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ strip = true
 
 [workspace.dependencies]
 andromeda-std = { path = "./packages/std" }
-andromeda-macros = { path = "./packages/std/macros" }
+andromeda-macros = { path = "./packages/std/macros", version = "1.0.0-rc1" }
 andromeda-non-fungible-tokens = { path = "./packages/andromeda-non-fungible-tokens" }
 andromeda-fungible-tokens = { path = "./packages/andromeda-fungible-tokens" }
 andromeda-finance = { path = "./packages/andromeda-finance" }

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -182,7 +182,9 @@ fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
         // let direct_message = recipient_addr
         //     .recipient
         //     .generate_direct_msg(&deps.as_ref(), vec_coin)?;
-        let amp_msg = recipient_addr.recipient.generate_amp_msg(Some(vec_coin));
+        let amp_msg = recipient_addr
+            .recipient
+            .generate_amp_msg(&deps.as_ref(), Some(vec_coin))?;
         pkt = pkt.add_message(amp_msg);
     }
     remainder_funds.retain(|x| x.amount > Uint128::zero());

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -34,9 +34,6 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    msg.validate(deps.as_ref())?;
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
     let current_time = Milliseconds::from_seconds(env.block.time.seconds());
     let splitter = match msg.lock_time {
         Some(lock_time) => {
@@ -52,13 +49,13 @@ pub fn instantiate(
                 ContractError::LockTimeTooLong {}
             );
             Splitter {
-                recipients: msg.recipients,
+                recipients: msg.recipients.clone(),
                 lock: current_time.plus_milliseconds(lock_time),
             }
         }
         None => {
             Splitter {
-                recipients: msg.recipients,
+                recipients: msg.recipients.clone(),
                 // If locking isn't desired upon instantiation, it's automatically set to 0
                 lock: Milliseconds::default(),
             }
@@ -77,10 +74,12 @@ pub fn instantiate(
         BaseInstantiateMsg {
             ado_type: CONTRACT_NAME.to_string(),
             ado_version: CONTRACT_VERSION.to_string(),
-            kernel_address: msg.kernel_address,
-            owner: msg.owner,
+            kernel_address: msg.kernel_address.clone(),
+            owner: msg.owner.clone(),
         },
     )?;
+
+    msg.validate(deps.as_ref())?;
 
     Ok(inst_resp)
 }

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -184,8 +184,12 @@ fn test_execute_send() {
     ];
     let msg = ExecuteMsg::Send {};
 
-    let amp_msg_1 = recip1.generate_amp_msg(Some(vec![Coin::new(1000, "uluna")]));
-    let amp_msg_2 = recip2.generate_amp_msg(Some(vec![Coin::new(2000, "uluna")]));
+    let amp_msg_1 = recip1
+        .generate_amp_msg(&deps.as_ref(), Some(vec![Coin::new(1000, "uluna")]))
+        .unwrap();
+    let amp_msg_2 = recip2
+        .generate_amp_msg(&deps.as_ref(), Some(vec![Coin::new(2000, "uluna")]))
+        .unwrap();
     let amp_pkt = AMPPkt::new(
         MOCK_CONTRACT_ADDR.to_string(),
         MOCK_CONTRACT_ADDR.to_string(),
@@ -255,8 +259,12 @@ fn test_execute_send_ado_recipient() {
     ];
     let msg = ExecuteMsg::Send {};
 
-    let amp_msg_1 = recip1.generate_amp_msg(Some(vec![Coin::new(1000, "uluna")]));
-    let amp_msg_2 = recip2.generate_amp_msg(Some(vec![Coin::new(2000, "uluna")]));
+    let amp_msg_1 = recip1
+        .generate_amp_msg(&deps.as_ref(), Some(vec![Coin::new(1000, "uluna")]))
+        .unwrap();
+    let amp_msg_2 = recip2
+        .generate_amp_msg(&deps.as_ref(), Some(vec![Coin::new(2000, "uluna")]))
+        .unwrap();
     let amp_pkt = AMPPkt::new(
         MOCK_CONTRACT_ADDR.to_string(),
         MOCK_CONTRACT_ADDR.to_string(),

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -687,7 +687,10 @@ fn transfer_tokens_and_send_funds(
                     );
                 }
                 Some(_) => {
-                    let amp_message = state.recipient.generate_amp_msg(Some(funds));
+                    let amp_message = state
+                        .recipient
+                        .generate_amp_msg(&deps.as_ref(), Some(funds))
+                        .unwrap();
                     pkt = pkt.add_message(amp_message);
                     let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
                     let sub_msg = pkt.to_sub_msg(

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -299,6 +299,7 @@ fn execute_start_sale(
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
+    recipient.validate(&deps.as_ref())?;
     nonpayable(&info)?;
     let ado_contract = ADOContract::default();
 

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -99,6 +99,7 @@ pub fn validate_recipient_list(
     let mut recipient_address_set = HashSet::new();
 
     for rec in recipients {
+        rec.recipient.validate(&deps)?;
         percent_sum = percent_sum.checked_add(rec.percent)?;
         ensure!(
             percent_sum <= Decimal::one(),

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = { version = "1.0.21" }
 lazy_static = "1"
 hex = "0.4"
 regex = { version = "1.9.1", default-features = false }
-andromeda-macros = { workspace = true, version = "1.0.0-rc1" }
+andromeda-macros = { workspace = true }
 strum_macros = { workspace = true }
 cw721 = { workspace = true }
 serde-json-wasm = "0.5.0"

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -119,7 +119,7 @@ impl AndrAddr {
     }
 
     /// Converts a local path to a valid VFS path by replacing `./` with the app contract address
-    fn local_path_to_vfs_path(
+    pub fn local_path_to_vfs_path(
         &self,
         storage: &dyn Storage,
         querier: &QuerierWrapper,

--- a/packages/std/src/amp/recipient.rs
+++ b/packages/std/src/amp/recipient.rs
@@ -1,5 +1,5 @@
 use super::{addresses::AndrAddr, messages::AMPMsg};
-use crate::{common::encode_binary, error::ContractError};
+use crate::{ado_contract::ADOContract, common::encode_binary, error::ContractError};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, SubMsg, WasmMsg};
 use cw20::{Cw20Coin, Cw20ExecuteMsg};
@@ -98,13 +98,22 @@ impl Recipient {
     /// Generates an AMP message from the given Recipient.
     ///
     /// This can be attached to an AMP Packet for execution via the aOS.
-    pub fn generate_amp_msg(&self, funds: Option<Vec<Coin>>) -> AMPMsg {
-        AMPMsg::new(
-            self.address.to_string(),
+    pub fn generate_amp_msg(
+        &self,
+        deps: &Deps,
+        funds: Option<Vec<Coin>>,
+    ) -> Result<AMPMsg, ContractError> {
+        let mut address = self.address.clone();
+        if address.is_local_path() {
+            let vfs_addr = ADOContract::default().get_vfs_address(deps.storage, &deps.querier)?;
+            address = address.local_path_to_vfs_path(deps.storage, &deps.querier, vfs_addr)?;
+        }
+        Ok(AMPMsg::new(
+            address.to_string(),
             self.msg.clone().unwrap_or_default(),
             funds,
         )
-        .with_ibc_recovery(self.ibc_recovery_address.clone())
+        .with_ibc_recovery(self.ibc_recovery_address.clone()))
     }
 
     /// Adds an IBC recovery address to the recipient
@@ -126,7 +135,9 @@ impl Recipient {
 
 #[cfg(test)]
 mod test {
-    use cosmwasm_std::{from_json, testing::mock_dependencies, Uint128};
+    use cosmwasm_std::{from_json, testing::mock_dependencies, Addr, Uint128};
+
+    use crate::testing::mock_querier::{mock_dependencies_custom, MOCK_APP_CONTRACT};
 
     use super::*;
 
@@ -229,13 +240,14 @@ mod test {
     #[test]
     fn test_generate_amp_msg() {
         let recipient = Recipient::from_string("test");
-        let msg = recipient.generate_amp_msg(None);
+        let mut deps = mock_dependencies_custom(&[]);
+        let msg = recipient.generate_amp_msg(&deps.as_ref(), None).unwrap();
         assert_eq!(msg.recipient, "test");
         assert_eq!(msg.message, Binary::default());
         assert_eq!(msg.funds, vec![] as Vec<Coin>);
 
         let recipient = Recipient::new("test", Some(Binary::from(b"test".to_vec())));
-        let msg = recipient.generate_amp_msg(None);
+        let msg = recipient.generate_amp_msg(&deps.as_ref(), None).unwrap();
         assert_eq!(msg.recipient, "test");
         assert_eq!(msg.message, Binary::from(b"test".to_vec()));
         assert_eq!(msg.funds, vec![] as Vec<Coin>);
@@ -245,8 +257,25 @@ mod test {
             amount: Uint128::from(100u128),
         }];
         let recipient = Recipient::from_string("test");
-        let msg = recipient.generate_amp_msg(Some(funds.clone()));
+        let msg = recipient
+            .generate_amp_msg(&deps.as_ref(), Some(funds.clone()))
+            .unwrap();
         assert_eq!(msg.recipient, "test");
+        assert_eq!(msg.message, Binary::default());
+        assert_eq!(msg.funds, funds);
+
+        ADOContract::default()
+            .app_contract
+            .save(deps.as_mut().storage, &Addr::unchecked(MOCK_APP_CONTRACT))
+            .unwrap();
+        let recipient = Recipient::from_string("./test");
+        let msg = recipient
+            .generate_amp_msg(&deps.as_ref(), Some(funds.clone()))
+            .unwrap();
+        assert_eq!(
+            msg.recipient.to_string(),
+            format!("~{MOCK_APP_CONTRACT}/test")
+        );
         assert_eq!(msg.message, Binary::default());
         assert_eq!(msg.funds, funds);
     }

--- a/packages/std/src/amp/recipient.rs
+++ b/packages/std/src/amp/recipient.rs
@@ -27,6 +27,20 @@ impl Recipient {
         }
     }
 
+    /// Validates a recipient by validating its address and recovery address (if it is provided)
+    pub fn validate(&self, deps: &Deps) -> Result<(), ContractError> {
+        self.address.validate(deps.api)?;
+        self.address.get_raw_address(deps)?;
+
+        // Validate the recovery address if it is providedReci
+        if let Some(ibc_recovery_address) = self.ibc_recovery_address.clone() {
+            ibc_recovery_address.validate(deps.api)?;
+            ibc_recovery_address.get_raw_address(deps)?;
+        }
+
+        Ok(())
+    }
+
     /// Creates a Recipient from the given string with no attached message
     pub fn from_string(addr: impl Into<String>) -> Recipient {
         Recipient {

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -31,7 +31,6 @@ fn mock_andromeda(app: &mut MockApp, admin_address: Addr) -> MockAndromeda {
     MockAndromeda::new(app, &admin_address)
 }
 
-// TODO: Fix to check wallet balance post sale
 #[test]
 fn test_crowdfund_app() {
     let mut router = mock_app();
@@ -203,9 +202,8 @@ fn test_crowdfund_app() {
     // Start Sale
     let token_price = coin(100, "uandr");
 
-    let sale_recipient =
-        Recipient::from_string(format!("/home/{owner}/app/{}", splitter_app_component.name))
-            .with_msg(mock_splitter_send_msg());
+    let sale_recipient = Recipient::from_string(format!("./{}", splitter_app_component.name))
+        .with_msg(mock_splitter_send_msg());
     let current_time = router.block_info().time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO;
 
     let start_msg = mock_start_crowdfund_msg(

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -123,7 +123,7 @@ fn test_crowdfund_app() {
     // Eventhough it shows in execute_send's response in the splitter that both messages are being sent.
     let splitter_recipients = vec![
         AddressPercent {
-            recipient: Recipient::from_string(vault_one_recipient_addr),
+            recipient: Recipient::from_string(format!("~{vault_one_recipient_addr}")),
             percent: Decimal::from_str("0.5").unwrap(),
         },
         AddressPercent {


### PR DESCRIPTION
Closes: #395 

# Motivation

When a `Recipient` struct was used with a local reference (starting with `./`) as it's address the message was sent without converting from a local path to an absolute path. These changes correct that.

# Implementation

Upon generating an AMP message we check if the recipient address is a local path, if it is we convert it to an absolute path before returning the generated message:

```rust
    pub fn generate_amp_msg(
        &self,
        deps: &Deps,
        funds: Option<Vec<Coin>>,
    ) -> Result<AMPMsg, ContractError> {
        let mut address = self.address.clone();
        if address.is_local_path() {
            let vfs_addr = ADOContract::default().get_vfs_address(deps.storage, &deps.querier)?;
            address = address.local_path_to_vfs_path(deps.storage, &deps.querier, vfs_addr)?;
        }
        Ok(AMPMsg::new(
            address.to_string(),
            self.msg.clone().unwrap_or_default(),
            funds,
        )
        .with_ibc_recovery(self.ibc_recovery_address.clone()))
    }
```

# Testing

The `crowdfund_app.rs` test was updated to use a local reference for the sale recipient.

# Notes

This PR also includes an additional `validate` function for `Recipient`.
