### PR TITLE
[1.0.rc-1] Replace Expiration by MillisecondsExpiration in RegisterMerkleRoot

### DIFF
--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/state.rs
@@ -1,9 +1,9 @@
+use andromeda_std::common::MillisecondsExpiration;
 use cosmwasm_schema::cw_serde;
 
 use cosmwasm_std::{Addr, Uint128};
 use cw_asset::AssetInfo;
 use cw_storage_plus::{Item, Map};
-use cw_utils::Expiration;
 
 #[cw_serde]
 pub struct Config {
@@ -17,7 +17,8 @@ pub const LATEST_STAGE_KEY: &str = "stage";
 pub const LATEST_STAGE: Item<u8> = Item::new(LATEST_STAGE_KEY);
 
 pub const STAGE_EXPIRATION_KEY: &str = "stage_exp";
-pub const STAGE_EXPIRATION: Map<u8, Expiration> = Map::new(STAGE_EXPIRATION_KEY);
+pub const STAGE_EXPIRATION: Map<u8, Option<MillisecondsExpiration>> =
+    Map::new(STAGE_EXPIRATION_KEY);
 
 pub const STAGE_AMOUNT_KEY: &str = "stage_amount";
 pub const STAGE_AMOUNT: Map<u8, Uint128> = Map::new(STAGE_AMOUNT_KEY);

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -17,7 +17,7 @@ use andromeda_std::{
         denom::{validate_denom, SEND_CW20_ACTION},
         encode_binary,
         expiration::{expiration_from_milliseconds, get_and_validate_start_time},
-        Funds, MillisecondsExpiration, OrderBy,
+        Funds, Milliseconds, MillisecondsExpiration, OrderBy,
     },
     error::ContractError,
 };
@@ -564,7 +564,7 @@ fn execute_place_bid(
     bids_for_auction.push(Bid {
         bidder: info.sender.to_string(),
         amount: payment.amount,
-        timestamp: env.block.time,
+        timestamp: Milliseconds::from_nanos(env.block.time.nanos()),
     });
     BIDS.save(deps.storage, key, &bids_for_auction)?;
     Ok(Response::new().add_messages(messages).add_attributes(vec![
@@ -678,7 +678,7 @@ fn execute_place_bid_cw20(
     bids_for_auction.push(Bid {
         bidder: sender.to_string(),
         amount: amount_sent,
-        timestamp: env.block.time,
+        timestamp: Milliseconds::from_nanos(env.block.time.nanos()),
     });
     BIDS.save(deps.storage, key, &bids_for_auction)?;
     Ok(Response::new()

--- a/contracts/non-fungible-tokens/andromeda-auction/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/state.rs
@@ -105,35 +105,35 @@ pub fn read_auction_infos(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use andromeda_std::common::Milliseconds;
     use cosmwasm_std::testing::mock_dependencies;
-    use cosmwasm_std::Timestamp;
 
     fn get_mock_bids() -> Vec<Bid> {
         vec![
             Bid {
                 bidder: "0".to_string(),
                 amount: Uint128::zero(),
-                timestamp: Timestamp::from_seconds(0),
+                timestamp: Milliseconds::from_nanos(0),
             },
             Bid {
                 bidder: "1".to_string(),
                 amount: Uint128::zero(),
-                timestamp: Timestamp::from_seconds(0),
+                timestamp: Milliseconds::from_nanos(0),
             },
             Bid {
                 bidder: "2".to_string(),
                 amount: Uint128::zero(),
-                timestamp: Timestamp::from_seconds(0),
+                timestamp: Milliseconds::from_nanos(0),
             },
             Bid {
                 bidder: "3".to_string(),
                 amount: Uint128::zero(),
-                timestamp: Timestamp::from_seconds(0),
+                timestamp: Milliseconds::from_nanos(0),
             },
             Bid {
                 bidder: "4".to_string(),
                 amount: Uint128::zero(),
-                timestamp: Timestamp::from_seconds(0),
+                timestamp: Milliseconds::from_nanos(0),
             },
         ]
     }

--- a/packages/andromeda-fungible-tokens/src/airdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/airdrop.rs
@@ -1,8 +1,10 @@
-use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_query};
+use andromeda_std::{
+    andr_exec, andr_instantiate, andr_instantiate_modules, andr_query,
+    common::MillisecondsExpiration,
+};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw_asset::{AssetInfo, AssetInfoUnchecked};
-use cw_utils::Expiration;
 
 #[andr_instantiate]
 #[andr_instantiate_modules]
@@ -17,7 +19,7 @@ pub enum ExecuteMsg {
     RegisterMerkleRoot {
         /// MerkleRoot is hex-encoded merkle root.
         merkle_root: String,
-        expiration: Option<Expiration>,
+        expiration: Option<MillisecondsExpiration>,
         total_amount: Option<Uint128>,
     },
     /// Claim does not check if contract has enough funds, owner must ensure it.
@@ -58,7 +60,7 @@ pub struct MerkleRootResponse {
     pub stage: u8,
     /// MerkleRoot is hex-encoded merkle root.
     pub merkle_root: String,
-    pub expiration: Expiration,
+    pub expiration: Option<MillisecondsExpiration>,
     pub total_amount: Uint128,
 }
 

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -3,7 +3,7 @@ use andromeda_std::common::{MillisecondsExpiration, OrderBy};
 use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_query};
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Uint128};
 use cw20::Cw20ReceiveMsg;
 use cw721::{Cw721ReceiveMsg, Expiration};
 
@@ -205,7 +205,7 @@ pub struct TokenAuctionState {
 pub struct Bid {
     pub bidder: String,
     pub amount: Uint128,
-    pub timestamp: Timestamp,
+    pub timestamp: MillisecondsExpiration,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation
Closes: #411 

# Implementation
Changed `Expiration` to `MillisecondsExpiration` in `RegisterMerkleRoot`. 
`STAGE_EXPIRATION` now stores an `Option<MillisecondsExpiration>` instead of `Expiration`.

# Testing
Made necessary adjustments to unit tests
