### PR TITLE
[RC]: Marketplace and Auction Recipients

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -566,7 +566,7 @@ fn execute_claim(
     if !after_tax_payment.0.amount.is_zero() {
         let recipient = token_auction_state
             .recipient
-            .unwrap_or(Recipient::from_string(info.sender));
+            .unwrap_or(Recipient::from_string(token_auction_state.owner));
         let msg = recipient.generate_direct_msg(&deps.as_ref(), vec![after_tax_payment.0])?;
         // Send funds to the specified recipient
         response = response.add_submessage(msg);

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -55,8 +55,11 @@ impl MockAuction {
         coin_denom: String,
         min_bid: Option<Uint128>,
         whitelist: Option<Vec<Addr>>,
+        recipient: Option<Recipient>,
     ) -> AppResponse {
-        let msg = mock_start_auction(start_time, end_time, coin_denom, min_bid, whitelist);
+        let msg = mock_start_auction(
+            start_time, end_time, coin_denom, min_bid, whitelist, recipient,
+        );
         app.execute_contract(sender, self.addr().clone(), &msg, &[])
             .unwrap()
     }
@@ -80,9 +83,8 @@ impl MockAuction {
         sender: Addr,
         token_id: String,
         token_address: String,
-        recipient: Option<Recipient>,
     ) -> ExecuteResult {
-        let msg = mock_claim_auction(token_id, token_address, recipient);
+        let msg = mock_claim_auction(token_id, token_address);
         self.execute(app, &msg, sender, &[])
     }
 
@@ -138,6 +140,7 @@ pub fn mock_start_auction(
     coin_denom: String,
     min_bid: Option<Uint128>,
     whitelist: Option<Vec<Addr>>,
+    recipient: Option<Recipient>,
 ) -> Cw721HookMsg {
     Cw721HookMsg::StartAuction {
         start_time,
@@ -145,6 +148,7 @@ pub fn mock_start_auction(
         coin_denom,
         min_bid,
         whitelist,
+        recipient,
     }
 }
 
@@ -193,15 +197,10 @@ pub fn mock_get_bids(auction_id: Uint128) -> QueryMsg {
     }
 }
 
-pub fn mock_claim_auction(
-    token_id: String,
-    token_address: String,
-    recipient: Option<Recipient>,
-) -> ExecuteMsg {
+pub fn mock_claim_auction(token_id: String, token_address: String) -> ExecuteMsg {
     ExecuteMsg::Claim {
         token_id,
         token_address,
-        recipient,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -7,6 +7,7 @@ use andromeda_non_fungible_tokens::auction::{
 };
 use andromeda_std::ado_base::permissioning::{Permission, PermissioningMessage};
 use andromeda_std::amp::messages::AMPPkt;
+use andromeda_std::amp::Recipient;
 use andromeda_std::common::Milliseconds;
 use andromeda_std::{ado_base::modules::Module, amp::AndrAddr};
 use andromeda_testing::mock::MockApp;
@@ -79,8 +80,9 @@ impl MockAuction {
         sender: Addr,
         token_id: String,
         token_address: String,
+        recipient: Option<Recipient>,
     ) -> ExecuteResult {
-        let msg = mock_claim_auction(token_id, token_address);
+        let msg = mock_claim_auction(token_id, token_address, recipient);
         self.execute(app, &msg, sender, &[])
     }
 
@@ -191,10 +193,15 @@ pub fn mock_get_bids(auction_id: Uint128) -> QueryMsg {
     }
 }
 
-pub fn mock_claim_auction(token_id: String, token_address: String) -> ExecuteMsg {
+pub fn mock_claim_auction(
+    token_id: String,
+    token_address: String,
+    recipient: Option<Recipient>,
+) -> ExecuteMsg {
     ExecuteMsg::Claim {
         token_id,
         token_address,
+        recipient,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/mock_querier.rs
@@ -136,12 +136,6 @@ impl WasmMockQuerier {
                 BankQuery::AllBalances { address: _ } => {
                     panic!("Unsupported Query")
                 }
-                BankQuery::DenomMetadata { denom: _ } => {
-                    panic!("Unsupported Query")
-                }
-                BankQuery::AllDenomMetadata { pagination: _ } => {
-                    panic!("Unsupported Query")
-                }
                 _ => panic!("Unsupported Query"),
             },
             _ => MockAndromedaQuerier::default().handle_query(&self.base, request),

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -900,6 +900,7 @@ fn execute_claim_no_bids() {
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
+        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);
@@ -962,6 +963,7 @@ fn execute_claim() {
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
+        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);
@@ -1025,6 +1027,7 @@ fn execute_claim_auction_not_ended() {
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
+        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);
@@ -1060,6 +1063,7 @@ fn execute_claim_auction_already_claimed() {
     let msg = ExecuteMsg::Claim {
         token_id: "claimed_token".to_string(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
+        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -985,14 +985,14 @@ fn execute_claim() {
     };
     assert_eq!(
         Response::new()
-            .add_message(CosmosMsg::Bank(BankMsg::Send {
-                to_address: MOCK_TOKEN_OWNER.to_owned(),
-                amount: coins(100, "uusd"),
-            }))
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: MOCK_TOKEN_ADDR.to_string(),
                 msg: encode_binary(&transfer_nft_msg).unwrap(),
                 funds: vec![],
+            }))
+            .add_message(CosmosMsg::Bank(BankMsg::Send {
+                to_address: MOCK_TOKEN_OWNER.to_owned(),
+                amount: coins(100, "uusd"),
             }))
             .add_attribute("action", "claim")
             .add_attribute("token_id", MOCK_UNCLAIMED_TOKEN)

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -63,6 +63,7 @@ fn start_auction(deps: DepsMut, whitelist: Option<Vec<Addr>>, min_bid: Option<Ui
         coin_denom: "uusd".to_string(),
         whitelist,
         min_bid,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -94,6 +95,7 @@ fn assert_auction_created(deps: Deps, whitelist: Option<Vec<Addr>>, min_bid: Opt
             token_address: MOCK_TOKEN_ADDR.to_owned(),
             is_cancelled: false,
             min_bid,
+            recipient: None,
         },
         TOKEN_AUCTION_STATE.load(deps.storage, 1u128).unwrap()
     );
@@ -559,6 +561,7 @@ fn execute_start_auction_start_time_in_past() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -590,6 +593,7 @@ fn execute_start_auction_zero_start_time() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -620,6 +624,7 @@ fn execute_start_auction_start_time_not_provided() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -643,6 +648,7 @@ fn execute_start_auction_zero_duration() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -702,6 +708,7 @@ fn execute_update_auction_zero_start() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let mut env = mock_env();
     env.block.time = env.block.time.minus_days(1);
@@ -733,6 +740,7 @@ fn execute_update_auction_zero_duration() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let mut env = mock_env();
     env.block.time = Timestamp::from_seconds(0);
@@ -758,6 +766,7 @@ fn execute_update_auction_unauthorized() {
         coin_denom: "uluna".to_string(),
         whitelist: Some(vec![Addr::unchecked("user")]),
         min_bid: None,
+        recipient: None,
     };
     let env = mock_env();
 
@@ -781,6 +790,7 @@ fn execute_update_auction_auction_started() {
         coin_denom: "uluna".to_string(),
         whitelist: Some(vec![Addr::unchecked("user")]),
         min_bid: None,
+        recipient: None,
     };
     let mut env = mock_env();
 
@@ -806,6 +816,7 @@ fn execute_update_auction() {
         coin_denom: "uluna".to_string(),
         whitelist: Some(vec![Addr::unchecked("user")]),
         min_bid: None,
+        recipient: None,
     };
     let mut env = mock_env();
 
@@ -827,6 +838,7 @@ fn execute_update_auction() {
             token_address: MOCK_TOKEN_ADDR.to_owned(),
             is_cancelled: false,
             min_bid: None,
+            recipient: None,
         },
         TOKEN_AUCTION_STATE
             .load(deps.as_ref().storage, 1u128)
@@ -848,6 +860,7 @@ fn execute_start_auction_after_previous_finished() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -900,7 +913,6 @@ fn execute_claim_no_bids() {
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
-        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);
@@ -963,7 +975,6 @@ fn execute_claim() {
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
-        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);
@@ -1027,7 +1038,6 @@ fn execute_claim_auction_not_ended() {
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
-        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);
@@ -1046,6 +1056,7 @@ fn execute_claim_auction_already_claimed() {
         coin_denom: "uusd".to_string(),
         whitelist: None,
         min_bid: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -1063,7 +1074,6 @@ fn execute_claim_auction_already_claimed() {
     let msg = ExecuteMsg::Claim {
         token_id: "claimed_token".to_string(),
         token_address: MOCK_TOKEN_ADDR.to_string(),
-        recipient: None,
     };
 
     let info = mock_info("any_user", &[]);

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -364,7 +364,7 @@ fn execute_buy(
     if !after_tax_payment.0.amount.is_zero() {
         let recipient = token_sale_state
             .recipient
-            .unwrap_or(Recipient::from_string(info.sender));
+            .unwrap_or(Recipient::from_string(token_sale_state.owner));
         resp = resp.add_submessage(
             recipient.generate_direct_msg(&deps.as_ref(), vec![after_tax_payment.0])?,
         )

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
@@ -4,8 +4,10 @@ use crate::contract::{execute, instantiate, query};
 use andromeda_non_fungible_tokens::marketplace::{
     Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
 };
-use andromeda_std::ado_base::modules::Module;
 use andromeda_std::amp::messages::AMPPkt;
+
+use andromeda_std::common::Milliseconds;
+use andromeda_std::{ado_base::modules::Module, amp::Recipient};
 use andromeda_testing::{
     mock::MockApp, mock_ado, mock_contract::ExecuteResult, MockADO, MockContract,
 };
@@ -66,12 +68,19 @@ pub fn mock_marketplace_instantiate_msg(
     }
 }
 
-pub fn mock_start_sale(price: Uint128, coin_denom: impl Into<String>) -> Cw721HookMsg {
+pub fn mock_start_sale(
+    price: Uint128,
+    coin_denom: impl Into<String>,
+    duration: Option<Milliseconds>,
+    start_time: Option<Milliseconds>,
+    recipient: Option<Recipient>,
+) -> Cw721HookMsg {
     Cw721HookMsg::StartSale {
         price,
         coin_denom: coin_denom.into(),
-        start_time: None,
-        duration: None,
+        start_time,
+        duration,
+        recipient,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
@@ -1,5 +1,5 @@
 use andromeda_non_fungible_tokens::marketplace::{SaleStateResponse, Status};
-use andromeda_std::error::ContractError;
+use andromeda_std::{amp::Recipient, error::ContractError};
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Order, Storage, SubMsg, Uint128};
@@ -20,6 +20,7 @@ pub struct TokenSaleState {
     pub status: Status,
     pub start_time: Expiration,
     pub end_time: Expiration,
+    pub recipient: Option<Recipient>,
 }
 
 #[cw_serde]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -38,6 +38,7 @@ fn start_sale(deps: DepsMut) {
         price: Uint128::new(100),
         start_time: None,
         duration: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -58,6 +59,7 @@ fn start_sale_future_start(deps: DepsMut, env: Env) {
         // Add one to the current time to have it set in the future
         start_time: Some(Milliseconds(current_time + 1)),
         duration: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -79,6 +81,7 @@ fn start_sale_future_start_with_duration(deps: DepsMut, env: Env) {
         start_time: Some(Milliseconds(current_time + 1)),
         // Add duration, the end time's expiration will be current time + duration
         duration: Some(Milliseconds(1)),
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),
@@ -117,7 +120,8 @@ fn assert_sale_created(deps: Deps, env: Env) {
             price: Uint128::new(100),
             // start sale function has start_time set as None, so it defaults to the current time
             start_time: start_time_expiration,
-            end_time: Expiration::Never {}
+            end_time: Expiration::Never {},
+            recipient: None,
         },
         TOKEN_SALE_STATE.load(deps.storage, 1u128).unwrap()
     );
@@ -152,7 +156,8 @@ fn assert_sale_created_future_start(deps: Deps, env: Env) {
             status: Status::Open,
             price: Uint128::new(100),
             start_time: start_time_expiration,
-            end_time: Expiration::Never {}
+            end_time: Expiration::Never {},
+            recipient: None,
         },
         TOKEN_SALE_STATE.load(deps.storage, 1u128).unwrap()
     );
@@ -406,6 +411,7 @@ fn test_execute_update_sale_unauthorized() {
         token_address: MOCK_TOKEN_ADDR.to_string(),
         price: Uint128::new(11),
         coin_denom: "juno".to_string(),
+        recipient: None,
     };
 
     let info = mock_info("someone", &[]);
@@ -428,6 +434,7 @@ fn test_execute_update_sale_invalid_price() {
         token_address: MOCK_TOKEN_ADDR.to_string(),
         price: Uint128::zero(),
         coin_denom: "juno".to_string(),
+        recipient: None,
     };
 
     let info = mock_info("owner", &[]);
@@ -445,6 +452,7 @@ fn test_execute_start_sale_invalid_price() {
         price: Uint128::zero(),
         start_time: None,
         duration: None,
+        recipient: None,
     };
     let msg = ExecuteMsg::ReceiveNft(Cw721ReceiveMsg {
         sender: MOCK_TOKEN_OWNER.to_owned(),

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -550,10 +550,6 @@ fn test_execute_buy_with_tax_and_royalty_works() {
             to_address: "tax_recipient".to_string(),
             amount: vec![coin(50, "uusd")],
         })),
-        SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
-            to_address: "owner".to_string(),
-            amount: vec![coin(90, "uusd")],
-        })),
         SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: MOCK_TOKEN_ADDR.to_string(),
             msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
@@ -562,6 +558,10 @@ fn test_execute_buy_with_tax_and_royalty_works() {
             })
             .unwrap(),
             funds: vec![],
+        })),
+        SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+            to_address: "owner".to_string(),
+            amount: vec![coin(90, "uusd")],
         })),
         SubMsg::reply_on_error(
             CosmosMsg::Wasm(WasmMsg::Execute {

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -1,4 +1,4 @@
-use andromeda_std::amp::AndrAddr;
+use andromeda_std::amp::{AndrAddr, Recipient};
 use andromeda_std::common::{Milliseconds, OrderBy};
 use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_query};
 
@@ -27,6 +27,7 @@ pub enum ExecuteMsg {
     Claim {
         token_id: String,
         token_address: String,
+        recipient: Option<Recipient>,
     },
     UpdateAuction {
         token_id: String,

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -27,7 +27,6 @@ pub enum ExecuteMsg {
     Claim {
         token_id: String,
         token_address: String,
-        recipient: Option<Recipient>,
     },
     UpdateAuction {
         token_id: String,
@@ -37,6 +36,7 @@ pub enum ExecuteMsg {
         coin_denom: String,
         whitelist: Option<Vec<Addr>>,
         min_bid: Option<Uint128>,
+        recipient: Option<Recipient>,
     },
     CancelAuction {
         token_id: String,
@@ -65,6 +65,7 @@ pub enum Cw721HookMsg {
         coin_denom: String,
         min_bid: Option<Uint128>,
         whitelist: Option<Vec<Addr>>,
+        recipient: Option<Recipient>,
     },
 }
 #[andr_query]
@@ -180,6 +181,7 @@ pub struct TokenAuctionState {
     pub token_id: String,
     pub token_address: String,
     pub is_cancelled: bool,
+    pub recipient: Option<Recipient>,
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -1,5 +1,6 @@
 use andromeda_std::{
-    andr_exec, andr_instantiate, andr_instantiate_modules, andr_query, common::Milliseconds,
+    amp::Recipient, andr_exec, andr_instantiate, andr_instantiate_modules, andr_query,
+    common::Milliseconds,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
@@ -27,6 +28,7 @@ pub enum ExecuteMsg {
         token_address: String,
         price: Uint128,
         coin_denom: String,
+        recipient: Option<Recipient>,
     },
     CancelSale {
         token_id: String,
@@ -43,6 +45,7 @@ pub enum Cw721HookMsg {
         coin_denom: String,
         start_time: Option<Milliseconds>,
         duration: Option<Milliseconds>,
+        recipient: Option<Recipient>,
     },
 }
 #[cw_serde]

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -21,7 +21,7 @@ use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal, Uint128};
 use cw_multi_test::Executor;
 
 #[test]
-fn test_auction_app() {
+fn test_auction_app_modules() {
     let mut router = mock_app(None);
     let andr = MockAndromedaBuilder::new(&mut router, "admin")
         .with_wallets(vec![
@@ -226,6 +226,205 @@ fn test_auction_app() {
             buyer_two.clone(),
             "0".to_string(),
             cw721.addr().to_string(),
+            None,
+        )
+        .unwrap();
+
+    // Check Final State
+    let token_owner = cw721.query_owner_of(&router, "0");
+    assert_eq!(token_owner, buyer_two);
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(owner_balance.amount, Uint128::zero());
+    let recipient_one_balance = router.wrap().query_balance(recipient_one, "uandr").unwrap();
+    assert_eq!(recipient_one_balance.amount, Uint128::from(50u128));
+    let recipient_two_balance = router.wrap().query_balance(recipient_two, "uandr").unwrap();
+    assert_eq!(recipient_two_balance.amount, Uint128::from(50u128));
+}
+
+#[test]
+fn test_auction_app_recipient() {
+    let mut router = mock_app(None);
+    let andr = MockAndromedaBuilder::new(&mut router, "admin")
+        .with_wallets(vec![
+            ("owner", vec![]),
+            ("buyer_one", vec![coin(1000, "uandr")]),
+            ("buyer_two", vec![coin(1000, "uandr")]),
+            ("recipient_one", vec![]),
+            ("recipient_two", vec![]),
+        ])
+        .with_contracts(vec![
+            ("cw721", mock_andromeda_cw721()),
+            ("auction", mock_andromeda_auction()),
+            ("app-contract", mock_andromeda_app()),
+            ("splitter", mock_andromeda_splitter()),
+        ])
+        .build(&mut router);
+    let owner = andr.get_wallet("owner");
+    let buyer_one = andr.get_wallet("buyer_one");
+    let buyer_two = andr.get_wallet("buyer_two");
+    let recipient_one = andr.get_wallet("recipient_one");
+    let recipient_two = andr.get_wallet("recipient_two");
+
+    // Generate App Components
+    let cw721_init_msg = mock_cw721_instantiate_msg(
+        "Test Tokens".to_string(),
+        "TT".to_string(),
+        owner.to_string(),
+        None,
+        andr.kernel.addr().to_string(),
+        None,
+    );
+    let cw721_component = AppComponent::new(
+        "cw721".to_string(),
+        "cw721".to_string(),
+        to_json_binary(&cw721_init_msg).unwrap(),
+    );
+
+    let splitter_init_msg = mock_splitter_instantiate_msg(
+        vec![
+            AddressPercent::new(
+                Recipient::from_string(format!("{recipient_one}")),
+                Decimal::from_ratio(1u8, 2u8),
+            ),
+            AddressPercent::new(
+                Recipient::from_string(format!("{recipient_two}")),
+                Decimal::from_ratio(1u8, 2u8),
+            ),
+        ],
+        andr.kernel.addr(),
+        None,
+        None,
+    );
+    let splitter_component = AppComponent::new(
+        "splitter",
+        "splitter",
+        to_json_binary(&splitter_init_msg).unwrap(),
+    );
+
+    let auction_init_msg =
+        mock_auction_instantiate_msg(None, andr.kernel.addr().to_string(), None, None);
+    let auction_component = AppComponent::new(
+        "auction".to_string(),
+        "auction".to_string(),
+        to_json_binary(&auction_init_msg).unwrap(),
+    );
+
+    // Create App
+    let app_components = vec![
+        cw721_component.clone(),
+        auction_component.clone(),
+        splitter_component,
+    ];
+    let app = MockAppContract::instantiate(
+        andr.get_code_id(&mut router, "app-contract"),
+        owner,
+        &mut router,
+        "Auction App",
+        app_components,
+        andr.kernel.addr(),
+        Some(owner.to_string()),
+    );
+
+    router
+        .execute_contract(
+            owner.clone(),
+            Addr::unchecked(app.addr().clone()),
+            &mock_claim_ownership_msg(None),
+            &[],
+        )
+        .unwrap();
+
+    // Mint Tokens
+    let cw721: MockCW721 = app.query_ado_by_component_name(&router, cw721_component.name);
+    cw721
+        .execute_quick_mint(&mut router, owner.clone(), 1, owner.to_string())
+        .unwrap();
+
+    // Send Token to Auction
+    let auction: MockAuction = app.query_ado_by_component_name(&router, auction_component.name);
+    let start_time = Milliseconds::from_nanos(router.block_info().time.nanos())
+        .plus_milliseconds(Milliseconds(100));
+    let receive_msg = mock_start_auction(
+        Some(start_time),
+        start_time.plus_milliseconds(Milliseconds(1000)),
+        "uandr".to_string(),
+        None,
+        None,
+    );
+    cw721
+        .execute_send_nft(
+            &mut router,
+            owner.clone(),
+            auction.addr(),
+            "0",
+            &receive_msg,
+        )
+        .unwrap();
+
+    router.set_block(BlockInfo {
+        height: router.block_info().height,
+        time: start_time.into(),
+        chain_id: router.block_info().chain_id,
+    });
+
+    // Query Auction State
+    let auction_ids: Vec<Uint128> =
+        auction.query_auction_ids(&mut router, "0".to_string(), cw721.addr().to_string());
+
+    assert_eq!(auction_ids.len(), 1);
+
+    let auction_id = auction_ids.first().unwrap();
+    let auction_state = auction.query_auction_state(&mut router, *auction_id);
+
+    assert_eq!(auction_state.coin_denom, "uandr".to_string());
+    assert_eq!(auction_state.owner, owner.to_string());
+
+    // Place Bid One
+    auction.execute_place_bid(
+        &mut router,
+        buyer_one.clone(),
+        "0".to_string(),
+        cw721.addr().to_string(),
+        &[coin(50, "uandr")],
+    );
+
+    // Check Bid Status One
+    let bids = auction.query_bids(&mut router, *auction_id);
+    assert_eq!(bids.len(), 1);
+
+    let bid = bids.first().unwrap();
+    assert_eq!(bid.bidder, buyer_one.to_string());
+    assert_eq!(bid.amount, Uint128::from(50u128));
+
+    auction.execute_place_bid(
+        &mut router,
+        buyer_two.clone(),
+        "0".to_string(),
+        cw721.addr().to_string(),
+        &[coin(100, "uandr")],
+    );
+
+    // Check Bid Status One
+    let bids = auction.query_bids(&mut router, *auction_id);
+    assert_eq!(bids.len(), 2);
+
+    let bid_two = bids.get(1).unwrap();
+    assert_eq!(bid_two.bidder, buyer_two.to_string());
+    assert_eq!(bid_two.amount, Uint128::from(100u128));
+
+    // End Auction
+    router.set_block(BlockInfo {
+        height: router.block_info().height,
+        time: start_time.plus_milliseconds(Milliseconds(1000)).into(),
+        chain_id: router.block_info().chain_id,
+    });
+    auction
+        .execute_claim_auction(
+            &mut router,
+            buyer_two.clone(),
+            "0".to_string(),
+            cw721.addr().to_string(),
+            Some(Recipient::from_string("./splitter").with_msg(mock_splitter_send_msg())),
         )
         .unwrap();
 

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -152,6 +152,7 @@ fn test_auction_app_modules() {
         "uandr".to_string(),
         None,
         None,
+        None,
     );
     cw721
         .execute_send_nft(
@@ -226,7 +227,6 @@ fn test_auction_app_modules() {
             buyer_two.clone(),
             "0".to_string(),
             cw721.addr().to_string(),
-            None,
         )
         .unwrap();
 
@@ -350,6 +350,7 @@ fn test_auction_app_recipient() {
         "uandr".to_string(),
         None,
         None,
+        Some(Recipient::from_string("./splitter").with_msg(mock_splitter_send_msg())),
     );
     cw721
         .execute_send_nft(
@@ -424,7 +425,6 @@ fn test_auction_app_recipient() {
             buyer_two.clone(),
             "0".to_string(),
             cw721.addr().to_string(),
-            Some(Recipient::from_string("./splitter").with_msg(mock_splitter_send_msg())),
         )
         .unwrap();
 

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -65,7 +65,7 @@ fn test_auction_app_modules() {
             is_additive: false,
             description: None,
             rate: Rate::Percent(PercentRate {
-                percent: Decimal::one(),
+                percent: Decimal::from_ratio(1u32, 2u32),
             }),
             recipients: vec![
                 Recipient::from_string("./splitter").with_msg(mock_splitter_send_msg())
@@ -234,11 +234,11 @@ fn test_auction_app_modules() {
     let token_owner = cw721.query_owner_of(&router, "0");
     assert_eq!(token_owner, buyer_two);
     let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
-    assert_eq!(owner_balance.amount, Uint128::zero());
+    assert_eq!(owner_balance.amount, Uint128::from(50u128));
     let recipient_one_balance = router.wrap().query_balance(recipient_one, "uandr").unwrap();
-    assert_eq!(recipient_one_balance.amount, Uint128::from(50u128));
+    assert_eq!(recipient_one_balance.amount, Uint128::from(25u128));
     let recipient_two_balance = router.wrap().query_balance(recipient_two, "uandr").unwrap();
-    assert_eq!(recipient_two_balance.amount, Uint128::from(50u128));
+    assert_eq!(recipient_two_balance.amount, Uint128::from(25u128));
 }
 
 #[test]

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -6,6 +6,7 @@ use andromeda_address_list::mock::{
 use andromeda_app::app::AppComponent;
 use andromeda_app_contract::mock::{mock_andromeda_app, MockAppContract};
 use andromeda_cw721::mock::{mock_andromeda_cw721, mock_cw721_instantiate_msg, MockCW721};
+use andromeda_finance::splitter::AddressPercent;
 use andromeda_marketplace::mock::{
     mock_andromeda_marketplace, mock_buy_token, mock_marketplace_instantiate_msg,
     mock_receive_packet, mock_start_sale, MockMarketplace,
@@ -13,13 +14,16 @@ use andromeda_marketplace::mock::{
 use andromeda_modules::rates::{Rate, RateInfo};
 
 use andromeda_rates::mock::{mock_andromeda_rates, mock_rates_instantiate_msg};
+use andromeda_splitter::mock::{
+    mock_andromeda_splitter, mock_splitter_instantiate_msg, mock_splitter_send_msg,
+};
 use andromeda_std::ado_base::modules::Module;
 use andromeda_std::amp::messages::{AMPMsg, AMPPkt};
 use andromeda_std::amp::Recipient;
 use andromeda_testing::mock::mock_app;
 use andromeda_testing::mock_builder::MockAndromedaBuilder;
 use andromeda_testing::MockContract;
-use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Uint128};
+use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal, Uint128};
 use cw_multi_test::Executor;
 
 #[test]
@@ -140,7 +144,7 @@ fn test_marketplace_app() {
             owner.clone(),
             marketplace.addr().clone(),
             token_id,
-            &mock_start_sale(Uint128::from(100u128), "uandr"),
+            &mock_start_sale(Uint128::from(100u128), "uandr", None, None, None),
         )
         .unwrap();
 
@@ -179,5 +183,149 @@ fn test_marketplace_app() {
         .wrap()
         .query_balance(rates_receiver, "uandr")
         .unwrap();
+    assert_eq!(balance.amount, Uint128::from(100u128));
+}
+
+#[test]
+fn test_marketplace_app_recipient() {
+    let mut router = mock_app(None);
+    let andr = MockAndromedaBuilder::new(&mut router, "admin")
+        .with_wallets(vec![
+            ("owner", vec![]),
+            ("buyer", vec![coin(200, "uandr")]),
+            ("receiver", vec![]),
+        ])
+        .with_contracts(vec![
+            ("app-contract", mock_andromeda_app()),
+            ("cw721", mock_andromeda_cw721()),
+            ("marketplace", mock_andromeda_marketplace()),
+            ("splitter", mock_andromeda_splitter()),
+            ("address-list", mock_andromeda_address_list()),
+        ])
+        .build(&mut router);
+    let owner = andr.get_wallet("owner");
+    let buyer = andr.get_wallet("buyer");
+    let receiver = andr.get_wallet("receiver");
+
+    // Generate App Components
+    let cw721_init_msg = mock_cw721_instantiate_msg(
+        "Test Tokens".to_string(),
+        "TT".to_string(),
+        owner.to_string(),
+        None,
+        andr.kernel.addr().to_string(),
+        None,
+    );
+    let cw721_component = AppComponent::new(
+        "tokens".to_string(),
+        "cw721".to_string(),
+        to_json_binary(&cw721_init_msg).unwrap(),
+    );
+
+    let splitter_init_msg = mock_splitter_instantiate_msg(
+        vec![AddressPercent::new(
+            Recipient::from_string(receiver),
+            Decimal::one(),
+        )],
+        andr.kernel.addr(),
+        None,
+        None,
+    );
+    let splitter_component = AppComponent::new(
+        "splitter",
+        "splitter",
+        to_json_binary(&splitter_init_msg).unwrap(),
+    );
+
+    let marketplace_init_msg =
+        mock_marketplace_instantiate_msg(andr.kernel.addr().to_string(), None, None);
+    let marketplace_component = AppComponent::new(
+        "marketplace".to_string(),
+        "marketplace".to_string(),
+        to_json_binary(&marketplace_init_msg).unwrap(),
+    );
+
+    // Create App
+    let app_components = vec![
+        cw721_component.clone(),
+        splitter_component.clone(),
+        marketplace_component.clone(),
+    ];
+    let app_code_id = andr.get_code_id(&mut router, "app-contract");
+    let app = MockAppContract::instantiate(
+        app_code_id,
+        owner,
+        &mut router,
+        "Auction App",
+        app_components.clone(),
+        andr.kernel.addr(),
+        None,
+    );
+
+    let components = app.query_components(&router);
+    assert_eq!(components, app_components);
+
+    let cw721: MockCW721 = app.query_ado_by_component_name(&router, cw721_component.name);
+    let marketplace: MockMarketplace =
+        app.query_ado_by_component_name(&router, marketplace_component.name);
+
+    // Mint Tokens
+    cw721
+        .execute_quick_mint(&mut router, owner.clone(), 1, owner.to_string())
+        .unwrap();
+    let token_id = "0";
+
+    // Send Token to Marketplace
+    cw721
+        .execute_send_nft(
+            &mut router,
+            owner.clone(),
+            marketplace.addr().clone(),
+            token_id,
+            &mock_start_sale(
+                Uint128::from(100u128),
+                "uandr",
+                None,
+                None,
+                Some(
+                    Recipient::from_string(format!("./{}", splitter_component.name))
+                        .with_msg(mock_splitter_send_msg()),
+                ),
+            ),
+        )
+        .unwrap();
+
+    // Buy Token
+    let buy_msg = mock_buy_token(cw721.addr().clone(), token_id);
+    let amp_msg = AMPMsg::new(
+        Addr::unchecked(marketplace.addr().clone()),
+        to_json_binary(&buy_msg).unwrap(),
+        Some(vec![coin(200, "uandr")]),
+    );
+
+    let packet = AMPPkt::new(buyer.clone(), andr.kernel.addr().to_string(), vec![amp_msg]);
+    let receive_packet_msg = mock_receive_packet(packet);
+
+    let block_info = router.block_info();
+    router.set_block(BlockInfo {
+        height: block_info.height,
+        time: block_info.time.plus_minutes(1),
+        chain_id: block_info.chain_id,
+    });
+
+    router
+        .execute_contract(
+            buyer.clone(),
+            Addr::unchecked(marketplace.addr()),
+            &receive_packet_msg,
+            &[coin(100, "uandr")],
+        )
+        .unwrap();
+
+    // Check final state
+    let owner_of_token = cw721.query_owner_of(&router, token_id);
+    assert_eq!(owner_of_token, buyer.to_string());
+
+    let balance = router.wrap().query_balance(receiver, "uandr").unwrap();
     assert_eq!(balance.amount, Uint128::from(100u128));
 }


### PR DESCRIPTION
# Motivation

Our auction and marketplace did not contain the ability to specify the recipient of the proceeds. This PR adds an optional `Recipient` field to both the auction and marketplace contracts so that a user may quickly redirect funds.

# Implementation

For auction the recipient field was added to the `StartAuction` CW721 hook message (and `UpdateAuction`) accordingly. For market the recipient field was added to the `StartSale` message (and `UpdateSale`) accordingly. Both contracts store the recipient as part of their appropriate state structs.

When funds are being dispensed to the contract owner the `Recipient` field is checked, if `None` then the recipient is set as the owner of the sale. 

# Testing

Integration tests were written for both contracts as extensions of previous integration tests.

# Future work

We should add unit tests for this in future.
