### PR TITLE
[1.0.rc-1] ADOBaseVersion Query for AndromedaQuery

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
@@ -198,3 +198,11 @@ pub fn mock_crowdfund_quick_mint_msg(amount: u32, publisher: String) -> ExecuteM
 pub fn mock_purchase_msg(number_of_tokens: Option<u32>) -> ExecuteMsg {
     ExecuteMsg::Purchase { number_of_tokens }
 }
+
+pub fn mock_query_ado_base_version() -> QueryMsg {
+    QueryMsg::ADOBaseVersion {}
+}
+
+pub fn mock_query_ado_version() -> QueryMsg {
+    QueryMsg::Version {}
+}

--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -177,6 +177,8 @@ pub fn andr_query(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                 BlockHeightUponCreation {},
                 #[returns(andromeda_std::ado_base::version::VersionResponse)]
                 Version {},
+                #[returns(andromeda_std::ado_base::version::ADOBaseVersionResponse)]
+                ADOBaseVersion {},
                 #[returns(Vec<::andromeda_std::ado_base::permissioning::PermissionInfo>)]
                 Permissions { actor: String, limit: Option<u32>, start_after: Option<String> },
                 #[returns(Vec<String>)]

--- a/packages/std/src/ado_base/mod.rs
+++ b/packages/std/src/ado_base/mod.rs
@@ -77,6 +77,8 @@ pub enum AndromedaQuery {
     BlockHeightUponCreation {},
     #[returns(self::version::VersionResponse)]
     Version {},
+    #[returns(self::version::ADOBaseVersionResponse)]
+    ADOBaseVersion {},
     #[returns(self::app_contract::AppContractResponse)]
     AppContract {},
     #[cfg(feature = "modules")]

--- a/packages/std/src/ado_base/version.rs
+++ b/packages/std/src/ado_base/version.rs
@@ -4,3 +4,9 @@ use cosmwasm_schema::cw_serde;
 pub struct VersionResponse {
     pub version: String,
 }
+
+#[cw_serde]
+pub struct ADOBaseVersionResponse {
+    // andromeda-std version in semver format
+    pub version: String,
+}

--- a/packages/std/src/ado_contract/query.rs
+++ b/packages/std/src/ado_contract/query.rs
@@ -1,3 +1,4 @@
+use crate::ado_base::version::ADOBaseVersionResponse;
 use crate::ado_contract::state::ADOContract;
 use crate::{
     ado_base::{
@@ -39,6 +40,7 @@ impl<'a> ADOContract<'a> {
                     encode_binary(&self.query_kernel_address(deps)?)
                 }
                 AndromedaQuery::Version {} => encode_binary(&self.query_version(deps)?),
+                AndromedaQuery::ADOBaseVersion {} => encode_binary(&self.query_ado_base_version()?),
                 AndromedaQuery::OwnershipRequest {} => {
                     encode_binary(&self.ownership_request(deps.storage)?)
                 }
@@ -106,6 +108,14 @@ impl<'a> ADOContract<'a> {
         let contract_version = get_contract_version(deps.storage)?;
         Ok(VersionResponse {
             version: contract_version.version,
+        })
+    }
+
+    #[inline]
+    pub fn query_ado_base_version(&self) -> Result<ADOBaseVersionResponse, ContractError> {
+        let ado_base_version: &str = env!("CARGO_PKG_VERSION");
+        Ok(ADOBaseVersionResponse {
+            version: ado_base_version.to_string(),
         })
     }
 }

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -1,11 +1,13 @@
 use andromeda_app::app::{AppComponent, ComponentType};
 use andromeda_app_contract::mock::{mock_andromeda_app, MockAppContract};
 use andromeda_crowdfund::mock::{
-    mock_andromeda_crowdfund, mock_crowdfund_instantiate_msg, MockCrowdfund,
+    mock_andromeda_crowdfund, mock_crowdfund_instantiate_msg, mock_query_ado_base_version,
+    MockCrowdfund,
 };
 use andromeda_cw721::mock::{mock_andromeda_cw721, mock_cw721_instantiate_msg, MockCW721};
 use andromeda_finance::splitter::AddressPercent;
 use andromeda_std::{
+    ado_base::version::ADOBaseVersionResponse,
     amp::{AndrAddr, Recipient},
     common::Milliseconds,
 };
@@ -229,4 +231,14 @@ fn test_crowdfund_app() {
         .query_balance(vault_two_recipient_addr, "uandr")
         .unwrap();
     assert_eq!(balance_two.amount, Uint128::from(148u128));
+
+    let ado_base_version: ADOBaseVersionResponse = router
+        .wrap()
+        .query_wasm_smart(
+            crowdfund_contract.addr().clone(),
+            &mock_query_ado_base_version(),
+        )
+        .unwrap();
+
+    assert_eq!(ado_base_version.version, "1.0.0".to_string())
 }


### PR DESCRIPTION
# Motivation
Closes: #409 

# Implementation
The query function calls `env!("CARGO_PKG_VERSION")` in `query.rs` which is found in the `ado_contract` folder.

# Testing
Called the query in the crowdfund integration test and checked for the expected result.