### PR TITLE
Feat: crowdfund-restructure/end campaign

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -23,6 +23,7 @@ use cosmwasm_std::{
 };
 
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
+use cw_utils::nonpayable;
 
 use crate::state::{
     add_tier, get_config, get_current_cap, get_current_stage, get_tier, is_valid_tiers,
@@ -346,6 +347,8 @@ fn handle_receive_cw20(
 }
 
 fn execute_end_campaign(ctx: ExecuteContext) -> Result<Response, ContractError> {
+    nonpayable(&ctx.info)?;
+
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -140,7 +140,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         } => execute_start_campaign(ctx, start_time, end_time, presale),
         ExecuteMsg::PurchaseTiers { orders } => execute_purchase_tiers(ctx, orders),
         ExecuteMsg::Receive(msg) => handle_receive_cw20(ctx, msg),
-        ExecuteMsg::EndCampaign { is_discard } => execute_end_campaign(ctx, is_discard),
+        ExecuteMsg::EndCampaign {} => execute_end_campaign(ctx, false),
+        ExecuteMsg::DiscardCampaign {} => execute_end_campaign(ctx, true),
         _ => ADOContract::default().execute(ctx, msg),
     }?;
 
@@ -402,8 +403,13 @@ fn execute_end_campaign(ctx: ExecuteContext, is_discard: bool) -> Result<Respons
 
     set_current_stage(deps.storage, next_stage.clone())?;
 
+    let action = if is_discard {
+        "discard_campaign"
+    } else {
+        "end_campaign"
+    };
     let mut resp = Response::new()
-        .add_attribute("action", "end_campaign")
+        .add_attribute("action", action)
         .add_attribute("result", next_stage.to_string());
     if next_stage == CampaignStage::SUCCESS {
         let withdrawal_address = campaign_config

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -364,11 +364,17 @@ fn execute_end_campaign(ctx: ExecuteContext, is_discard: bool) -> Result<Respons
     // Campaign is finished already successfully
     // NOTE: ending failed campaign has no effect and is ignored
     let curr_stage = get_current_stage(deps.storage);
+    let action = if is_discard {
+        "discard_campaign"
+    } else {
+        "end_campaign"
+    };
+
     ensure!(
         curr_stage == CampaignStage::ONGOING
             || (is_discard && curr_stage != CampaignStage::SUCCESS),
         ContractError::InvalidCampaignOperation {
-            operation: "end_campaign".to_string(),
+            operation: action.to_string(),
             stage: curr_stage.to_string()
         }
     );
@@ -403,11 +409,6 @@ fn execute_end_campaign(ctx: ExecuteContext, is_discard: bool) -> Result<Respons
 
     set_current_stage(deps.storage, next_stage.clone())?;
 
-    let action = if is_discard {
-        "discard_campaign"
-    } else {
-        "end_campaign"
-    };
     let mut resp = Response::new()
         .add_attribute("action", action)
         .add_attribute("result", next_stage.to_string());

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -140,7 +140,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         } => execute_start_campaign(ctx, start_time, end_time, presale),
         ExecuteMsg::PurchaseTiers { orders } => execute_purchase_tiers(ctx, orders),
         ExecuteMsg::Receive(msg) => handle_receive_cw20(ctx, msg),
-        ExecuteMsg::EndCampaign {} => execute_end_campaign(ctx),
+        ExecuteMsg::EndCampaign { is_discard } => execute_end_campaign(ctx, is_discard),
         _ => ADOContract::default().execute(ctx, msg),
     }?;
 
@@ -346,7 +346,7 @@ fn handle_receive_cw20(
     }
 }
 
