### PR TITLE
[RC]: Removed Expiration from Permissioning and UpdateOwner messages

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -29,7 +29,7 @@ use cosmwasm_std::{
     SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw20::{Cw20Coin, Cw20ExecuteMsg, Cw20ReceiveMsg};
-use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, Expiration, OwnerOfResponse};
+use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, OwnerOfResponse};
 use cw_utils::nonpayable;
 
 const CONTRACT_NAME: &str = "crates.io:andromeda-auction";
@@ -902,7 +902,7 @@ fn execute_authorize_token_contract(
     deps: DepsMut,
     info: MessageInfo,
     token_address: AndrAddr,
-    expiration: Option<Expiration>,
+    expiration: Option<MillisecondsExpiration>,
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
     let addr = token_address.get_raw_address(&deps.as_ref())?;

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -8,7 +8,7 @@ use andromeda_non_fungible_tokens::auction::{
 use andromeda_std::ado_base::permissioning::{Permission, PermissioningMessage};
 use andromeda_std::amp::messages::AMPPkt;
 use andromeda_std::amp::Recipient;
-use andromeda_std::common::Milliseconds;
+use andromeda_std::common::{Milliseconds, MillisecondsExpiration};
 use andromeda_std::{ado_base::modules::Module, amp::AndrAddr};
 use andromeda_testing::mock::MockApp;
 use andromeda_testing::{
@@ -17,7 +17,6 @@ use andromeda_testing::{
 };
 use cosmwasm_std::{Addr, Coin, Empty, Uint128};
 use cw20::Cw20ReceiveMsg;
-use cw20::Expiration;
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 
 pub struct MockAuction(Addr);
@@ -164,7 +163,7 @@ pub fn mock_auction_cw20_receive(msg: Cw20ReceiveMsg) -> ExecuteMsg {
 
 pub fn mock_authorize_token_address(
     token_address: impl Into<String>,
-    expiration: Option<Expiration>,
+    expiration: Option<MillisecondsExpiration>,
 ) -> ExecuteMsg {
     ExecuteMsg::AuthorizeTokenContract {
         addr: AndrAddr::from_string(token_address.into()),

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -50,7 +50,7 @@ pub enum ExecuteMsg {
     /// Restricted to owner
     AuthorizeTokenContract {
         addr: AndrAddr,
-        expiration: Option<Expiration>,
+        expiration: Option<MillisecondsExpiration>,
     },
     /// Restricted to owner
     DeauthorizeTokenContract {

--- a/packages/std/src/ado_base/ownership.rs
+++ b/packages/std/src/ado_base/ownership.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
-use cw_utils::Expiration;
+
+use crate::common::MillisecondsExpiration;
 
 #[cw_serde]
 pub struct ContractOwnerResponse {
@@ -10,7 +11,7 @@ pub struct ContractOwnerResponse {
 #[cw_serde]
 pub struct ContractPotentialOwnerResponse {
     pub potential_owner: Option<Addr>,
-    pub expiration: Option<Expiration>,
+    pub expiration: Option<MillisecondsExpiration>,
 }
 
 #[cw_serde]
@@ -22,7 +23,7 @@ pub struct PublisherResponse {
 pub enum OwnershipMessage {
     UpdateOwner {
         new_owner: Addr,
-        expiration: Option<Expiration>,
+        expiration: Option<MillisecondsExpiration>,
     },
     RevokeOwnershipOffer,
     AcceptOwnership,

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -2,9 +2,8 @@ use core::fmt;
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Env;
-use cw_utils::Expiration;
 
-use crate::{amp::AndrAddr, error::ContractError};
+use crate::{amp::AndrAddr, common::MillisecondsExpiration, error::ContractError};
 
 #[cw_serde]
 pub enum PermissioningMessage {
@@ -46,12 +45,12 @@ pub struct PermissionedActionsResponse {
 /// Expiration defaults to `Never` if not provided
 #[cw_serde]
 pub enum Permission {
-    Blacklisted(Option<Expiration>),
+    Blacklisted(Option<MillisecondsExpiration>),
     Limited {
-        expiration: Option<Expiration>,
+        expiration: Option<MillisecondsExpiration>,
         uses: u32,
     },
-    Whitelisted(Option<Expiration>),
+    Whitelisted(Option<MillisecondsExpiration>),
 }
 
 impl std::default::Default for Permission {
@@ -61,15 +60,15 @@ impl std::default::Default for Permission {
 }
 
 impl Permission {
-    pub fn blacklisted(expiration: Option<Expiration>) -> Self {
+    pub fn blacklisted(expiration: Option<MillisecondsExpiration>) -> Self {
         Self::Blacklisted(expiration)
     }
 
-    pub fn whitelisted(expiration: Option<Expiration>) -> Self {
+    pub fn whitelisted(expiration: Option<MillisecondsExpiration>) -> Self {
         Self::Whitelisted(expiration)
     }
 
-    pub fn limited(expiration: Option<Expiration>, uses: u32) -> Self {
+    pub fn limited(expiration: Option<MillisecondsExpiration>, uses: u32) -> Self {
         Self::Limited { expiration, uses }
     }
 
@@ -105,7 +104,7 @@ impl Permission {
         }
     }
 
-    pub fn get_expiration(&self) -> Expiration {
+    pub fn get_expiration(&self) -> MillisecondsExpiration {
         match self {
             Self::Blacklisted(expiration) => expiration.unwrap_or_default(),
             Self::Limited { expiration, .. } => expiration.unwrap_or_default(),


### PR DESCRIPTION
Closes: #406 

# Motivation

We're moving away from using `Expiration` as it does not support milliseconds. Instead we are using our own `Milliseconds` type. This change is to replace two cases where `Expiration` was still being used.

# Implementation

Replaced any cases of `Expiration` with `MillisecondsExpiration` in:
- OwnershipMessage::UpdateOwner
- PermissioningMessage::Permission

A few queries were also adjusted.

# Testing
Affected tests were updated to match new functionality.

# Future work

Continue to remove any cases of `Expiration`.
