### PR TITLE
Fix: Instantiate 2 address length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ andromeda-fungible-tokens = { path = "./packages/andromeda-fungible-tokens", ver
 andromeda-finance = { path = "./packages/andromeda-finance", version = "1.0.0" }
 andromeda-data-storage = { path = "./packages/andromeda-data-storage", version = "1.0.0" }
 andromeda-modules = { path = "./packages/andromeda-modules", version = "1.0.0" }
-andromeda-app = { path = "./packages/andromeda-app", version = "1.0.0" }
+andromeda-app = { path = "./packages/andromeda-app", version = "1.0.1" }
 andromeda-ecosystem = { path = "./packages/andromeda-ecosystem", version = "1.0.0" }
 andromeda-testing = { path = "./packages/andromeda-testing", version = "1.0.0" }
 

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.65.0"
 

--- a/packages/andromeda-app/Cargo.toml
+++ b/packages/andromeda-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.65.0"
 description = "Utility methods and message definitions for the Andromeda App Contract"

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -142,6 +142,19 @@ impl AppComponent {
         let creator = api.addr_canonicalize(parent_addr.as_str())?;
         let new_addr = instantiate2_address(&checksum, &creator, &salt).unwrap();
 
+        // Instantiate 2 impl uses default cannonical address of 32 bytes (SHA 256). But as mentioned here -
+        // https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/docs/architecture/adr-028-public-key-addresses.md
+        // chains can use different length for cannonical address, eg, injective uses 20 (eth based).
+        // Instead of having fallback for each chain we can use parent address, which itself is a contract.
+        // Slice the default 32 bytes canonical address to size of parent cannonical address
+
+        let cannonical_parent_addr = api.addr_canonicalize(parent_addr.as_str())?;
+        let new_addr = new_addr
+            .as_slice()
+            .split_at(cannonical_parent_addr.len())
+            .0
+            .into();
+
         Ok(Some(api.addr_humanize(&new_addr)?))
     }
 

--- a/packages/andromeda-testing/Cargo.toml
+++ b/packages/andromeda-testing/Cargo.toml
@@ -22,7 +22,7 @@ prost = "0.9.0"
 anyhow = "1.0.79"
 
 andromeda-non-fungible-tokens = { workspace = true }
-andromeda-app = { version = "1.0.0", path = "../andromeda-app" }
+andromeda-app = { version = "1.0.1", path = "../andromeda-app" }
 andromeda-modules = { version = "1.0.0", path = "../andromeda-modules" }
 andromeda-adodb = { version = "1.0.0", path = "../../contracts/os/andromeda-adodb", features = [
     "testing",


### PR DESCRIPTION
# Motivation

 Instantiate 2 impl uses default canonical address of 32 bytes (SHA 256). But as mentioned [here](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/docs/architecture/adr-028-public-key-addresses.md) chains can use different length for canonical address, eg, injective uses 20 (eth based).

Instead of having fallback for each chain we can use parent address, which itself is a contract, slice the default 32 bytes canonical address to size of parent canonical address

# Implementation

Slice canonical address returned by `instantiate2_address` to length of parent canonical address.

# Testing

- [ ] Test on-chain deployment
- [ ] App Version Bump


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated address generation logic to align with the chain's requirements for canonical address slicing.

- **Chores**
  - Updated `andromeda-app` package version from `1.0.0` to `1.0.1` across various components and dependencies for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->