-fn execute_end_campaign(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_end_campaign(ctx: ExecuteContext, is_discard: bool) -> Result<Response, ContractError> {
     nonpayable(&ctx.info)?;
 
     let ExecuteContext {
@@ -360,10 +360,12 @@ fn execute_end_campaign(ctx: ExecuteContext) -> Result<Response, ContractError> 
         ContractError::Unauthorized {}
     );
 
-    // Campaign is finished already or not started
+    // Campaign is finished already successfully
+    // NOTE: ending failed campaign has no effect and is ignored
     let curr_stage = get_current_stage(deps.storage);
     ensure!(
-        curr_stage == CampaignStage::ONGOING,
+        curr_stage == CampaignStage::ONGOING
+            || (is_discard && curr_stage != CampaignStage::SUCCESS),
         ContractError::InvalidCampaignOperation {
             operation: "end_campaign".to_string(),
             stage: curr_stage.to_string()
@@ -376,11 +378,21 @@ fn execute_end_campaign(ctx: ExecuteContext) -> Result<Response, ContractError> 
     let end_time = campaign_config.end_time;
 
     // Decide the next stage
-    let next_stage = match (current_cap >= soft_cap, end_time.is_expired(&env.block)) {
-        (true, _) => CampaignStage::SUCCESS,
-        (false, true) => CampaignStage::FAILED,
-        (false, false) => {
+    let next_stage = match (
+        is_discard,
+        current_cap >= soft_cap,
+        end_time.is_expired(&env.block),
+    ) {
+        // discard the campaign as there are some unexpected issues
+        (true, _, _) => CampaignStage::FAILED,
+        // Capital hit the target capital and thus campaign is successful
+        (false, true, _) => CampaignStage::SUCCESS,
+        // Capital did hit the target capital and is expired, failed
+        (false, false, true) => CampaignStage::FAILED,
+        // Capital did not hit the target capital and campaign is not expired
+        (false, false, false) => {
             if current_cap != Uint128::zero() {
+                // Need to wait until campaign expires
                 return Err(ContractError::CampaignNotExpired {});
             }
             // No capital is gained and thus it can be paused and restart again

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -40,7 +40,9 @@ pub enum ExecuteMsg {
     /// Purchase tiers with cw20
     Receive(Cw20ReceiveMsg),
     /// End the campaign
-    EndCampaign { is_discard: bool },
+    EndCampaign {},
+    /// End the campaign
+    DiscardCampaign {},
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -39,8 +39,8 @@ pub enum ExecuteMsg {
     PurchaseTiers { orders: Vec<SimpleTierOrder> },
     /// Purchase tiers with cw20
     Receive(Cw20ReceiveMsg),
-    // /// End the campaign
-    // EndCampaign {},
+    /// End the campaign
+    EndCampaign {},
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -40,7 +40,7 @@ pub enum ExecuteMsg {
     /// Purchase tiers with cw20
     Receive(Cw20ReceiveMsg),
     /// End the campaign
-    EndCampaign {},
+    EndCampaign { is_discard: bool },
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -41,7 +41,7 @@ pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     /// End the campaign
     EndCampaign {},
-    /// End the campaign
+    /// Discard the campaign
     DiscardCampaign {},
 }
 


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/447.

# Implementation
- Only owner can send `EndCampaign` msg to end/pause the campaign.
- Only campaign on `ONGOING` stage can be ended/paused.
- In case current capital is 0, the campaign is not expired and did not hit the soft capital, the campaign stage is set to `READY`
- If campaign did not hit the soft capital and is not expired, it throws an error
- If campaign hit the did soft capital, current stage is set to `SUCCESS`
- If campaign hit the did not hit soft capital and is expired, current stage is set to `FAILED`
- In case campaign was successful, gained capital is sent to the withdrawal address

# Testing
Unit tests for end campaign added with following cases
- Successful campaign using native token
- Successful campaign using cw20
- Failed campaign (did not hit the soft capital)
- Pause campaign (current capital is zero and is not expired)
- End campaign from unauthorized sender
- End campaign on invalid stage(not `ONGOING` stage)
- End unexpired campaign

# Future work

- https://github.com/andromedaprotocol/andromeda-core/issues/448
- https://github.com/andromedaprotocol/andromeda-core/issues/449
- https://github.com/andromedaprotocol/andromeda-core/issues/451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to discard a campaign in the crowdfund contract, providing more flexibility in campaign management.

- **Enhancements**
  - Updated the campaign end logic to differentiate between ending and discarding a campaign, improving control over campaign outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->