### PR TITLE
[1.0.rc-1] AndrAddr for Some CW20 & CW721 Messages

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -107,6 +107,34 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
             amount,
             msg,
         } => execute_send(ctx, contract, amount, msg),
+        ExecuteMsg::SendFrom {
+            owner,
+            contract,
+            amount,
+            msg,
+        } => {
+            let contract = contract.get_raw_address(&ctx.deps.as_ref())?.into_string();
+            let msg = Cw20ExecuteMsg::SendFrom {
+                owner,
+                contract,
+                amount,
+                msg,
+            };
+            Ok(execute_cw20(ctx.deps, ctx.env, ctx.info, msg)?)
+        }
+        ExecuteMsg::TransferFrom {
+            owner,
+            recipient,
+            amount,
+        } => {
+            let recipient = recipient.get_raw_address(&ctx.deps.as_ref())?.into_string();
+            let msg = Cw20ExecuteMsg::TransferFrom {
+                owner,
+                recipient,
+                amount,
+            };
+            Ok(execute_cw20(ctx.deps, ctx.env, ctx.info, msg)?)
+        }
         ExecuteMsg::Mint { recipient, amount } => execute_mint(ctx, recipient, amount),
         _ => {
             let serialized = encode_binary(&msg)?;
@@ -124,7 +152,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
 
 fn execute_transfer(
     ctx: ExecuteContext,
-    recipient: String,
+    recipient: AndrAddr,
     amount: Uint128,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -151,6 +179,7 @@ fn execute_transfer(
 
     let mut resp = filter_out_cw20_messages(msgs, deps.storage, deps.api, &info.sender)?;
 
+    let recipient = recipient.get_raw_address(&deps.as_ref())?.into_string();
     // Continue with standard cw20 operation
     let cw20_resp = execute_cw20(
         deps,

--- a/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
@@ -57,6 +57,6 @@ pub fn mock_cw20_send(contract: AndrAddr, amount: Uint128, msg: Binary) -> Execu
     }
 }
 
-pub fn mock_cw20_transfer(recipient: String, amount: Uint128) -> ExecuteMsg {
+pub fn mock_cw20_transfer(recipient: AndrAddr, amount: Uint128) -> ExecuteMsg {
     ExecuteMsg::Transfer { recipient, amount }
 }

--- a/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
@@ -78,7 +78,7 @@ fn test_transfer() {
     );
 
     let msg = ExecuteMsg::Transfer {
-        recipient: "other".into(),
+        recipient: AndrAddr::from_string("other"),
         amount: 100u128.into(),
     };
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -908,7 +908,7 @@ fn execute_claim_no_bids() {
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: MOCK_TOKEN_ADDR.to_owned(),
                 msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
-                    recipient: MOCK_TOKEN_OWNER.to_owned(),
+                    recipient: AndrAddr::from_string(MOCK_TOKEN_OWNER.to_owned()),
                     token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
                 })
                 .unwrap(),
@@ -966,7 +966,7 @@ fn execute_claim() {
     let info = mock_info("any_user", &[]);
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
     let transfer_nft_msg = Cw721ExecuteMsg::TransferNft {
-        recipient: "sender".to_string(),
+        recipient: AndrAddr::from_string("sender".to_string()),
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
     };
     assert_eq!(
@@ -1087,7 +1087,7 @@ fn execute_cancel_no_bids() {
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: MOCK_TOKEN_ADDR.to_owned(),
                 msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
-                    recipient: MOCK_TOKEN_OWNER.to_owned(),
+                    recipient: AndrAddr::from_string(MOCK_TOKEN_OWNER.to_owned()),
                     token_id: MOCK_UNCLAIMED_TOKEN.to_owned()
                 })
                 .unwrap(),
@@ -1148,7 +1148,7 @@ fn execute_cancel_with_bids() {
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: MOCK_TOKEN_ADDR.to_owned(),
                 msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
-                    recipient: MOCK_TOKEN_OWNER.to_owned(),
+                    recipient: AndrAddr::from_string(MOCK_TOKEN_OWNER.to_owned()),
                     token_id: MOCK_UNCLAIMED_TOKEN.to_owned()
                 })
                 .unwrap(),

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -772,7 +772,7 @@ fn transfer_tokens_and_send_funds(
         transfer_msgs.push(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: token_contract_address.to_string(),
             msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
-                recipient: purchaser,
+                recipient: AndrAddr::from_string(purchaser),
                 token_id: purchase.token_id,
             })?,
             funds: vec![],

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -79,11 +79,11 @@ fn get_burn_message(token_id: impl Into<String>) -> CosmosMsg {
     })
 }
 
