### PR TITLE
fix: Development Merge 

### DIFF
--- a/contracts/finance/andromeda-conditional-splitter/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/testing/mock_querier.rs
@@ -1,23 +1,15 @@
-use andromeda_std::ado_base::hooks::{AndromedaHook, HookMsg, OnFundsTransferResponse};
 use andromeda_std::ado_base::InstantiateMsg;
 use andromeda_std::ado_contract::ADOContract;
-use andromeda_std::common::Funds;
 use andromeda_std::testing::mock_querier::MockAndromedaQuerier;
 use cosmwasm_std::testing::mock_info;
+use cosmwasm_std::QuerierWrapper;
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
-    to_json_binary, Binary, Coin, ContractResult, OwnedDeps, Querier, QuerierResult, QueryRequest,
-    SystemError, SystemResult, WasmQuery,
-};
-use cosmwasm_std::{BankMsg, CosmosMsg, QuerierWrapper, Response, SubMsg, Uint128};
-
-pub use andromeda_std::testing::mock_querier::{
-    MOCK_ADDRESS_LIST_CONTRACT, MOCK_KERNEL_CONTRACT, MOCK_RATES_CONTRACT,
+    Coin, OwnedDeps, Querier, QuerierResult, QueryRequest, SystemError, SystemResult,
 };
 
-pub const MOCK_TAX_RECIPIENT: &str = "tax_recipient";
-pub const MOCK_ROYALTY_RECIPIENT: &str = "royalty_recipient";
+pub use andromeda_std::testing::mock_querier::MOCK_KERNEL_CONTRACT;
 
 /// Alternative to `cosmwasm_std::testing::mock_dependencies` that allows us to respond to custom queries.
 ///
@@ -77,90 +69,7 @@ impl Querier for WasmMockQuerier {
 
 impl WasmMockQuerier {
     pub fn handle_query(&self, request: &QueryRequest<cosmwasm_std::Empty>) -> QuerierResult {
-        match &request {
-            QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
-                match contract_addr.as_str() {
-                    MOCK_RATES_CONTRACT => self.handle_rates_query(msg),
-                    MOCK_ADDRESS_LIST_CONTRACT => self.handle_addresslist_query(msg),
-                    _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
-                }
-            }
-            _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
-        }
-    }
-
-    fn handle_rates_query(&self, msg: &Binary) -> QuerierResult {
-        match from_json(msg).unwrap() {
-            HookMsg::AndrHook(hook_msg) => match hook_msg {
-                AndromedaHook::OnFundsTransfer {
-                    sender: _,
-                    payload: _,
-                    amount,
-                } => {
-                    let (new_funds, msgs): (Funds, Vec<SubMsg>) = match amount {
-                        Funds::Native(ref coin) => (
-                            Funds::Native(Coin {
-                                // Deduct royalty of 10%.
-                                amount: coin.amount.multiply_ratio(90u128, 100u128),
-                                denom: coin.denom.clone(),
-                            }),
-                            vec![
-                                SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
-                                    to_address: MOCK_ROYALTY_RECIPIENT.to_owned(),
-                                    amount: vec![Coin {
-                                        // Royalty of 10%
-                                        amount: coin.amount.multiply_ratio(10u128, 100u128),
-                                        denom: coin.denom.clone(),
-                                    }],
-                                })),
-                                SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
-                                    to_address: MOCK_TAX_RECIPIENT.to_owned(),
-                                    amount: vec![Coin {
-                                        // Flat tax of 50
-                                        amount: Uint128::from(50u128),
-                                        denom: coin.denom.clone(),
-                                    }],
-                                })),
-                            ],
-                        ),
-                        Funds::Cw20(_) => {
-                            let resp: Response = Response::default();
-                            return SystemResult::Ok(ContractResult::Ok(
-                                to_json_binary(&resp).unwrap(),
-                            ));
-                        }
-                    };
-                    let response = OnFundsTransferResponse {
-                        msgs,
-                        events: vec![],
-                        leftover_funds: new_funds,
-                    };
-                    SystemResult::Ok(ContractResult::Ok(to_json_binary(&Some(response)).unwrap()))
-                }
-                _ => SystemResult::Ok(ContractResult::Ok(
-                    to_json_binary(&None::<Response>).unwrap(),
-                )),
-            },
-        }
-    }
-
-    fn handle_addresslist_query(&self, msg: &Binary) -> QuerierResult {
-        match from_json(msg).unwrap() {
-            HookMsg::AndrHook(hook_msg) => match hook_msg {
-                AndromedaHook::OnExecute { sender, payload: _ } => {
-                    let whitelisted_addresses = ["sender"];
-                    let response: Response = Response::default();
-                    if whitelisted_addresses.contains(&sender.as_str()) {
-                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&response).unwrap()))
-                    } else {
-                        SystemResult::Ok(ContractResult::Err("InvalidAddress".to_string()))
-                    }
-                }
-                _ => SystemResult::Ok(ContractResult::Ok(
-                    to_json_binary(&None::<Response>).unwrap(),
-                )),
-            },
-        }
+        MockAndromedaQuerier::default().handle_query(&self.base, request)
     }
 
     pub fn new(base: MockQuerier) -> Self {


### PR DESCRIPTION
# Motivation
This [merge](https://github.com/andromedaprotocol/andromeda-core/commit/d21184ac72a102cbfd99d005aa6023a30071cc6e) caused an error in the `development` branch

# Implementation
Remove outdated code from conditional splitter's mock querier which was related to the old module system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified query handling in the mock querier, improving maintainability and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->