### PR TITLE
Feat/crowdfund restructure/claim tiers

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -566,7 +566,7 @@ fn execute_claim(ctx: ExecuteContext) -> Result<Response, ContractError> {
 fn handle_successful_claim(deps: DepsMut, sender: &Addr) -> Result<Response, ContractError> {
     let campaign_config = get_config(deps.storage)?;
 
-    let orders = get_user_orders(deps.storage, sender.clone(), None, None, true)?;
+    let orders = get_user_orders(deps.storage, sender.clone(), None, None, true);
     ensure!(!orders.is_empty(), ContractError::NoPurchases {});
 
     // mint tier token to the owner
@@ -595,7 +595,7 @@ fn handle_successful_claim(deps: DepsMut, sender: &Addr) -> Result<Response, Con
 fn handle_failed_claim(deps: DepsMut, sender: &Addr) -> Result<Response, ContractError> {
     let campaign_config = get_config(deps.storage)?;
 
-    let orders = get_user_orders(deps.storage, sender.clone(), None, None, false)?;
+    let orders = get_user_orders(deps.storage, sender.clone(), None, None, false);
     ensure!(!orders.is_empty(), ContractError::NoPurchases {});
 
     // refund

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -541,7 +541,6 @@ fn transfer_asset_msg(
 fn execute_claim(ctx: ExecuteContext) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
-    // Ensure campaign is finished
     let curr_stage = get_current_stage(deps.storage);
     let campaign_config = get_config(deps.storage)?;
     let mut resp = Response::new().add_attribute("action", "claim");

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -1,7 +1,7 @@
-use andromeda_non_fungible_tokens::crowdfund::{CampaignConfig, CampaignStage, Tier, TierOrder};
+use andromeda_non_fungible_tokens::crowdfund::{CampaignConfig, CampaignStage, Tier, TierOrder, SimpleTierOrder};
 use andromeda_std::error::ContractError;
-use cosmwasm_std::{ensure, Addr, Order, Storage, Uint128};
-use cw_storage_plus::{Item, Map};
+use cosmwasm_std::{ensure, Addr, Order, Storage, Uint128, Uint64};
+use cw_storage_plus::{Item, Map, Bound};
 
 pub const CAMPAIGN_CONFIG: Item<CampaignConfig> = Item::new("campaign_config");
 
@@ -12,6 +12,8 @@ pub const CURRENT_CAP: Item<Uint128> = Item::new("current_capital");
 pub const TIERS: Map<u64, Tier> = Map::new("tiers");
 
 pub const TIER_ORDERS: Map<(Addr, u64), u128> = Map::new("tier_orders");
+
+pub const TIER_TOKEN_ID: Item<Uint128> = Item::new("tier_token_id");
 
 pub(crate) fn update_config(
     storage: &mut dyn Storage,
@@ -155,4 +157,36 @@ pub(crate) fn set_tier_orders(
         )?;
     }
     Ok(())
+}
+
+pub(crate) fn get_user_orders(
+    storage: &dyn Storage,
+    user: Addr,
+    start_after: Option<u64>,
+    limit: Option<u32>,
+) -> Result<Vec<SimpleTierOrder>, ContractError> {
+    let limit = limit.unwrap_or(u32::MAX) as usize;
+    let start = start_after.map(Bound::exclusive);
+
+    TIER_ORDERS
+        .prefix(user)
+        .range(storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|v| {
+            let (level, amount) = v?;
+            Ok(SimpleTierOrder {
+                level: Uint64::new(level),
+                amount: Uint128::new(amount),
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn get_and_increase_tier_token_id(
+    storage: &mut dyn Storage,
+) -> Result<Uint128, ContractError> {
+    let tier_token_id = TIER_TOKEN_ID.load(storage)?;
+    let next_tier_token_id = tier_token_id.checked_add(Uint128::from(1u128))?;
+    TIER_TOKEN_ID.save(storage, &next_tier_token_id)?;
+    Ok(tier_token_id)
 }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -1,7 +1,9 @@
-use andromeda_non_fungible_tokens::crowdfund::{CampaignConfig, CampaignStage, Tier, TierOrder, SimpleTierOrder};
+use andromeda_non_fungible_tokens::crowdfund::{
+    CampaignConfig, CampaignStage, SimpleTierOrder, Tier, TierOrder,
+};
 use andromeda_std::error::ContractError;
 use cosmwasm_std::{ensure, Addr, Order, Storage, Uint128, Uint64};
-use cw_storage_plus::{Item, Map, Bound};
+use cw_storage_plus::{Bound, Item, Map};
 
 pub const CAMPAIGN_CONFIG: Item<CampaignConfig> = Item::new("campaign_config");
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -187,7 +187,7 @@ pub(crate) fn get_user_orders(
     start_after: Option<u64>,
     limit: Option<u32>,
     include_presale: bool,
-) -> Result<Vec<SimpleTierOrder>, ContractError> {
+) -> Vec<SimpleTierOrder> {
     let limit = limit.unwrap_or(u32::MAX) as usize;
     let start = start_after.map(Bound::exclusive);
 
@@ -196,16 +196,16 @@ pub(crate) fn get_user_orders(
         .range(storage, start, None, Order::Ascending)
         .take(limit)
         .map(|v| {
-            let (level, order_info) = v?;
+            let (level, order_info) = v.unwrap();
             let amount = if include_presale {
                 order_info.amount().unwrap()
             } else {
                 order_info.ordered
             };
-            Ok(SimpleTierOrder {
+            SimpleTierOrder {
                 level: Uint64::new(level),
                 amount: Uint128::new(amount),
-            })
+            }
         })
         .collect()
 }
@@ -233,4 +233,229 @@ pub(crate) fn get_and_increase_tier_token_id(
     let next_tier_token_id = tier_token_id.checked_add(Uint128::from(1u128))?;
     TIER_TOKEN_ID.save(storage, &next_tier_token_id)?;
     Ok(tier_token_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use andromeda_non_fungible_tokens::{crowdfund::TierMetaData, cw721::TokenExtension};
+    use cosmwasm_std::testing::MockStorage;
+
+    fn mock_storage() -> MockStorage {
+        let mut storage = MockStorage::new();
+        // Initialize some mock data for testing
+        let tiers = vec![
+            Tier {
+                level: Uint64::one(),
+                price: Uint128::new(100),
+                limit: Some(Uint128::new(1000)),
+                sold_amount: Uint128::new(0),
+                label: "tier 1".to_string(),
+                metadata: TierMetaData {
+                    token_uri: None,
+                    extension: TokenExtension {
+                        ..Default::default()
+                    },
+                },
+            },
+            Tier {
+                level: Uint64::new(2u64),
+                price: Uint128::new(200),
+                limit: None,
+                sold_amount: Uint128::new(0),
+                label: "tier 2".to_string(),
+                metadata: TierMetaData {
+                    token_uri: None,
+                    extension: TokenExtension {
+                        ..Default::default()
+                    },
+                },
+            },
+        ];
+        set_tiers(&mut storage, tiers).unwrap();
+        let user1 = Addr::unchecked("user1");
+        let orders = vec![
+            TierOrder {
+                orderer: user1.clone(),
+                level: Uint64::one(),
+                amount: Uint128::new(50),
+                is_presale: true,
+            },
+            TierOrder {
+                orderer: user1.clone(),
+                level: Uint64::one(),
+                amount: Uint128::new(50),
+                is_presale: false,
+            },
+        ];
+        set_tier_orders(&mut storage, orders).unwrap();
+        storage
+    }
+
+    pub struct GetUserOrderTestCase {
+        name: String,
+        include_presale: bool,
+        user: Addr,
+        expected_res: Vec<SimpleTierOrder>,
+    }
+    #[test]
+    fn test_get_user_orders() {
+        let test_cases = vec![
+            GetUserOrderTestCase {
+                name: "get_user_orders including pesale".to_string(),
+                include_presale: true,
+                user: Addr::unchecked("user1"),
+                expected_res: vec![SimpleTierOrder {
+                    level: Uint64::one(),
+                    amount: Uint128::new(100),
+                }],
+            },
+            GetUserOrderTestCase {
+                name: "get_user_orders excluding pesale".to_string(),
+                include_presale: false,
+                user: Addr::unchecked("user1"),
+                expected_res: vec![SimpleTierOrder {
+                    level: Uint64::one(),
+                    amount: Uint128::new(50),
+                }],
+            },
+            GetUserOrderTestCase {
+                name: "get_user_orders for non ordered user".to_string(),
+                include_presale: false,
+                user: Addr::unchecked("user2"),
+                expected_res: vec![],
+            },
+        ];
+        let storage = mock_storage();
+
+        for test in test_cases {
+            let res = get_user_orders(
+                &storage,
+                test.user.clone(),
+                None,
+                None,
+                test.include_presale,
+            );
+            assert_eq!(res, test.expected_res, "Test case: {}", test.name);
+        }
+    }
+
+    pub struct SetOrderTestCase {
+        name: String,
+        order: TierOrder,
+        expected_res: Result<(), ContractError>,
+    }
+
+    #[test]
+    fn test_set_tier_orders() {
+        let test_cases = vec![
+            SetOrderTestCase {
+                name: "set_tier_orders with valid orders".to_string(),
+                order: TierOrder {
+                    level: Uint64::new(1),
+                    amount: Uint128::new(100),
+                    orderer: Addr::unchecked("user1"),
+                    is_presale: false,
+                },
+                expected_res: Ok(()),
+            },
+            SetOrderTestCase {
+                name: "set_tier_orders with an order exceeding limit".to_string(),
+                order: TierOrder {
+                    level: Uint64::new(1),
+                    amount: Uint128::new(1000),
+                    orderer: Addr::unchecked("user2"),
+                    is_presale: false,
+                },
+                expected_res: Err(ContractError::PurchaseLimitReached {}),
+            },
+            SetOrderTestCase {
+                name: "set_tier_orders with an order for non-existing tier".to_string(),
+                order: TierOrder {
+                    level: Uint64::new(3),
+                    amount: Uint128::new(50),
+                    orderer: Addr::unchecked("user3"),
+                    is_presale: false,
+                },
+                expected_res: Err(ContractError::InvalidTier {
+                    operation: "set_tier_orders".to_string(),
+                    msg: "Tier with level 3 does not exist".to_string(),
+                }),
+            },
+        ];
+
+        for test in test_cases {
+            let mut storage = mock_storage();
+            let level: u64 = test.order.level.into();
+            let ordered_amount = test.order.amount;
+            let orderer = test.order.orderer.clone();
+            let prev_tier = get_tier(&mut storage, level);
+            let prev_order = TIER_ORDERS.load(&storage, (orderer.clone(), level));
+            let is_presale = test.order.is_presale;
+
+            let res = set_tier_orders(&mut storage, vec![test.order]);
+            assert_eq!(res, test.expected_res, "Test case: {}", test.name);
+
+            if res.is_ok() {
+                let tier = get_tier(&mut storage, level).unwrap();
+                assert_eq!(
+                    tier.sold_amount,
+                    prev_tier.unwrap().sold_amount + ordered_amount
+                );
+                let order = TIER_ORDERS.load(&storage, (orderer, level)).unwrap();
+                let prev_order = prev_order.unwrap();
+                if is_presale {
+                    assert_eq!(
+                        order,
+                        OrderInfo {
+                            ordered: prev_order.ordered,
+                            preordered: prev_order.preordered + ordered_amount.u128(),
+                        },
+                        "Test case: {}",
+                        test.name
+                    );
+                } else {
+                    assert_eq!(
+                        order,
+                        OrderInfo {
+                            ordered: prev_order.ordered + ordered_amount.u128(),
+                            preordered: prev_order.preordered,
+                        },
+                        "Test case: {}",
+                        test.name
+                    );
+                }
+            }
+        }
+    }
+
+    // #[test]
+    // fn test_set_tier_orders() {
+    //     let mut storage = mock_storage();
+    //     let test_cases = vec![
+    //         SetOrderTestCase {
+    //             name: "Valid et order for limited tier".to_string(),
+    //             order: TierOrder {
+    //                 orderer: user3.clone(),
+    //                 level: Uint64::new(2u64),
+    //                 amount: Uint128::new(150),
+    //                 is_presale: false,
+    //             }
+    //         }
+    //     ];
+    // let user3 = Addr::unchecked("user3");
+    // let order = TierOrder {
+    //     orderer: user3.clone(),
+    //     level: Uint64::new(2u64),
+    //     amount: Uint128::new(150),
+    //     is_presale: false,
+    // };
+    // set_tier_orders(&mut storage, vec![order.clone()]).unwrap();
+    // let orders = TIER_ORDERS.load(&storage, (user3, 2)).unwrap();
+    // assert_eq!(orders.ordered, 150);
+    // assert_eq!(orders.preordered, 0);
+
+    // // Test if the sold_amount of the tier is updated correctly
+    // let tier2 = get_tier(&mut storage, 2).unwrap();
+    // assert_eq!(tier2.sold_amount, Uint128::new(250));
 }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
@@ -26,7 +26,7 @@ pub fn mock_campaign_config(denom: Asset) -> CampaignConfig {
         banner: "http://<campaign_banner>".to_string(),
         url: "http://<campaign_url>".to_string(),
         denom,
-        tier_address: AndrAddr::from_string(MOCK_TIER_CONTRACT.to_owned()),
+        token_address: AndrAddr::from_string(MOCK_TIER_CONTRACT.to_owned()),
         withdrawal_recipient: Recipient::from_string(MOCK_WITHDRAWAL_ADDRESS.to_owned()),
         soft_cap: None,
         hard_cap: None,
@@ -42,7 +42,7 @@ pub fn mock_campaign_tiers() -> Vec<Tier> {
             label: "Basic Tier".to_string(),
             limit: None,
             price: Uint128::new(10u128),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -55,7 +55,7 @@ pub fn mock_campaign_tiers() -> Vec<Tier> {
             label: "Tier 1".to_string(),
             limit: Some(Uint128::new(MOCK_DEFAULT_LIMIT)),
             price: Uint128::new(10u128),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -72,7 +72,7 @@ pub fn mock_zero_price_tier(level: Uint64) -> Tier {
         label: "Invalid Tier".to_string(),
         limit: None,
         price: Uint128::zero(),
-        meta_data: TierMetaData {
+        metadata: TierMetaData {
             extension: TokenExtension {
                 publisher: MOCK_ADO_PUBLISHER.to_string(),
             },

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -215,7 +215,7 @@ mod test {
             limit: Some(Uint128::new(100)),
             sold_amount: Uint128::zero(),
             price: Uint128::new(100),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -228,7 +228,7 @@ mod test {
             limit: Some(Uint128::new(100)),
             sold_amount: Uint128::zero(),
             price: Uint128::new(100),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -323,7 +323,7 @@ mod test {
             limit: Some(Uint128::new(100)),
             sold_amount: Uint128::zero(),
             price: Uint128::new(100),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -336,7 +336,7 @@ mod test {
             limit: Some(Uint128::new(100)),
             sold_amount: Uint128::zero(),
             price: Uint128::new(100),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -431,7 +431,7 @@ mod test {
             limit: Some(Uint128::new(100)),
             price: Uint128::new(100),
             sold_amount: Uint128::zero(),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -444,7 +444,7 @@ mod test {
             limit: Some(Uint128::new(100)),
             price: Uint128::new(100),
             sold_amount: Uint128::zero(),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -546,7 +546,7 @@ mod test {
             limit: Some(Uint128::new(1000u128)),
             sold_amount: Uint128::zero(),
             price: Uint128::new(10u128),
-            meta_data: TierMetaData {
+            metadata: TierMetaData {
                 extension: TokenExtension {
                     publisher: MOCK_ADO_PUBLISHER.to_string(),
                 },
@@ -1407,7 +1407,7 @@ mod test {
                     ))),
             },
             ClaimTestCase {
-                name: "Claim when native token accpeting campaign failed ".to_string(),
+                name: "Claim when native token accepting campaign failed ".to_string(),
                 stage: CampaignStage::FAILED,
                 orders: vec![
                     TierOrder {
@@ -1444,7 +1444,7 @@ mod test {
                     ))),
             },
             ClaimTestCase {
-                name: "Claim when cw20 accpeting campaign failed ".to_string(),
+                name: "Claim when cw20 accepting campaign failed ".to_string(),
                 stage: CampaignStage::FAILED,
                 orders: vec![
                     TierOrder {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -1447,7 +1447,7 @@ mod test {
                     ))),
             },
             ClaimTestCase {
-                name: "Claim when ccw20 accpeting campaign failed ".to_string(),
+                name: "Claim when cw20 accpeting campaign failed ".to_string(),
                 stage: CampaignStage::FAILED,
                 orders: vec![
                     TierOrder {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -1,7 +1,5 @@
 use andromeda_non_fungible_tokens::{
-    crowdfund::{
-        CampaignConfig, CampaignStage, ExecuteMsg, InstantiateMsg, Tier, TierMetaData, TierOrder,
-    },
+    crowdfund::{CampaignConfig, CampaignStage, ExecuteMsg, InstantiateMsg, Tier, TierMetaData},
     cw721::TokenExtension,
 };
 
@@ -67,7 +65,9 @@ fn set_campaign_config(store: &mut dyn Storage, config: &CampaignConfig) {
 
 #[cfg(test)]
 mod test {
-    use andromeda_non_fungible_tokens::crowdfund::{Cw20HookMsg, SimpleTierOrder};
+    use andromeda_non_fungible_tokens::crowdfund::{
+        Cw20HookMsg, PresaleTierOrder, SimpleTierOrder,
+    };
     use andromeda_std::{
         amp::AndrAddr,
         common::{denom::Asset, encode_binary},
@@ -495,7 +495,7 @@ mod test {
     struct StartCampaignTestCase {
         name: String,
         tiers: Vec<Tier>,
-        presale: Option<Vec<TierOrder>>,
+        presale: Option<Vec<PresaleTierOrder>>,
         start_time: Option<MillisecondsExpiration>,
         end_time: MillisecondsExpiration,
         expected_res: Result<Response, ContractError>,
@@ -505,13 +505,13 @@ mod test {
     #[test]
     fn test_start_campaign() {
         let mock_orderer = Addr::unchecked("mock_orderer".to_string());
-        let valid_presale = vec![TierOrder {
+        let valid_presale = vec![PresaleTierOrder {
             amount: Uint128::new(100u128),
             level: Uint64::new(1u64),
             orderer: mock_orderer.clone(),
         }];
 
-        let invalid_presale = vec![TierOrder {
+        let invalid_presale = vec![PresaleTierOrder {
             amount: Uint128::new(100u128),
             level: Uint64::new(2u64),
             orderer: mock_orderer.clone(),

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -1,6 +1,9 @@
 use andromeda_non_fungible_tokens::{
-    crowdfund::{CampaignConfig, CampaignStage, ExecuteMsg, InstantiateMsg, Tier, TierMetaData},
-    cw721::TokenExtension,
+    crowdfund::{
+        CampaignConfig, CampaignStage, ExecuteMsg, InstantiateMsg, SimpleTierOrder, Tier,
+        TierMetaData,
+    },
+    cw721::{ExecuteMsg as Cw721ExecuteMsg, TokenExtension},
 };
 
 use andromeda_std::{
@@ -62,11 +65,34 @@ fn set_current_cap(store: &mut dyn Storage, cur_cap: &Uint128) {
 fn set_campaign_config(store: &mut dyn Storage, config: &CampaignConfig) {
     CAMPAIGN_CONFIG.save(store, config).unwrap();
 }
+fn set_tiers(storage: &mut dyn Storage, tiers: Vec<Tier>) {
+    for tier in tiers {
+        TIERS.save(storage, tier.level.into(), &tier).unwrap();
+    }
+}
 
+fn get_user_orders(
+    storage: &dyn Storage,
+    user: Addr,
+) -> Result<Vec<SimpleTierOrder>, ContractError> {
+    TIER_ORDERS
+        .prefix(user)
+        .range(storage, None, None, Order::Ascending)
+        .map(|v| {
+            let (level, order_info) = v?;
+
+            let amount = order_info.amount().unwrap();
+            Ok(SimpleTierOrder {
+                level: Uint64::new(level),
+                amount: Uint128::new(amount),
+            })
+        })
+        .collect()
+}
 #[cfg(test)]
 mod test {
     use andromeda_non_fungible_tokens::crowdfund::{
-        Cw20HookMsg, PresaleTierOrder, SimpleTierOrder,
+        Cw20HookMsg, PresaleTierOrder, SimpleTierOrder, TierOrder,
     };
     use andromeda_std::{
         amp::AndrAddr,
@@ -77,7 +103,7 @@ mod test {
     use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
     use crate::{
-        state::{get_current_cap, set_tiers},
+        state::{get_current_cap, set_current_stage, set_tier_orders},
         testing::mock_querier::{MOCK_DEFAULT_OWNER, MOCK_WITHDRAWAL_ADDRESS},
     };
 
@@ -640,12 +666,13 @@ mod test {
                 );
                 for order in &test.presale.unwrap() {
                     let order_amount: u128 = order.amount.into();
-                    assert_eq!(
-                        TIER_ORDERS
-                            .load(&deps.storage, (mock_orderer.clone(), order.level.into()))
-                            .unwrap(),
-                        order_amount
-                    );
+                    let order_info = TIER_ORDERS
+                        .load(&deps.storage, (mock_orderer.clone(), order.level.into()))
+                        .unwrap();
+
+                    assert_eq!(order_info.preordered, order_amount);
+                    assert_eq!(order_info.ordered, 0u128);
+                    assert_eq!(order_info.amount().unwrap(), order_amount);
                     let cur_limit = TIERS.load(&deps.storage, order.level.into()).unwrap().limit;
                     if cur_limit.is_some() {
                         assert_eq!(
@@ -826,7 +853,7 @@ mod test {
             // Mock necessary storage setup
             set_campaign_stage(deps.as_mut().storage, &test.stage);
             set_current_cap(deps.as_mut().storage, &test.initial_cap);
-            set_tiers(deps.as_mut().storage, mock_campaign_tiers()).unwrap();
+            set_tiers(deps.as_mut().storage, mock_campaign_tiers());
 
             let mut mock_config = mock_campaign_config(test.denom);
             mock_config.start_time = test.start_time;
@@ -848,14 +875,14 @@ mod test {
 
                 // Check tier orders
                 for order in &test.orders {
-                    let stored_order = TIER_ORDERS
+                    let stored_order_info = TIER_ORDERS
                         .load(
                             deps.as_ref().storage,
                             (Addr::unchecked(buyer), order.level.into()),
                         )
                         .unwrap();
                     assert_eq!(
-                        stored_order,
+                        stored_order_info.ordered,
                         order.amount.u128(),
                         "Test case: {}",
                         test.name
@@ -1019,7 +1046,7 @@ mod test {
             // Mock necessary storage setup
             set_campaign_stage(deps.as_mut().storage, &test.stage);
             set_current_cap(deps.as_mut().storage, &test.initial_cap);
-            set_tiers(deps.as_mut().storage, mock_campaign_tiers()).unwrap();
+            set_tiers(deps.as_mut().storage, mock_campaign_tiers());
 
             let mut mock_config = mock_campaign_config(valid_denom.clone());
             mock_config.start_time = test.start_time;
@@ -1046,14 +1073,14 @@ mod test {
 
                 // Check tier orders
                 for order in &test.orders {
-                    let stored_order = TIER_ORDERS
+                    let stored_order_info = TIER_ORDERS
                         .load(
                             deps.as_ref().storage,
                             (Addr::unchecked(buyer), order.level.into()),
                         )
                         .unwrap();
                     assert_eq!(
-                        stored_order,
+                        stored_order_info.ordered,
                         order.amount.u128(),
                         "Test case: {}",
                         test.name
@@ -1306,6 +1333,206 @@ mod test {
                     "Test case: {}",
                     test.name
                 );
+            }
+        }
+    }
+
+    struct ClaimTestCase {
+        name: String,
+        stage: CampaignStage,
+        orders: Vec<TierOrder>,
+        denom: Asset,
+        expected_res: Result<Response, ContractError>,
+    }
+
+    #[test]
+    fn test_execute_claim() {
+        let orderer = Addr::unchecked("orderer");
+
+        let test_cases = vec![
+            ClaimTestCase {
+                name: "Claim when campaign is successful ".to_string(),
+                stage: CampaignStage::SUCCESS,
+                orders: vec![
+                    TierOrder {
+                        is_presale: true,
+                        amount: Uint128::one(),
+                        level: Uint64::one(),
+                        orderer: orderer.clone(),
+                    },
+                    TierOrder {
+                        is_presale: false,
+                        amount: Uint128::one(),
+                        level: Uint64::one(),
+                        orderer: orderer.clone(),
+                    },
+                ],
+                denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+                expected_res: Ok(Response::new()
+                    .add_attribute("action", "claim")
+                    .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+                        contract_addr: "tier_contract".to_string(),
+                        msg: to_json_binary(&Cw721ExecuteMsg::Mint {
+                            token_id: "0".to_string(),
+                            owner: orderer.to_string(),
+                            extension: TokenExtension {
+                                publisher: MOCK_ADO_PUBLISHER.to_string(),
+                            },
+                            token_uri: None,
+                        })
+                        .unwrap(),
+                        funds: vec![],
+                    }))
+                    .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+                        contract_addr: "tier_contract".to_string(),
+                        msg: to_json_binary(&Cw721ExecuteMsg::Mint {
+                            token_id: "1".to_string(),
+                            owner: orderer.to_string(),
+                            extension: TokenExtension {
+                                publisher: MOCK_ADO_PUBLISHER.to_string(),
+                            },
+                            token_uri: None,
+                        })
+                        .unwrap(),
+                        funds: vec![],
+                    }))
+                    .add_submessage(SubMsg::reply_on_error(
+                        CosmosMsg::Wasm(WasmMsg::Execute {
+                            contract_addr: "economics_contract".to_string(),
+                            msg: to_json_binary(&EconomicsExecuteMsg::PayFee {
+                                payee: orderer.clone(),
+                                action: "Claim".to_string(),
+                            })
+                            .unwrap(),
+                            funds: vec![],
+                        }),
+                        ReplyId::PayFee.repr(),
+                    ))),
+            },
+            ClaimTestCase {
+                name: "Claim when native token accpeting campaign failed ".to_string(),
+                stage: CampaignStage::FAILED,
+                orders: vec![
+                    TierOrder {
+                        is_presale: true,
+                        amount: Uint128::one(),
+                        level: Uint64::one(),
+                        orderer: orderer.clone(),
+                    },
+                    TierOrder {
+                        is_presale: false,
+                        amount: Uint128::one(),
+                        level: Uint64::one(),
+                        orderer: orderer.clone(),
+                    },
+                ],
+                denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+                expected_res: Ok(Response::new()
+                    .add_attribute("action", "claim")
+                    .add_message(BankMsg::Send {
+                        to_address: orderer.to_string(),
+                        amount: coins(10, MOCK_NATIVE_DENOM), // only non presale order refunded
+                    })
+                    .add_submessage(SubMsg::reply_on_error(
+                        CosmosMsg::Wasm(WasmMsg::Execute {
+                            contract_addr: "economics_contract".to_string(),
+                            msg: to_json_binary(&EconomicsExecuteMsg::PayFee {
+                                payee: orderer.clone(),
+                                action: "Claim".to_string(),
+                            })
+                            .unwrap(),
+                            funds: vec![],
+                        }),
+                        ReplyId::PayFee.repr(),
+                    ))),
+            },
+            ClaimTestCase {
+                name: "Claim when ccw20 accpeting campaign failed ".to_string(),
+                stage: CampaignStage::FAILED,
+                orders: vec![
+                    TierOrder {
+                        is_presale: true,
+                        amount: Uint128::one(),
+                        level: Uint64::one(),
+                        orderer: orderer.clone(),
+                    },
+                    TierOrder {
+                        is_presale: false,
+                        amount: Uint128::one(),
+                        level: Uint64::one(),
+                        orderer: orderer.clone(),
+                    },
+                ],
+                denom: Asset::Cw20Token(AndrAddr::from_string(MOCK_CW20_CONTRACT.to_string())),
+                expected_res: Ok(Response::new()
+                    .add_attribute("action", "claim")
+                    .add_message(
+                        wasm_execute(
+                            MOCK_CW20_CONTRACT.to_string(),
+                            &Cw20ExecuteMsg::Transfer {
+                                recipient: orderer.to_string(),
+                                amount: Uint128::new(10u128),
+                            },
+                            vec![],
+                        )
+                        .unwrap(),
+                    )
+                    .add_submessage(SubMsg::reply_on_error(
+                        CosmosMsg::Wasm(WasmMsg::Execute {
+                            contract_addr: "economics_contract".to_string(),
+                            msg: to_json_binary(&EconomicsExecuteMsg::PayFee {
+                                payee: orderer.clone(),
+                                action: "Claim".to_string(),
+                            })
+                            .unwrap(),
+                            funds: vec![],
+                        }),
+                        ReplyId::PayFee.repr(),
+                    ))),
+            },
+            ClaimTestCase {
+                name: "Claim without purchasing in successful campaign".to_string(),
+                stage: CampaignStage::SUCCESS,
+                orders: vec![],
+                denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+                expected_res: Err(ContractError::NoPurchases {}),
+            },
+            ClaimTestCase {
+                name: "Claim without purchasing in failed campaign".to_string(),
+                stage: CampaignStage::FAILED,
+                orders: vec![],
+                denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+                expected_res: Err(ContractError::NoPurchases {}),
+            },
+            ClaimTestCase {
+                name: "Claim on invalid stage".to_string(),
+                stage: CampaignStage::READY,
+                orders: vec![],
+                denom: Asset::NativeToken(MOCK_NATIVE_DENOM.to_string()),
+                expected_res: Err(ContractError::InvalidCampaignOperation {
+                    operation: "Claim".to_string(),
+                    stage: CampaignStage::READY.to_string(),
+                }),
+            },
+        ];
+        for test in test_cases {
+            let mut deps = mock_dependencies_custom(&[coin(100000, MOCK_NATIVE_DENOM)]);
+            let env = mock_env();
+            let mock_config = mock_campaign_config(test.denom.clone());
+            set_campaign_config(deps.as_mut().storage, &mock_config);
+            set_current_stage(deps.as_mut().storage, test.stage).unwrap();
+            set_tiers(deps.as_mut().storage, mock_campaign_tiers());
+            set_tier_orders(deps.as_mut().storage, test.orders).unwrap();
+            let msg = ExecuteMsg::Claim {};
+
+            let info = mock_info(orderer.as_ref(), &[]);
+
+            let res = execute(deps.as_mut(), env.clone(), info, msg);
+            assert_eq!(res, test.expected_res, "Test case: {}", test.name);
+            if res.is_ok() {
+                // processed orders should be cleared
+                let orders = get_user_orders(deps.as_ref().storage, orderer.clone()).unwrap();
+                assert!(orders.is_empty(), "Test case: {}", test.name);
             }
         }
     }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -78,14 +78,11 @@ fn get_user_orders(
     TIER_ORDERS
         .prefix(user)
         .range(storage, None, None, Order::Ascending)
-        .map(|v| {
-            let (level, order_info) = v?;
-
-            let amount = order_info.amount().unwrap();
-            Ok(SimpleTierOrder {
+        .map(|res| {
+            Ok(res.map(|(level, order_info)| SimpleTierOrder {
                 level: Uint64::new(level),
-                amount: Uint128::new(amount),
-            })
+                amount: Uint128::new(order_info.amount().unwrap()),
+            })?)
         })
         .collect()
 }

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -41,6 +41,8 @@ pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     /// End the campaign
     EndCampaign {},
+    /// Claim tiers or get refunded based on the campaign result
+    Claim {},
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -33,7 +33,7 @@ pub enum ExecuteMsg {
     StartCampaign {
         start_time: Option<MillisecondsExpiration>,
         end_time: MillisecondsExpiration,
-        presale: Option<Vec<TierOrder>>,
+        presale: Option<Vec<PresaleTierOrder>>,
     },
     /// Purchase tiers
     PurchaseTiers { orders: Vec<SimpleTierOrder> },
@@ -152,6 +152,26 @@ pub struct TierOrder {
     pub orderer: Addr,
     pub level: Uint64,
     pub amount: Uint128,
+    pub is_presale: bool,
+}
+
+// Used for presale
+#[cw_serde]
+pub struct PresaleTierOrder {
+    pub level: Uint64,
+    pub amount: Uint128,
+    pub orderer: Addr,
+}
+
+impl From<PresaleTierOrder> for TierOrder {
+    fn from(val: PresaleTierOrder) -> Self {
+        TierOrder {
+            level: val.level,
+            amount: val.amount,
+            orderer: val.orderer,
+            is_presale: true,
+        }
+    }
 }
 
 // Used when the orderer is defined

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -68,7 +68,7 @@ pub struct CampaignConfig {
     /// Official website of the campaign
     pub url: String,
     /// The address of the tier contract whose tokens are being distributed
-    pub tier_address: AndrAddr,
+    pub token_address: AndrAddr,
     /// The denom of the token that is being accepted by the campaign
     pub denom: Asset,
     /// Recipient that is upposed to receive the funds gained by the campaign
@@ -86,7 +86,7 @@ pub struct CampaignConfig {
 impl CampaignConfig {
     pub fn validate(&self, deps: DepsMut, env: &Env) -> Result<(), ContractError> {
         // validate addresses
-        self.tier_address.validate(deps.api)?;
+        self.token_address.validate(deps.api)?;
         self.withdrawal_recipient.validate(&deps.as_ref())?;
         let _ = self
             .denom
@@ -146,7 +146,7 @@ pub struct Tier {
     pub price: Uint128,
     pub limit: Option<Uint128>, // None for no limit
     pub sold_amount: Uint128,
-    pub meta_data: TierMetaData,
+    pub metadata: TierMetaData,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/448

# Implementation
- Added `execute_claim` function and `Claim` msg to handle claim functionality.
- Claim logic is designed as follow
 - If the current stage is
   - `SUCCESS`, minted tier NFT with owner is the `info.sender`.
   - `FAILED`, refunded funds for ordered tiers. (Presale orders are not refunded)
   - Other stage (`READY` or `ONGOING`), throw error
 - At the end of the function, `sender` orders are cleared as they are handled. 
- Updated `TIER_ORDERS` to save `OrderInfo` so that preorder and normal order amount can be separated.

# Testing
- Test case for successful campaign added
- Test cases for failed campaign added
 - for a campaign that is accepting native token
 - for a campaign that is accepting cw20 token
- Test cases for claim without order added for both successful and failed campaign
- Test case for claim on invalid stage added

# Future work
- https://github.com/andromedaprotocol/andromeda-core/issues/449
- https://github.com/andromedaprotocol/andromeda-core/issues/451
- https://github.com/andromedaprotocol/andromeda-core/issues/439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to claim rewards and mint tokens.
  - Added support for presale orders with dedicated `PresaleTierOrder`.
  - Users can now discard campaigns.

- **Enhancements**
  - Improved campaign management with updated `execute_start_campaign` and `purchase_tiers` functions.
  - Enhanced order tracking with new `OrderInfo` struct.

- **Bug Fixes**
  - Fixed issues related to starting campaigns and claiming rewards in test cases.

- **Documentation**
  - Updated comments and documentation for new features and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->