-fn get_transfer_message(token_id: impl Into<String>, recipient: impl Into<String>) -> CosmosMsg {
+fn get_transfer_message(token_id: impl Into<String>, recipient: AndrAddr) -> CosmosMsg {
     CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: MOCK_TOKEN_CONTRACT.to_owned(),
         msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
-            recipient: recipient.into(),
+            recipient,
             token_id: token_id.into(),
         })
         .unwrap(),
@@ -1462,7 +1462,10 @@ fn test_integration_conditions_met() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "transfer_tokens_and_send_funds")
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[0], "A"))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[0],
+                AndrAddr::from_string("A")
+            ))
             .add_submessages(get_rates_messages())
             .add_submessage(generate_economics_message("anyone", "EndSale")),
         res
@@ -1482,8 +1485,14 @@ fn test_integration_conditions_met() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "transfer_tokens_and_send_funds")
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[1], "A"))
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[2], "B"))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[1],
+                AndrAddr::from_string("A")
+            ))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[2],
+                AndrAddr::from_string("B")
+            ))
             .add_message(CosmosMsg::Bank(BankMsg::Send {
                 to_address: MOCK_ROYALTY_RECIPIENT.to_owned(),
                 amount: vec![Coin {
@@ -1521,8 +1530,14 @@ fn test_integration_conditions_met() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "transfer_tokens_and_send_funds")
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[3], "C"))
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[4], "D"))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[3],
+                AndrAddr::from_string("C")
+            ))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[4],
+                AndrAddr::from_string("D")
+            ))
             .add_message(CosmosMsg::Bank(BankMsg::Send {
                 to_address: MOCK_ROYALTY_RECIPIENT.to_owned(),
                 amount: vec![Coin {
@@ -1625,7 +1640,10 @@ fn test_end_sale_single_purchase() {
         Response::new()
             .add_attribute("action", "transfer_tokens_and_send_funds")
             // Burn tokens that were not purchased
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[0], "A"))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[0],
+                AndrAddr::from_string("A")
+            ))
             .add_submessage(generate_economics_message("anyone", "EndSale")),
         res
     );
@@ -1678,7 +1696,10 @@ fn test_end_sale_all_tokens_sold() {
         Response::new()
             .add_attribute("action", "transfer_tokens_and_send_funds")
             // Burn tokens that were not purchased
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[0], "A"))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[0],
+                AndrAddr::from_string("A")
+            ))
             .add_submessage(generate_economics_message("anyone", "EndSale")),
         res
     );
@@ -1737,7 +1758,10 @@ fn test_end_sale_some_tokens_sold_threshold_met() {
         Response::new()
             .add_attribute("action", "transfer_tokens_and_send_funds")
             // Burn tokens that were not purchased
-            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[0], "A"))
+            .add_message(get_transfer_message(
+                MOCK_TOKENS_FOR_SALE[0],
+                AndrAddr::from_string("A")
+            ))
             .add_submessage(generate_economics_message("owner", "EndSale")),
         res
     );

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -394,11 +394,11 @@ fn check_can_send(
 }
 
 fn execute_update_transfer_agreement(
-    env: ExecuteContext,
+    ctx: ExecuteContext,
     token_id: String,
     agreement: Option<TransferAgreement>,
 ) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, info, .. } = env;
+    let ExecuteContext { deps, info, .. } = ctx;
     let contract = AndrCW721Contract::default();
     let token = contract.tokens.load(deps.storage, &token_id)?;
     ensure!(token.owner == info.sender, ContractError::Unauthorized {});
@@ -422,8 +422,8 @@ fn execute_update_transfer_agreement(
     Ok(Response::default())
 }
 
-fn execute_archive(env: ExecuteContext, token_id: String) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, info, .. } = env;
+fn execute_archive(ctx: ExecuteContext, token_id: String) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, info, .. } = ctx;
     ensure!(
         !is_archived(deps.storage, &token_id)?,
         ContractError::TokenIsArchived {}
@@ -439,8 +439,8 @@ fn execute_archive(env: ExecuteContext, token_id: String) -> Result<Response, Co
     Ok(Response::default())
 }
 
