### PR TITLE
Feat/crowdfund restructure/purchase tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
+ "cw20",
  "cw721 0.18.0",
 ]
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -21,6 +21,7 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw721 = { workspace = true }
+cw20 = { workspace = true }
 
 andromeda-std = { workspace = true, features = ["modules"] }
 andromeda-non-fungible-tokens = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -309,9 +309,7 @@ fn execute_purchase_tiers(
     } = ctx;
 
     // Ensure campaign accepting coin is received
-    let payment: &Coin = &info.funds[0];
     let campaign_config = get_config(deps.storage)?;
-
     ensure!(
         info.funds.len() == 1,
         ContractError::InvalidFunds {
@@ -321,6 +319,8 @@ fn execute_purchase_tiers(
             ),
         }
     );
+
+    let payment: &Coin = &info.funds[0];
 
     let sender = info.sender.to_string();
     let denom = payment.denom.clone();

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -424,22 +424,20 @@ fn purchase_tiers(
 
     if amount > total_cost {
         resp = match denom {
-            Asset::NativeToken(denom) => resp
-                .add_attribute("refunded", amount - total_cost)
-                .add_message(BankMsg::Send {
-                    to_address: sender.to_string(),
-                    amount: vec![coin((amount - total_cost).u128(), denom)],
-                }),
+            Asset::NativeToken(denom) => resp.add_message(BankMsg::Send {
+                to_address: sender.to_string(),
+                amount: vec![coin((amount - total_cost).u128(), denom)],
+            }),
             Asset::Cw20Token(denom) => {
                 let transfer_msg = Cw20ExecuteMsg::Transfer {
                     recipient: sender,
                     amount: amount - total_cost,
                 };
                 let wasm_msg = wasm_execute(denom, &transfer_msg, vec![])?;
-                resp.add_attribute("refunded", amount - total_cost)
-                    .add_message(wasm_msg)
+                resp.add_message(wasm_msg)
             }
         }
+        .add_attribute("refunded", amount - total_cost);
     }
 
     Ok(resp)

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -40,6 +40,12 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
+    let branch = DepsMut {
+        storage: deps.storage,
+        api: deps.api,
+        querier: deps.querier,
+    };
+    msg.campaign_config.validate(branch, &env)?;
     update_config(deps.storage, msg.campaign_config)?;
 
     set_tiers(deps.storage, msg.tiers)?;

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -18,8 +18,8 @@ use andromeda_std::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, ensure, from_json, wasm_execute, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdError, Uint128, Uint64,
+    coin, ensure, from_json, wasm_execute, Addr, BankMsg, Binary, Coin, Deps, DepsMut, Env,
+    MessageInfo, Reply, Response, StdError, Uint128, Uint64,
 };
 
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
@@ -351,9 +351,7 @@ fn purchase_tiers(
     sender: String,
     orders: Vec<SimpleTierOrder>,
 ) -> Result<Response, ContractError> {
-    let ExecuteContext {
-        deps, info, env, ..
-    } = ctx;
+    let ExecuteContext { deps, env, .. } = ctx;
 
     let campaign_config = get_config(deps.storage)?;
     let mut current_cap = get_current_cap(deps.storage);
@@ -403,7 +401,7 @@ fn purchase_tiers(
         let tier = get_tier(deps.storage, u64::from(order.level))?;
         let uint128: Result<Uint128, ContractError> = Ok(sum + tier.price * order.amount);
         full_orders.push(TierOrder {
-            orderer: info.sender.clone(),
+            orderer: Addr::unchecked(sender.clone()),
             level: order.level,
             amount: order.amount,
         });

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -26,12 +26,17 @@ pub(crate) fn get_config(storage: &dyn Storage) -> Result<CampaignConfig, Contra
     CAMPAIGN_CONFIG.load(storage).map_err(ContractError::Std)
 }
 
-pub (crate) fn get_current_cap(storage: &mut dyn Storage) -> Uint128 {
+pub(crate) fn get_current_cap(storage: &mut dyn Storage) -> Uint128 {
     CURRENT_CAP.load(storage).unwrap_or_default()
 }
 
-pub (crate) fn set_current_cap(storage: &mut dyn Storage, current_cap: Uint128) -> Result<(), ContractError> {
-    CURRENT_CAP.save(storage, &current_cap).map_err(ContractError::Std)
+pub(crate) fn set_current_cap(
+    storage: &mut dyn Storage,
+    current_cap: Uint128,
+) -> Result<(), ContractError> {
+    CURRENT_CAP
+        .save(storage, &current_cap)
+        .map_err(ContractError::Std)
 }
 
 /// Only used on the instantiation
@@ -52,12 +57,12 @@ pub(crate) fn set_tiers(storage: &mut dyn Storage, tiers: Vec<Tier>) -> Result<(
 }
 
 pub(crate) fn get_tier(storage: &mut dyn Storage, level: u64) -> Result<Tier, ContractError> {
-    TIERS.load(storage, level).map_err(
-        |_| ContractError::InvalidTier {
+    TIERS
+        .load(storage, level)
+        .map_err(|_| ContractError::InvalidTier {
             operation: "get_tier".to_string(),
-            msg: format!("Tier with level {} does not exist", level)
-        }
-    )
+            msg: format!("Tier with level {} does not exist", level),
+        })
 }
 
 pub(crate) fn add_tier(storage: &mut dyn Storage, tier: &Tier) -> Result<(), ContractError> {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -26,7 +26,7 @@ pub(crate) fn get_config(storage: &dyn Storage) -> Result<CampaignConfig, Contra
     CAMPAIGN_CONFIG.load(storage).map_err(ContractError::Std)
 }
 
-pub(crate) fn get_current_cap(storage: &mut dyn Storage) -> Uint128 {
+pub(crate) fn get_current_cap(storage: &dyn Storage) -> Uint128 {
     CURRENT_CAP.load(storage).unwrap_or_default()
 }
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -134,9 +134,13 @@ pub(crate) fn set_tier_orders(
                 msg: format!("Tier with level {} does not exist", new_order.level),
             }
         })?;
-        if let Some(mut remaining_amount) = tier.limit {
-            remaining_amount = remaining_amount.checked_sub(new_order.amount)?;
-            tier.limit = Some(remaining_amount);
+        if let Some(limit) = tier.limit {
+            tier.sold_amount = tier.sold_amount.checked_add(new_order.amount)?;
+            ensure!(
+                limit >= tier.sold_amount,
+                ContractError::PurchaseLimitReached {}
+            );
+
             update_tier(storage, &tier)?;
         }
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -26,6 +26,14 @@ pub(crate) fn get_config(storage: &dyn Storage) -> Result<CampaignConfig, Contra
     CAMPAIGN_CONFIG.load(storage).map_err(ContractError::Std)
 }
 
+pub (crate) fn get_current_cap(storage: &mut dyn Storage) -> Uint128 {
+    CURRENT_CAP.load(storage).unwrap_or_default()
+}
+
+pub (crate) fn set_current_cap(storage: &mut dyn Storage, current_cap: Uint128) -> Result<(), ContractError> {
+    CURRENT_CAP.save(storage, &current_cap).map_err(ContractError::Std)
+}
+
 /// Only used on the instantiation
 pub(crate) fn set_tiers(storage: &mut dyn Storage, tiers: Vec<Tier>) -> Result<(), ContractError> {
     for tier in tiers {
@@ -41,6 +49,15 @@ pub(crate) fn set_tiers(storage: &mut dyn Storage, tiers: Vec<Tier>) -> Result<(
     }
 
     Ok(())
+}
+
+pub(crate) fn get_tier(storage: &mut dyn Storage, level: u64) -> Result<Tier, ContractError> {
+    TIERS.load(storage, level).map_err(
+        |_| ContractError::InvalidTier {
+            operation: "get_tier".to_string(),
+            msg: format!("Tier with level {} does not exist", level)
+        }
+    )
 }
 
 pub(crate) fn add_tier(storage: &mut dyn Storage, tier: &Tier) -> Result<(), ContractError> {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
@@ -18,15 +18,14 @@ pub const MOCK_DEFAULT_OWNER: &str = "owner";
 pub const MOCK_TIER_CONTRACT: &str = "tier_contract";
 pub const MOCK_WITHDRAWAL_ADDRESS: &str = "withdrawal_address";
 pub const MOCK_DEFAULT_LIMIT: u128 = 100000;
-const MOCK_NATIVE_DENOM: &str = "uandr";
 
-pub fn mock_campaign_config() -> CampaignConfig {
+pub fn mock_campaign_config(denom: Asset) -> CampaignConfig {
     CampaignConfig {
         title: "First Crowdfund".to_string(),
         description: "Demo campaign for testing".to_string(),
         banner: "http://<campaign_banner>".to_string(),
         url: "http://<campaign_url>".to_string(),
-        denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+        denom,
         tier_address: AndrAddr::from_string(MOCK_TIER_CONTRACT.to_owned()),
         withdrawal_recipient: Recipient::from_string(MOCK_WITHDRAWAL_ADDRESS.to_owned()),
         soft_cap: None,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
@@ -48,6 +48,7 @@ pub fn mock_campaign_tiers() -> Vec<Tier> {
                 },
                 token_uri: None,
             },
+            sold_amount: Uint128::zero(),
         },
         Tier {
             level: Uint64::new(1u64),
@@ -60,6 +61,7 @@ pub fn mock_campaign_tiers() -> Vec<Tier> {
                 },
                 token_uri: None,
             },
+            sold_amount: Uint128::zero(),
         },
     ]
 }
@@ -76,6 +78,7 @@ pub fn mock_zero_price_tier(level: Uint64) -> Tier {
             },
             token_uri: None,
         },
+        sold_amount: Uint128::zero(),
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
@@ -6,7 +6,7 @@ use andromeda_std::{
     ado_base::InstantiateMsg,
     ado_contract::ADOContract,
     amp::{AndrAddr, Recipient},
-    common::MillisecondsExpiration,
+    common::{denom::Asset, MillisecondsExpiration},
     testing::mock_querier::{WasmMockQuerier, MOCK_ADO_PUBLISHER, MOCK_KERNEL_CONTRACT},
 };
 use cosmwasm_std::{
@@ -17,13 +17,15 @@ use cosmwasm_std::{
 pub const MOCK_TIER_CONTRACT: &str = "tier_contract";
 pub const MOCK_WITHDRAWAL_ADDRESS: &str = "withdrawal_address";
 pub const MOCK_DEFAULT_LIMIT: u128 = 100000;
+const MOCK_NATIVE_DENOM: &str = "uandr";
+
 pub fn mock_campaign_config() -> CampaignConfig {
     CampaignConfig {
         title: "First Crowdfund".to_string(),
         description: "Demo campaign for testing".to_string(),
         banner: "http://<campaign_banner>".to_string(),
         url: "http://<campaign_url>".to_string(),
-        denom: "uandr".to_string(),
+        denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
         tier_address: AndrAddr::from_string(MOCK_TIER_CONTRACT.to_owned()),
         withdrawal_recipient: Recipient::from_string(MOCK_WITHDRAWAL_ADDRESS.to_owned()),
         soft_cap: None,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
@@ -14,6 +14,7 @@ use cosmwasm_std::{
     Coin, OwnedDeps, QuerierWrapper, Uint128, Uint64,
 };
 
+pub const MOCK_DEFAULT_OWNER: &str = "owner";
 pub const MOCK_TIER_CONTRACT: &str = "tier_contract";
 pub const MOCK_WITHDRAWAL_ADDRESS: &str = "withdrawal_address";
 pub const MOCK_DEFAULT_LIMIT: u128 = 100000;

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -190,6 +190,7 @@ mod test {
             level: Uint64::new(2u64),
             label: "Tier 2".to_string(),
             limit: Some(Uint128::new(100)),
+            sold_amount: Uint128::zero(),
             price: Uint128::new(100),
             meta_data: TierMetaData {
                 extension: TokenExtension {
@@ -202,6 +203,7 @@ mod test {
             level: Uint64::new(0u64),
             label: "Tier 2".to_string(),
             limit: Some(Uint128::new(100)),
+            sold_amount: Uint128::zero(),
             price: Uint128::new(100),
             meta_data: TierMetaData {
                 extension: TokenExtension {
@@ -296,6 +298,7 @@ mod test {
             level: Uint64::zero(),
             label: "Tier 0".to_string(),
             limit: Some(Uint128::new(100)),
+            sold_amount: Uint128::zero(),
             price: Uint128::new(100),
             meta_data: TierMetaData {
                 extension: TokenExtension {
@@ -308,6 +311,7 @@ mod test {
             level: Uint64::new(2u64),
             label: "Tier 2".to_string(),
             limit: Some(Uint128::new(100)),
+            sold_amount: Uint128::zero(),
             price: Uint128::new(100),
             meta_data: TierMetaData {
                 extension: TokenExtension {
@@ -403,6 +407,7 @@ mod test {
             label: "Tier 0".to_string(),
             limit: Some(Uint128::new(100)),
             price: Uint128::new(100),
+            sold_amount: Uint128::zero(),
             meta_data: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
@@ -415,6 +420,7 @@ mod test {
             label: "Tier 2".to_string(),
             limit: Some(Uint128::new(100)),
             price: Uint128::new(100),
+            sold_amount: Uint128::zero(),
             meta_data: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
@@ -515,6 +521,7 @@ mod test {
             level: Uint64::new(1u64),
             label: "Tier 1".to_string(),
             limit: Some(Uint128::new(1000u128)),
+            sold_amount: Uint128::zero(),
             price: Uint128::new(10u128),
             meta_data: TierMetaData {
                 extension: TokenExtension {
@@ -645,10 +652,9 @@ mod test {
                             TIERS
                                 .load(&deps.storage, order.level.into())
                                 .unwrap()
-                                .limit
-                                .unwrap()
+                                .sold_amount
                                 .u128(),
-                            MOCK_DEFAULT_LIMIT - order_amount
+                            order_amount
                         );
                     }
                 }
@@ -715,6 +721,21 @@ mod test {
                 }],
                 initial_cap: Uint128::new(500),
                 funds: vec![coin(1000, MOCK_NATIVE_DENOM)],
+                denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+            },
+            PurchaseTierTestCase {
+                name: "Purchasing more than limit".to_string(),
+                stage: CampaignStage::ONGOING,
+                expected_res: Err(ContractError::PurchaseLimitReached {}),
+                payee: buyer.to_string(),
+                start_time: Some(past_time()),
+                end_time: future_time(&env),
+                orders: vec![SimpleTierOrder {
+                    level: Uint64::one(),
+                    amount: Uint128::new(MOCK_DEFAULT_LIMIT + 1),
+                }],
+                initial_cap: Uint128::new(500),
+                funds: vec![coin(10 * MOCK_DEFAULT_LIMIT + 20, MOCK_NATIVE_DENOM)],
                 denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
             },
             PurchaseTierTestCase {
@@ -847,8 +868,8 @@ mod test {
                         .load(deps.as_ref().storage, order.level.into())
                         .unwrap();
                     assert_eq!(
-                        tier.limit.unwrap().u128(),
-                        MOCK_DEFAULT_LIMIT - order.amount.u128(),
+                        tier.sold_amount.u128(),
+                        order.amount.u128(),
                         "Test case: {}",
                         test.name
                     );
@@ -1045,8 +1066,8 @@ mod test {
                         .load(deps.as_ref().storage, order.level.into())
                         .unwrap();
                     assert_eq!(
-                        tier.limit.unwrap().u128(),
-                        MOCK_DEFAULT_LIMIT - order.amount.u128(),
+                        tier.sold_amount.u128(),
+                        order.amount.u128(),
                         "Test case: {}",
                         test.name
                     );

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -39,8 +39,8 @@ pub enum ExecuteMsg {
     PurchaseTiers { orders: Vec<SimpleTierOrder> },
     /// Purchase tiers with cw20
     Receive(Cw20ReceiveMsg),
-    /// End the campaign
-    EndCampaign {},
+    // /// End the campaign
+    // EndCampaign {},
 }
 
 #[cw_serde]
@@ -141,6 +141,7 @@ pub struct Tier {
     pub label: String,
     pub price: Uint128,
     pub limit: Option<Uint128>, // None for no limit
+    pub sold_amount: Uint128,
     pub meta_data: TierMetaData,
 }
 

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -39,6 +39,8 @@ pub enum ExecuteMsg {
     PurchaseTiers { orders: Vec<SimpleTierOrder> },
     /// Purchase tiers with cw20
     Receive(Cw20ReceiveMsg),
+    /// End the campaign
+    EndCampaign {},
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -1,11 +1,12 @@
 use andromeda_std::amp::addresses::AndrAddr;
 use andromeda_std::amp::Recipient;
-use andromeda_std::common::denom::validate_denom;
+use andromeda_std::common::denom::Asset;
 use andromeda_std::common::MillisecondsExpiration;
 use andromeda_std::error::ContractError;
 use andromeda_std::{andr_exec, andr_instantiate, andr_instantiate_modules, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Addr, Deps, Uint128, Uint64};
+use cosmwasm_std::{ensure, Addr, DepsMut, Env, Uint128, Uint64};
+use cw20::Cw20ReceiveMsg;
 
 use crate::cw721::TokenExtension;
 
@@ -36,6 +37,13 @@ pub enum ExecuteMsg {
     },
     /// Purchase tiers
     PurchaseTiers { orders: Vec<SimpleTierOrder> },
+    /// Purchase tiers with cw20
+    Receive(Cw20ReceiveMsg),
+}
+
+#[cw_serde]
+pub enum Cw20HookMsg {
+    PurchaseTiers { orders: Vec<SimpleTierOrder> },
 }
 
 #[andr_query]
@@ -56,7 +64,7 @@ pub struct CampaignConfig {
     /// The address of the tier contract whose tokens are being distributed
     pub tier_address: AndrAddr,
     /// The denom of the token that is being accepted by the campaign
-    pub denom: String,
+    pub denom: Asset,
     /// Recipient that is upposed to receive the funds gained by the campaign
     pub withdrawal_recipient: Recipient,
     /// The minimum amount of funding to be sold for the successful fundraising
@@ -70,11 +78,12 @@ pub struct CampaignConfig {
 }
 
 impl CampaignConfig {
-    pub fn validate(&self, deps: Deps) -> Result<(), ContractError> {
+    pub fn validate(&self, mut deps: DepsMut, env: Env) -> Result<(), ContractError> {
         // validate addresses
         self.tier_address.validate(deps.api)?;
-        self.withdrawal_recipient.validate(&deps)?;
-        validate_denom(deps, self.denom.clone())?;
+        self.withdrawal_recipient.validate(&deps.as_ref())?;
+        // let _ = get_verified_asset();
+        let _ = self.denom.get_verified_asset(deps.branch(), env.clone())?;
 
         // validate meta info
         ensure!(

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -82,7 +82,6 @@ impl CampaignConfig {
         // validate addresses
         self.tier_address.validate(deps.api)?;
         self.withdrawal_recipient.validate(&deps.as_ref())?;
-        // let _ = get_verified_asset();
         let _ = self
             .denom
             .get_verified_asset(deps, env.clone())

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -78,12 +78,17 @@ pub struct CampaignConfig {
 }
 
 impl CampaignConfig {
-    pub fn validate(&self, mut deps: DepsMut, env: Env) -> Result<(), ContractError> {
+    pub fn validate(&self, deps: DepsMut, env: &Env) -> Result<(), ContractError> {
         // validate addresses
         self.tier_address.validate(deps.api)?;
         self.withdrawal_recipient.validate(&deps.as_ref())?;
         // let _ = get_verified_asset();
-        let _ = self.denom.get_verified_asset(deps.branch(), env.clone())?;
+        let _ = self
+            .denom
+            .get_verified_asset(deps, env.clone())
+            .map_err(|_| ContractError::InvalidAsset {
+                asset: self.denom.to_string(),
+            })?;
 
         // validate meta info
         ensure!(

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -34,6 +34,8 @@ pub enum ExecuteMsg {
         end_time: MillisecondsExpiration,
         presale: Option<Vec<TierOrder>>,
     },
+    /// Purchase tiers
+    PurchaseTiers { orders: Vec<SimpleTierOrder> },
 }
 
 #[andr_query]
@@ -130,6 +132,13 @@ pub struct Tier {
 #[cw_serde]
 pub struct TierOrder {
     pub orderer: Addr,
+    pub level: Uint64,
+    pub amount: Uint128,
+}
+
+// Used when the orderer is defined
+#[cw_serde]
+pub struct SimpleTierOrder {
     pub level: Uint64,
     pub amount: Uint128,
 }

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result as StdResult};
+
 use crate::{ado_contract::ADOContract, amp::AndrAddr, error::ContractError};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{ensure, to_json_binary, Deps, DepsMut, Env, QueryRequest, WasmQuery};
@@ -9,6 +11,16 @@ pub enum Asset {
     Cw20Token(AndrAddr),
     NativeToken(String),
 }
+
+impl Display for Asset {
+    fn fmt(&self, f: &mut Formatter) -> StdResult {
+        match self {
+            Asset::NativeToken(addr) => f.write_str(&format!("native:{addr}")),
+            Asset::Cw20Token(addr) => f.write_str(&format!("cw20:{addr}")),
+        }
+    }
+}
+
 impl Asset {
     pub fn get_verified_asset(
         &self,

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -279,6 +279,12 @@ pub enum ContractError {
     #[error("AuctionEnded")]
     AuctionEnded {},
 
+    #[error("CampaignNotStarted")]
+    CampaignNotStarted {},
+
+    #[error("CampaignEnded")]
+    CampaignEnded {},
+
     #[error("SaleNotStarted")]
     SaleNotStarted {},
 

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -285,6 +285,9 @@ pub enum ContractError {
     #[error("CampaignEnded")]
     CampaignEnded {},
 
+    #[error("Campaign is not expired yet")]
+    CampaignNotExpired {},
+
     #[error("SaleNotStarted")]
     SaleNotStarted {},
 


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/446

# Implementation
- Added messages to `packages/andromeda-non-fungible-tokens/src/crowdfund.rs` for purchasing tiers with native or cw20 token.
- Defined `purchase_tiers` function for the main logic to purchase tiers and let `execute_purchase_tiers` and `handle_receive_cw20` to use that for purchasing tiers.
- Updated `CampaignConfig` to save `denom` as `Asset` instead of `String`.
- Not related to the issue
   - Fixed instantiated function to validate `msg.campaign_config`.
# Testing
- Added unit tests for purchasing with native or cw20 contract
- Added test cases for `instantiate` to instantiate with cw20 as well.

# Future work
- https://github.com/andromedaprotocol/andromeda-core/issues/447
- https://github.com/andromedaprotocol/andromeda-core/issues/448
- https://github.com/andromedaprotocol/andromeda-core/issues/449
- https://github.com/andromedaprotocol/andromeda-core/issues/451