### PR TITLE
feat: add ability to removereplace reward tokens to cw20 staking contract

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20-staking/schema/andromeda-cw20-staking.json
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/schema/andromeda-cw20-staking.json
@@ -234,6 +234,54 @@
         "additionalProperties": false
       },
       {
+        "description": "Remove `reward_token`. Owner only.",
+        "type": "object",
+        "required": [
+          "remove_reward_token"
+        ],
+        "properties": {
+          "remove_reward_token": {
+            "type": "object",
+            "required": [
+              "reward_token"
+            ],
+            "properties": {
+              "reward_token": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Replace `reward_token` as another reward token. Owner only.",
+        "type": "object",
+        "required": [
+          "replace_reward_token"
+        ],
+        "properties": {
+          "replace_reward_token": {
+            "type": "object",
+            "required": [
+              "origin_reward_token",
+              "reward_token"
+            ],
+            "properties": {
+              "origin_reward_token": {
+                "type": "string"
+              },
+              "reward_token": {
+                "$ref": "#/definitions/RewardTokenUnchecked"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Unstakes the specified amount of assets, or all if not specified. The user's pending rewards and indexes are updated for each additional reward token.",
         "type": "object",
         "required": [

--- a/contracts/fungible-tokens/andromeda-cw20-staking/schema/raw/execute.json
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/schema/raw/execute.json
@@ -37,6 +37,54 @@
       "additionalProperties": false
     },
     {
+      "description": "Remove `reward_token`. Owner only.",
+      "type": "object",
+      "required": [
+        "remove_reward_token"
+      ],
+      "properties": {
+        "remove_reward_token": {
+          "type": "object",
+          "required": [
+            "reward_token"
+          ],
+          "properties": {
+            "reward_token": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Replace `reward_token` as another reward token. Owner only.",
+      "type": "object",
+      "required": [
+        "replace_reward_token"
+      ],
+      "properties": {
+        "replace_reward_token": {
+          "type": "object",
+          "required": [
+            "origin_reward_token",
+            "reward_token"
+          ],
+          "properties": {
+            "origin_reward_token": {
+              "type": "string"
+            },
+            "reward_token": {
+              "$ref": "#/definitions/RewardTokenUnchecked"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Unstakes the specified amount of assets, or all if not specified. The user's pending rewards and indexes are updated for each additional reward token.",
       "type": "object",
       "required": [

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/allocated_rewards.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/allocated_rewards.rs
@@ -19,7 +19,7 @@ pub(crate) fn update_allocated_index(
     init_timestamp: MillisecondsExpiration,
 ) -> Result<(), ContractError> {
     // If the reward distribution period is over
-    if state.last_distributed == config.till_timestamp {
+    if state.last_distributed == config.till_timestamp || !reward_token.is_active {
         return Ok(());
     }
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -247,11 +247,9 @@ fn execute_add_reward_token(
     let mut reward_token = reward_token.check(&env.block, deps.api)?;
     let reward_token_string = reward_token.to_string();
 
+    let reward_token_option = REWARD_TOKENS.may_load(deps.storage, &reward_token_string)?;
     ensure!(
-        !REWARD_TOKENS.has(deps.storage, &reward_token_string)
-            || !REWARD_TOKENS
-                .load(deps.storage, &reward_token_string)?
-                .is_active,
+        reward_token_option.map_or(true, |reward_token| !reward_token.is_active),
         ContractError::InvalidAsset {
             asset: reward_token_string,
         }

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -250,8 +250,7 @@ fn execute_add_reward_token(
     ensure!(
         !REWARD_TOKENS.has(deps.storage, &reward_token_string)
             || !REWARD_TOKENS
-                .load(deps.storage, &reward_token_string)
-                .unwrap()
+                .load(deps.storage, &reward_token_string)?
                 .is_active,
         ContractError::InvalidAsset {
             asset: reward_token_string,
@@ -329,6 +328,10 @@ fn execute_remove_reward_token(
 
     Ok(Response::new()
         .add_attribute("action", "remove_reward_token")
+        .add_attribute(
+            "number_of_reward_tokens",
+            config.number_of_reward_tokens.to_string(),
+        )
         .add_attribute("removed_token", reward_token_string))
 }
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
@@ -2000,6 +2000,7 @@ fn test_remove_reward_token() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "remove_reward_token")
+            .add_attribute("number_of_reward_tokens", "0")
             .add_attribute("removed_token", "native:uusd")
             .add_submessage(generate_economics_message("owner", "RemoveRewardToken")),
         res

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
@@ -104,6 +104,7 @@ fn test_instantiate() {
                 previous_reward_balance: Uint128::zero(),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -118,6 +119,7 @@ fn test_instantiate() {
                 previous_reward_balance: Uint128::zero(),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:incentive_token")
@@ -142,6 +144,7 @@ fn test_instantiate() {
                     last_distributed: current_timestamp,
                 }
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:allocated_token")
@@ -591,6 +594,7 @@ fn test_update_global_indexes() {
                 previous_reward_balance: Uint128::new(40),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -605,6 +609,7 @@ fn test_update_global_indexes() {
                 previous_reward_balance: Uint128::zero(),
                 init_timestamp: current_timestamp.plus_seconds(1),
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uandr")
@@ -619,6 +624,7 @@ fn test_update_global_indexes() {
                 previous_reward_balance: Uint128::new(20),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:incentive_token")
@@ -649,6 +655,7 @@ fn test_update_global_indexes() {
                 previous_reward_balance: Uint128::new(40),
                 init_timestamp: current_timestamp.plus_seconds(1),
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uandr")
@@ -720,6 +727,7 @@ fn test_update_global_indexes_selective() {
                 previous_reward_balance: Uint128::new(40),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -734,6 +742,7 @@ fn test_update_global_indexes_selective() {
                 previous_reward_balance: Uint128::zero(),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:incentive_token")
@@ -852,6 +861,7 @@ fn test_update_global_indexes_cw20_deposit() {
                 previous_reward_balance: Uint128::zero(),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -866,6 +876,7 @@ fn test_update_global_indexes_cw20_deposit() {
                 previous_reward_balance: Uint128::new(20),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:incentive_token")
@@ -955,6 +966,7 @@ fn test_claim_rewards() {
                 previous_reward_balance: Uint128::new(100),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -1009,6 +1021,7 @@ fn test_claim_rewards() {
                 previous_reward_balance: Uint128::new(34),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -1064,6 +1077,7 @@ fn test_claim_rewards() {
                 previous_reward_balance: Uint128::new(1),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "native:uusd")
@@ -1239,6 +1253,7 @@ fn test_claim_rewards_allocated() {
                     last_distributed: current_timestamp.plus_seconds(50),
                 },
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:allocated_token")
@@ -1416,6 +1431,7 @@ fn test_claim_rewards_allocated_init_timestamp_in_future() {
                     last_distributed: current_timestamp.plus_seconds(60),
                 },
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:allocated_token")
@@ -1630,6 +1646,7 @@ fn test_stake_rewards_update() {
                     last_distributed: current_timestamp.plus_seconds(50),
                 },
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:allocated_token")
@@ -1780,6 +1797,7 @@ fn test_unstake_rewards_update() {
                     last_distributed: current_timestamp.plus_seconds(50),
                 },
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:allocated_token")
@@ -1840,6 +1858,7 @@ fn test_add_reward_token() {
                 previous_reward_balance: Uint128::zero(),
                 init_timestamp: current_timestamp,
             },
+            is_active: true,
         },
         REWARD_TOKENS
             .load(deps.as_ref().storage, "cw20:incentive_token")
@@ -1986,7 +2005,10 @@ fn test_remove_reward_token() {
         res
     );
 
-    assert!(!REWARD_TOKENS.has(deps.as_ref().storage, "native:uusd"));
+    let reward_token = REWARD_TOKENS
+        .load(deps.as_ref().storage, "native:uusd")
+        .unwrap();
+    assert!(!reward_token.is_active);
 }
 
 #[test]
@@ -2043,6 +2065,332 @@ fn test_remove_reward_token_invalid_asset() {
 }
 
 #[test]
+fn test_claim_rewards_after_remove() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let current_timestamp = Milliseconds::from_seconds(mock_env().block.time.seconds());
+
+    // Init with additional rewards
+    init(
+        deps.as_mut(),
+        Some(vec![RewardTokenUnchecked {
+            asset_info: AssetInfoUnchecked::native("uusd"),
+            allocation_config: None,
+            init_timestamp: current_timestamp,
+        }]),
+    )
+    .unwrap();
+
+    deps.querier.with_token_balances(&[(
+        &MOCK_STAKING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(100 + 100))],
+    )]);
+
+    // user1 and user2 stake with 100 tokens separately
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "user1".to_string(),
+        amount: Uint128::new(100),
+        msg: to_json_binary(&Cw20HookMsg::StakeTokens {}).unwrap(),
+    });
+
+    let info = mock_info(MOCK_STAKING_TOKEN, &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    deps.querier.with_token_balances(&[(
+        &MOCK_STAKING_TOKEN.to_string(),
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(200 + 50))],
+    )]);
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "user2".to_string(),
+        amount: Uint128::new(50),
+        msg: to_json_binary(&Cw20HookMsg::StakeTokens {}).unwrap(),
+    });
+
+    let info = mock_info(MOCK_STAKING_TOKEN, &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Staker {
+            share: Uint128::new(100)
+        },
+        STAKERS.load(deps.as_ref().storage, "user1").unwrap()
+    );
+    assert_eq!(
+        Staker {
+            share: Uint128::new(25)
+        },
+        STAKERS.load(deps.as_ref().storage, "user2").unwrap()
+    );
+
+    let info = mock_info("user1", &[]);
+    let msg = ExecuteMsg::ClaimRewards {};
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    // No rewards have been given yet.
+    assert_eq!(ContractError::WithdrawalIsEmpty {}, res.unwrap_err());
+
+    deps.querier
+        .base
+        .update_balance(mock_env().contract.address, coins(100, "uusd"));
+
+    // Update the global index for uusd by depositing 100 uusd
+    let msg = ExecuteMsg::UpdateGlobalIndexes {
+        asset_infos: Some(vec![AssetInfoUnchecked::native("uusd")]),
+    };
+
+    let info = mock_info("owner", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        RewardToken {
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            asset_info: AssetInfo::native("uusd"),
+            reward_type: RewardType::NonAllocated {
+                previous_reward_balance: Uint128::new(100),
+                init_timestamp: current_timestamp,
+            },
+            is_active: true,
+        },
+        REWARD_TOKENS
+            .load(deps.as_ref().storage, "native:uusd")
+            .unwrap()
+    );
+
+    let info = mock_info("user1", &[]);
+    let msg = ExecuteMsg::ClaimRewards {};
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        StakerRewardInfo {
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            pending_rewards: Decimal256::zero(),
+        },
+        STAKER_REWARD_INFOS
+            .load(deps.as_ref().storage, ("user1", "native:uusd"))
+            .unwrap()
+    );
+
+    assert_eq!(
+        RewardToken {
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            asset_info: AssetInfo::native("uusd"),
+            reward_type: RewardType::NonAllocated {
+                previous_reward_balance: Uint128::new(20),
+                init_timestamp: current_timestamp,
+            },
+            is_active: true,
+        },
+        REWARD_TOKENS
+            .load(deps.as_ref().storage, "native:uusd")
+            .unwrap()
+    );
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "claim_rewards")
+            .add_message(BankMsg::Send {
+                to_address: "user1".to_string(),
+                amount: coins(80, "uusd")
+            })
+            .add_submessage(generate_economics_message("user1", "ClaimRewards")),
+        res
+    );
+
+    deps.querier
+        .base
+        .update_balance(mock_env().contract.address, coins(20, "uusd"));
+
+    let msg = ExecuteMsg::RemoveRewardToken {
+        reward_token: "native:uusd".to_string(),
+    };
+    let info = mock_info("owner", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let info = mock_info("user2", &[]);
+    let msg = ExecuteMsg::ClaimRewards {};
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "claim_rewards")
+            .add_message(BankMsg::Send {
+                to_address: "user2".to_string(),
+                amount: coins(20, "uusd")
+            })
+            .add_submessage(generate_economics_message("user2", "ClaimRewards")),
+        res
+    );
+
+    assert_eq!(
+        StakerRewardInfo {
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            pending_rewards: Decimal256::zero(),
+        },
+        STAKER_REWARD_INFOS
+            .load(deps.as_ref().storage, ("user2", "native:uusd"))
+            .unwrap()
+    );
+
+    // Last reward is distributed and reward token is removed from the reward token list
+    assert!(!REWARD_TOKENS.has(deps.as_ref().storage, "native:uusd"));
+    deps.querier
+        .base
+        .update_balance(mock_env().contract.address, coins(0, "uusd"));
+
+    // Verify that the queries return the empty pending rewards.
+    let msg = QueryMsg::Stakers {
+        start_after: None,
+        limit: None,
+    };
+    let res: Vec<StakerResponse> =
+        from_json(query(deps.as_ref(), mock_env(), msg).unwrap()).unwrap();
+
+    assert_eq!(
+        vec![
+            StakerResponse {
+                address: "user1".to_string(),
+                share: Uint128::new(100),
+                pending_rewards: vec![],
+                balance: Uint128::new(200),
+            },
+            StakerResponse {
+                address: "user2".to_string(),
+                share: Uint128::new(25),
+                pending_rewards: vec![],
+                balance: Uint128::new(50),
+            },
+        ],
+        res
+    );
+}
+
+#[test]
+fn test_claim_rewards_allocated_after_remove() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let current_timestamp = Milliseconds::from_seconds(mock_env().block.time.seconds());
+    init(
+        deps.as_mut(),
+        Some(vec![RewardTokenUnchecked {
+            asset_info: AssetInfoUnchecked::cw20(MOCK_ALLOCATED_TOKEN),
+            init_timestamp: current_timestamp,
+            allocation_config: Some(AllocationConfig {
+                till_timestamp: current_timestamp.plus_seconds(100),
+                cycle_rewards: Uint128::new(100),
+                cycle_duration: Milliseconds::from_seconds(100),
+                reward_increase: None,
+            }),
+        }]),
+    )
+    .unwrap();
+
+    deps.querier.with_token_balances(&[
+        (
+            &MOCK_STAKING_TOKEN.to_string(),
+            // 100 is user's deposit.
+            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(100))],
+        ),
+        (
+            &MOCK_ALLOCATED_TOKEN.to_string(),
+            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(100))],
+        ),
+    ]);
+
+    // user stake with 100 mock token
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "user".to_string(),
+        amount: Uint128::new(100),
+        msg: to_json_binary(&Cw20HookMsg::StakeTokens {}).unwrap(),
+    });
+
+    let info = mock_info(MOCK_STAKING_TOKEN, &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    deps.querier.with_token_balances(&[
+        (
+            &MOCK_STAKING_TOKEN.to_string(),
+            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(100 + 100))],
+        ),
+        (
+            &MOCK_ALLOCATED_TOKEN.to_string(),
+            &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(100))],
+        ),
+    ]);
+
+    // Speed time up to halfway through cycle.
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(50);
+
+    // User claims rewards.
+    let info = mock_info("user", &[]);
+    let msg = ExecuteMsg::ClaimRewards {};
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::RemoveRewardToken {
+        reward_token: format!("cw20:{MOCK_ALLOCATED_TOKEN}"),
+    };
+
+    env.block.time = env.block.time.plus_seconds(25);
+    let info = mock_info("owner", &[]);
+    execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    env.block.time = env.block.time.plus_seconds(25);
+    let info = mock_info("user", &[]);
+    let msg = ExecuteMsg::ClaimRewards {};
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "claim_rewards")
+            .add_message(WasmMsg::Execute {
+                contract_addr: MOCK_ALLOCATED_TOKEN.to_owned(),
+                funds: vec![],
+                msg: to_json_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: "user".to_string(),
+                    amount: Uint128::new(25)
+                })
+                .unwrap(),
+            })
+            .add_submessage(generate_economics_message("user", "ClaimRewards")),
+        res
+    );
+
+    assert_eq!(
+        StakerRewardInfo {
+            index: Decimal256::percent(75),
+            pending_rewards: Decimal256::zero(),
+        },
+        STAKER_REWARD_INFOS
+            .load(deps.as_ref().storage, ("user", "cw20:allocated_token"))
+            .unwrap()
+    );
+
+    assert_eq!(
+        RewardToken {
+            index: Decimal256::from_ratio(Uint256::from(150u128), Uint256::from(200u128)),
+            asset_info: AssetInfo::cw20(Addr::unchecked(MOCK_ALLOCATED_TOKEN)),
+            reward_type: RewardType::Allocated {
+                init_timestamp: current_timestamp,
+                allocation_config: AllocationConfig {
+                    till_timestamp: current_timestamp.plus_seconds(100),
+                    cycle_rewards: Uint128::new(100),
+                    cycle_duration: Milliseconds::from_seconds(100),
+                    reward_increase: None,
+                },
+                allocation_state: AllocationState {
+                    current_cycle: 0,
+                    current_cycle_rewards: Uint128::new(100),
+                    last_distributed: current_timestamp.plus_seconds(75),
+                },
+            },
+            is_active: false,
+        },
+        REWARD_TOKENS
+            .load(deps.as_ref().storage, "cw20:allocated_token")
+            .unwrap()
+    );
+}
+
+#[test]
 fn test_replace_reward_token() {
     let mut deps = mock_dependencies_custom(&[]);
     let current_timestamp = Milliseconds::from_seconds(mock_env().block.time.seconds());
@@ -2077,7 +2425,11 @@ fn test_replace_reward_token() {
         res
     );
 
-    assert!(!REWARD_TOKENS.has(deps.as_ref().storage, "native:uusd"));
+    let reward_token = REWARD_TOKENS
+        .load(deps.as_ref().storage, "native:uusd")
+        .unwrap();
+    assert!(!reward_token.is_active);
+
     assert!(REWARD_TOKENS.has(
         deps.as_ref().storage,
         &format!("cw20:{MOCK_INCENTIVE_TOKEN}")

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/testing/tests.rs
@@ -2097,12 +2097,12 @@ fn test_claim_rewards_after_remove() {
 
     deps.querier.with_token_balances(&[(
         &MOCK_STAKING_TOKEN.to_string(),
-        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(200 + 50))],
+        &[(&MOCK_CONTRACT_ADDR.to_string(), &Uint128::new(200 + 100))],
     )]);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: "user2".to_string(),
-        amount: Uint128::new(50),
+        amount: Uint128::new(100),
         msg: to_json_binary(&Cw20HookMsg::StakeTokens {}).unwrap(),
     });
 
@@ -2117,7 +2117,7 @@ fn test_claim_rewards_after_remove() {
     );
     assert_eq!(
         Staker {
-            share: Uint128::new(25)
+            share: Uint128::new(50)
         },
         STAKERS.load(deps.as_ref().storage, "user2").unwrap()
     );
@@ -2143,7 +2143,7 @@ fn test_claim_rewards_after_remove() {
 
     assert_eq!(
         RewardToken {
-            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(150u128)),
             asset_info: AssetInfo::native("uusd"),
             reward_type: RewardType::NonAllocated {
                 previous_reward_balance: Uint128::new(100),
@@ -2162,7 +2162,7 @@ fn test_claim_rewards_after_remove() {
 
     assert_eq!(
         StakerRewardInfo {
-            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(150u128)),
             pending_rewards: Decimal256::zero(),
         },
         STAKER_REWARD_INFOS
@@ -2172,10 +2172,10 @@ fn test_claim_rewards_after_remove() {
 
     assert_eq!(
         RewardToken {
-            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(150u128)),
             asset_info: AssetInfo::native("uusd"),
             reward_type: RewardType::NonAllocated {
-                previous_reward_balance: Uint128::new(20),
+                previous_reward_balance: Uint128::new(34),
                 init_timestamp: current_timestamp,
             },
             is_active: true,
@@ -2190,7 +2190,7 @@ fn test_claim_rewards_after_remove() {
             .add_attribute("action", "claim_rewards")
             .add_message(BankMsg::Send {
                 to_address: "user1".to_string(),
-                amount: coins(80, "uusd")
+                amount: coins(66, "uusd")
             })
             .add_submessage(generate_economics_message("user1", "ClaimRewards")),
         res
@@ -2198,7 +2198,7 @@ fn test_claim_rewards_after_remove() {
 
     deps.querier
         .base
-        .update_balance(mock_env().contract.address, coins(20, "uusd"));
+        .update_balance(mock_env().contract.address, coins(34, "uusd"));
 
     let msg = ExecuteMsg::RemoveRewardToken {
         reward_token: "native:uusd".to_string(),
@@ -2215,7 +2215,7 @@ fn test_claim_rewards_after_remove() {
             .add_attribute("action", "claim_rewards")
             .add_message(BankMsg::Send {
                 to_address: "user2".to_string(),
-                amount: coins(20, "uusd")
+                amount: coins(33, "uusd")
             })
             .add_submessage(generate_economics_message("user2", "ClaimRewards")),
         res
@@ -2223,8 +2223,8 @@ fn test_claim_rewards_after_remove() {
 
     assert_eq!(
         StakerRewardInfo {
-            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(125u128)),
-            pending_rewards: Decimal256::zero(),
+            index: Decimal256::from_ratio(Uint256::from(100u128), Uint256::from(150u128)),
+            pending_rewards: Decimal256::zero()
         },
         STAKER_REWARD_INFOS
             .load(deps.as_ref().storage, ("user2", "native:uusd"))
@@ -2235,7 +2235,7 @@ fn test_claim_rewards_after_remove() {
     assert!(!REWARD_TOKENS.has(deps.as_ref().storage, "native:uusd"));
     deps.querier
         .base
-        .update_balance(mock_env().contract.address, coins(0, "uusd"));
+        .update_balance(mock_env().contract.address, coins(1, "uusd"));
 
     // Verify that the queries return the empty pending rewards.
     let msg = QueryMsg::Stakers {
@@ -2255,9 +2255,9 @@ fn test_claim_rewards_after_remove() {
             },
             StakerResponse {
                 address: "user2".to_string(),
-                share: Uint128::new(25),
+                share: Uint128::new(50),
                 pending_rewards: vec![],
-                balance: Uint128::new(50),
+                balance: Uint128::new(100),
             },
         ],
         res

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -27,6 +27,11 @@ pub enum ExecuteMsg {
     AddRewardToken {
         reward_token: RewardTokenUnchecked,
     },
+    /// Remove `reward_token`. Owner only.
+    RemoveRewardToken {
+        reward_token: String,
+    },
+
     /// Unstakes the specified amount of assets, or all if not specified. The user's pending
     /// rewards and indexes are updated for each additional reward token.
     UnstakeTokens {

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -31,6 +31,11 @@ pub enum ExecuteMsg {
     RemoveRewardToken {
         reward_token: String,
     },
+    /// Replace `reward_token` as another reward token. Owner only.
+    ReplaceRewardToken {
+        origin_reward_token: String,
+        reward_token: RewardTokenUnchecked,
+    },
 
     /// Unstakes the specified amount of assets, or all if not specified. The user's pending
     /// rewards and indexes are updated for each additional reward token.

--- a/packages/andromeda-fungible-tokens/src/cw20_staking.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_staking.rs
@@ -166,6 +166,7 @@ impl RewardTokenUnchecked {
             asset_info: checked_asset_info,
             reward_type,
             index: Decimal256::zero(),
+            is_active: true,
         })
     }
 }
@@ -188,6 +189,7 @@ pub struct RewardToken {
     pub asset_info: AssetInfo,
     pub index: Decimal256,
     pub reward_type: RewardType,
+    pub is_active: bool,
 }
 
 impl fmt::Display for RewardToken {


### PR DESCRIPTION
# Motivation
Resolves https://github.com/andromedaprotocol/andromeda-core/issues/309

# Implementation
- Added  `RemoveRewardToken` and `ReplaceRewardToken` message to allow remove/replace reward token operation.
- Added implementation for remove/replace operation in `contracts\fungible-tokens\andromeda-cw20-staking\src\contract.rs`
  -  Removing operation involves the following operations
    - Update global index for the reward token to be removed to calculate the rewards to distribute for allocated rewards.
    - Set reward token's `is_active` as `false`
  - Replacing operation involves removing + adding reward token operation
- Updated related functions.
  - Updated `update_allocated_index` function in `contracts/fungible-tokens/andromeda-cw20-staking/src/allocated_rewards.rs` to ignore when the reward token is inactive. 
    - index is used to calculate the rewards and thus update operation is not needed for inactive tokens
  - Updated `execute_add_reward_token` to throw an error if the token already exist and is active.
  - Updated `execute_claim_rewards` to remove inactive tokens if the remaining balance is zero
    - If the remaining balance is zero, the rewards for the inactive token is all distributed and thus we can remove the reward token.
  - `update_nonallocated_index` function to ignore if the reward token is inactive.

# Testing
Following test cases are added.
- Basic reward token remove operation (Should flag the reward token as inactive)
- Unauthorized reward token remove/replace operation
- Removing/replacing invalid reward token that does not exist in reward tokens
- Claim rewards after the token is removed
  - If the reward type is `NonAllocated`, the reward is calculated based on share till remove operation
  - If the reward type is `Allocated`, the reward is calculated till remove time
    - If the lifecycle is 100, and the remove operation took in timestamp 75, 75% of the reward is supposed to be distributed
- Basic reward token replace operation (Should flag the original reward token as inactive and add a new token)

# Notes
- Due to rounding error, remaining rewards can be non zero in normal situation which means inactive native tokens will never be removed.