-fn execute_burn(env: ExecuteContext, token_id: String) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, info, .. } = env;
+fn execute_burn(ctx: ExecuteContext, token_id: String) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, info, .. } = ctx;
     let contract = AndrCW721Contract::default();
     let token = contract.tokens.load(deps.storage, &token_id)?;
     ensure!(token.owner == info.sender, ContractError::Unauthorized {});

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/mock.rs
@@ -74,7 +74,7 @@ pub fn mock_send_nft(contract: AndrAddr, token_id: String, msg: Binary) -> Execu
     }
 }
 
-pub fn mock_transfer_nft(recipient: String, token_id: String) -> ExecuteMsg {
+pub fn mock_transfer_nft(recipient: AndrAddr, token_id: String) -> ExecuteMsg {
     ExecuteMsg::TransferNft {
         recipient,
         token_id,

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/testing/mod.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/testing/mod.rs
@@ -66,7 +66,7 @@ fn test_transfer_nft() {
     );
 
     let transfer_msg = ExecuteMsg::TransferNft {
-        recipient: Addr::unchecked("recipient").to_string(),
+        recipient: AndrAddr::from_string(Addr::unchecked("recipient").to_string()),
         token_id: token_id.clone(),
     };
 
@@ -148,7 +148,7 @@ fn test_agreed_transfer_nft() {
     .unwrap();
 
     let transfer_msg = ExecuteMsg::TransferNft {
-        recipient: Addr::unchecked("recipient").to_string(),
+        recipient: AndrAddr::from_string(Addr::unchecked("recipient").to_string()),
         token_id: token_id.clone(),
     };
 
@@ -210,7 +210,7 @@ fn test_agreed_transfer_nft_wildcard() {
 
     // Transfer the nft
     let transfer_msg = ExecuteMsg::TransferNft {
-        recipient: Addr::unchecked("recipient").to_string(),
+        recipient: AndrAddr::from_string(Addr::unchecked("recipient").to_string()),
         token_id: token_id.clone(),
     };
 

--- a/contracts/os/andromeda-kernel/src/ibc.rs
+++ b/contracts/os/andromeda-kernel/src/ibc.rs
@@ -164,7 +164,7 @@ pub fn do_ibc_packet_receive(
 }
 
 pub fn ibc_create_ado(
-    _execute_env: ExecuteContext,
+    _execute_ctx: ExecuteContext,
     _owner: AndrAddr,
     _ado_type: String,
     _msg: Binary,
@@ -179,14 +179,14 @@ pub fn ibc_create_ado(
 }
 
 pub fn ibc_register_username(
-    execute_env: ExecuteContext,
+    execute_ctx: ExecuteContext,
     username: String,
     addr: String,
 ) -> Result<IbcReceiveResponse, ContractError> {
-    let vfs_address = KERNEL_ADDRESSES.load(execute_env.deps.storage, VFS_KEY)?;
+    let vfs_address = KERNEL_ADDRESSES.load(execute_ctx.deps.storage, VFS_KEY)?;
     let msg = VFSExecuteMsg::RegisterUser {
         username,
-        address: Some(execute_env.deps.api.addr_validate(&addr)?),
+        address: Some(execute_ctx.deps.api.addr_validate(&addr)?),
     };
     let sub_msg: SubMsg<Empty> = SubMsg::reply_on_error(
         WasmMsg::Execute {

--- a/packages/andromeda-fungible-tokens/src/cw20.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20.rs
@@ -39,7 +39,10 @@ impl From<InstantiateMsg> for Cw20InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Transfer is a base message to move tokens to another account without triggering actions
-    Transfer { recipient: String, amount: Uint128 },
+    Transfer {
+        recipient: AndrAddr,
+        amount: Uint128,
+    },
     /// Burn is a base message to destroy tokens forever
     Burn { amount: Uint128 },
     /// Send is a base message to transfer tokens to a contract and trigger an action
@@ -69,14 +72,14 @@ pub enum ExecuteMsg {
     /// if `env.sender` has sufficient pre-approval.
     TransferFrom {
         owner: String,
-        recipient: String,
+        recipient: AndrAddr,
         amount: Uint128,
     },
     /// Only with "approval" extension. Sends amount tokens from owner -> contract
     /// if `env.sender` has sufficient pre-approval.
     SendFrom {
         owner: String,
-        contract: String,
+        contract: AndrAddr,
         amount: Uint128,
         msg: Binary,
     },
@@ -103,9 +106,10 @@ pub enum ExecuteMsg {
 impl From<ExecuteMsg> for Cw20ExecuteMsg {
     fn from(msg: ExecuteMsg) -> Self {
         match msg {
-            ExecuteMsg::Transfer { recipient, amount } => {
-                Cw20ExecuteMsg::Transfer { recipient, amount }
-            }
+            ExecuteMsg::Transfer { recipient, amount } => Cw20ExecuteMsg::Transfer {
+                recipient: recipient.to_string(),
+                amount,
+            },
             ExecuteMsg::Burn { amount } => Cw20ExecuteMsg::Burn { amount },
             ExecuteMsg::Send {
                 contract,
@@ -140,7 +144,7 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
                 amount,
             } => Cw20ExecuteMsg::TransferFrom {
                 owner,
-                recipient,
+                recipient: recipient.to_string(),
                 amount,
             },
             ExecuteMsg::SendFrom {
@@ -150,7 +154,7 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
                 msg,
             } => Cw20ExecuteMsg::SendFrom {
                 owner,
-                contract,
+                contract: contract.to_string(),
                 amount,
                 msg,
             },

--- a/packages/andromeda-non-fungible-tokens/src/cw721.rs
+++ b/packages/andromeda-non-fungible-tokens/src/cw721.rs
@@ -84,7 +84,10 @@ pub enum ExecuteMsg {
         extension: TokenExtension,
     },
     /// Transfers ownership of a token
-    TransferNft { recipient: String, token_id: String },
+    TransferNft {
+        recipient: AndrAddr,
+        token_id: String,
+    },
     /// Sends a token to another contract
     SendNft {
         contract: AndrAddr,
@@ -127,7 +130,7 @@ impl From<ExecuteMsg> for Cw721ExecuteMsg<TokenExtension, ExecuteMsg> {
                 recipient,
                 token_id,
             } => Cw721ExecuteMsg::TransferNft {
-                recipient,
+                recipient: recipient.to_string(),
                 token_id,
             },
             ExecuteMsg::SendNft {

--- a/tests-integration/tests/cw20_staking.rs
+++ b/tests-integration/tests/cw20_staking.rs
@@ -182,7 +182,10 @@ fn test_cw20_staking_app() {
         .unwrap();
 
     // Transfer Tokens for Reward
-    let transfer_msg = mock_cw20_transfer(cw20_staking_addr.to_string(), Uint128::from(3000u128));
+    let transfer_msg = mock_cw20_transfer(
+        AndrAddr::from_string(cw20_staking_addr.to_string()),
+        Uint128::from(3000u128),
+    );
     router
         .execute_contract(owner, cw20_addr, &transfer_msg, &[])
         .unwrap();
@@ -318,7 +321,10 @@ fn test_cw20_staking_app_delayed() {
         .unwrap();
 
     // Transfer Tokens for Reward
-    let transfer_msg = mock_cw20_transfer(cw20_staking_addr.to_string(), Uint128::from(3000u128));
+    let transfer_msg = mock_cw20_transfer(
+        AndrAddr::from_string(cw20_staking_addr.to_string()),
+        Uint128::from(3000u128),
+    );
     router
         .execute_contract(owner.clone(), cw20_addr, &transfer_msg, &[])
         .unwrap();

--- a/tests-integration/tests/cw20_staking.rs
+++ b/tests-integration/tests/cw20_staking.rs
@@ -164,7 +164,7 @@ fn test_cw20_staking_app() {
 
     // Stake Tokens
     let staking_msg_one = mock_cw20_send(
-        AndrAddr::from_string(cw20_staking_addr.to_string()),
+        AndrAddr::from_string("./cw20staking"),
         Uint128::from(1000u128),
         to_json_binary(&mock_cw20_stake()).unwrap(),
     );
@@ -303,7 +303,7 @@ fn test_cw20_staking_app_delayed() {
 
     // Stake Tokens
     let staking_msg_one = mock_cw20_send(
-        AndrAddr::from_string(cw20_staking_addr.to_string()),
+        AndrAddr::from_string("./cw20staking"),
         Uint128::from(1000u128),
         to_json_binary(&mock_cw20_stake()).unwrap(),
     );


### PR DESCRIPTION
# Motivation
Closes #397 

# Implementation
Replaced `String` with `AndrAddr` for `recipient` or `contract` fields. 

Call `get_raw_address` whenever the raw address is needed.

#### Unrelated to the linked issue:
 Replaced all instances of `env: ExecuteContext` with `ctx: ExecuteContext`

# Testing
Replaced `String` with `AndrAddr` in the relevant places.

Replaced some raw addresses with VFS path in cw20 staking integration test. 
