### PR TITLE
refactor: remove Object and Vector Primitive Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ version = "1.0.0"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
+ "andromeda-testing",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
-testing = ["cw-multi-test"]
+testing = ["cw-multi-test", "andromeda-testing"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -40,3 +40,4 @@ andromeda-data-storage = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }
+andromeda-testing = { workspace = true, optional = true }

--- a/contracts/data-storage/andromeda-primitive/src/mock.rs
+++ b/contracts/data-storage/andromeda-primitive/src/mock.rs
@@ -4,8 +4,51 @@ use crate::contract::{execute, instantiate, query};
 use andromeda_data_storage::primitive::{
     ExecuteMsg, InstantiateMsg, Primitive, PrimitiveRestriction, QueryMsg,
 };
+use andromeda_testing::mock::MockApp;
+use andromeda_testing::{
+    mock_ado,
+    mock_contract::{ExecuteResult, MockADO, MockContract},
+};
 use cosmwasm_std::{Addr, Empty};
-use cw_multi_test::{Contract, ContractWrapper};
+use cw_multi_test::{Contract, ContractWrapper, Executor};
+
+pub struct MockPrimitive(Addr);
+mock_ado!(MockPrimitive, ExecuteMsg, QueryMsg);
+
+impl MockPrimitive {
+    pub fn instantiate(
+        code_id: u64,
+        sender: Addr,
+        app: &mut MockApp,
+        kernel_address: String,
+        owner: Option<String>,
+        restriction: PrimitiveRestriction,
+    ) -> MockPrimitive {
+        let msg = mock_primitive_instantiate_msg(kernel_address, owner, restriction);
+        let addr = app
+            .instantiate_contract(
+                code_id,
+                sender.clone(),
+                &msg,
+                &[],
+                "Primitive Contract",
+                Some(sender.to_string()),
+            )
+            .unwrap();
+        MockPrimitive(Addr::unchecked(addr))
+    }
+
+    pub fn execute_set_value(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        key: Option<String>,
+        value: Primitive,
+    ) -> ExecuteResult {
+        let msg = mock_store_value_msg(key, value);
+        app.execute_contract(sender, self.addr().clone(), &msg, &[])
+    }
+}
 
 pub fn mock_andromeda_primitive() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new_with_empty(execute, instantiate, query);

--- a/contracts/data-storage/andromeda-primitive/src/testing/tests.rs
+++ b/contracts/data-storage/andromeda-primitive/src/testing/tests.rs
@@ -1,10 +1,8 @@
-use cosmwasm_schema::schemars::Map;
-use cosmwasm_std::{from_json, testing::mock_env};
-
-use crate::{contract::query, state::DEFAULT_KEY};
+use crate::contract::query;
 use andromeda_data_storage::primitive::{
     GetValueResponse, Primitive, PrimitiveRestriction, QueryMsg,
 };
+use cosmwasm_std::{from_json, testing::mock_env};
 
 use andromeda_std::amp::AndrAddr;
 
@@ -275,30 +273,4 @@ fn test_query_owner_keys() {
     )
     .unwrap();
     assert!(res.len() == 2, "assertion failed {res:?}", res = res);
-}
-
-#[test]
-fn test_set_object() {
-    let (mut deps, info) = proper_initialization(PrimitiveRestriction::Private);
-
-    let mut map = Map::new();
-    map.insert("key".to_string(), Primitive::Bool(true));
-
-    set_value(
-        deps.as_mut(),
-        &None,
-        &Primitive::Object(map.clone()),
-        info.sender.as_ref(),
-    )
-    .unwrap();
-
-    let query_res: GetValueResponse = query_value(deps.as_ref(), &None).unwrap();
-
-    assert_eq!(
-        GetValueResponse {
-            key: DEFAULT_KEY.to_string(),
-            value: Primitive::Object(map.clone())
-        },
-        query_res
-    );
 }

--- a/tests-integration/tests/primitive.rs
+++ b/tests-integration/tests/primitive.rs
@@ -10,7 +10,7 @@ use andromeda_testing::{mock::mock_app, mock_builder::MockAndromedaBuilder, Mock
 use cw_multi_test::Executor;
 
 #[test]
-fn test_primtive() {
+fn test_primitive() {
     let mut router = mock_app(None);
 
     let andr = MockAndromedaBuilder::new(&mut router, "admin")
@@ -19,9 +19,9 @@ fn test_primtive() {
         .build(&mut router);
     let sender = andr.get_wallet("owner");
     // Store contract codes
-    let primtive_code_id = router.store_code(mock_andromeda_primitive());
+    let primitive_code_id = router.store_code(mock_andromeda_primitive());
 
-    andr.store_code_id(&mut router, "primitve", primtive_code_id);
+    andr.store_code_id(&mut router, "primitve", primitive_code_id);
 
     let primitive_init_msg = mock_primitive_instantiate_msg(
         andr.kernel.addr().to_string(),
@@ -31,7 +31,7 @@ fn test_primtive() {
 
     let primitive_addr = router
         .instantiate_contract(
-            primtive_code_id,
+            primitive_code_id,
             sender.clone(),
             &primitive_init_msg,
             &[],
@@ -77,7 +77,7 @@ fn test_primtive() {
 // use cw_multi_test::Executor;
 
 // #[test]
-// fn test_primtive() {
+// fn test_primitive() {
 //     let mut router = mock_app(None);
 //     let andr = MockAndromedaBuilder::new(&mut router, "admin")
 //         .with_wallets(vec![

--- a/tests-integration/tests/primtive.rs
+++ b/tests-integration/tests/primtive.rs
@@ -7,7 +7,6 @@ use andromeda_primitive::mock::{
     mock_store_value_msg,
 };
 use andromeda_testing::{mock::mock_app, mock_builder::MockAndromedaBuilder, MockContract};
-use cosmwasm_schema::schemars::Map;
 use cw_multi_test::Executor;
 
 #[test]
@@ -41,21 +40,12 @@ fn test_primtive() {
         )
         .unwrap();
 
-    let mut map = Map::new();
-    map.insert("bool".to_string(), Primitive::Bool(true));
-    map.insert(
-        "vec".into(),
-        Primitive::Vec(vec![Primitive::String("My String".to_string())]),
-    );
-    map.insert("object".into(), Primitive::Object(map.clone()));
-
-    let value = Primitive::Object(map.clone());
     // Claim Ownership
     router
         .execute_contract(
             sender.clone(),
             primitive_addr.clone(),
-            &mock_store_value_msg(Some("key".to_string()), value.clone()),
+            &mock_store_value_msg(Some("key".to_string()), Primitive::Bool(true)),
             &[],
         )
         .unwrap();
@@ -68,5 +58,89 @@ fn test_primtive() {
             &mock_primitive_get_value(Some("key".to_string())),
         )
         .unwrap();
-    assert_eq!(get_value_resp.value, value);
+    assert_eq!(get_value_resp.value, Primitive::Bool(true));
 }
+
+// #![cfg(not(target_arch = "wasm32"))]
+
+// use andromeda_app::app::AppComponent;
+// use andromeda_app_contract::mock::{mock_claim_ownership_msg, MockAppContract};
+// use andromeda_data_storage::primitive::{GetValueResponse, Primitive};
+
+// use andromeda_primitive::mock::{
+//     mock_andromeda_primitive, mock_primitive_get_value, mock_primitive_instantiate_msg,
+//     mock_store_value_msg, MockPrimitive,
+// };
+// use andromeda_testing::{mock::mock_app, mock_builder::MockAndromedaBuilder, MockContract};
+// use cosmwasm_schema::schemars::Map;
+// use cosmwasm_std::{coin, to_json_binary, Addr};
+// use cw_multi_test::Executor;
+
+// #[test]
+// fn test_primtive() {
+//     let mut router = mock_app(None);
+//     let andr = MockAndromedaBuilder::new(&mut router, "admin")
+//         .with_wallets(vec![
+//             ("owner", vec![]),
+//             ("buyer_one", vec![coin(1000, "uandr")]),
+//             ("recipient_one", vec![]),
+//         ])
+//         .with_contracts(vec![("primitive", mock_andromeda_primitive())])
+//         .build(&mut router);
+//     let owner = andr.get_wallet("owner");
+
+//     // Generate App Components
+//     let primitive_init_msg = mock_primitive_instantiate_msg(
+//         andr.kernel.addr().to_string(),
+//         None,
+//         andromeda_data_storage::primitive::PrimitiveRestriction::Private,
+//     );
+//     let primitive_component = AppComponent::new(
+//         "primitive".to_string(),
+//         "primitive".to_string(),
+//         to_json_binary(&primitive_init_msg).unwrap(),
+//     );
+
+//     // Create App
+//     let app_components: Vec<AppComponent> = vec![primitive_component.clone()];
+//     let app = MockAppContract::instantiate(
+//         andr.get_code_id(&mut router, "app-contract"),
+//         owner,
+//         &mut router,
+//         "Primitive App",
+//         app_components,
+//         andr.kernel.addr(),
+//         Some(owner.to_string()),
+//     );
+
+//     // router
+//     //     .execute_contract(
+//     //         owner.clone(),
+//     //         Addr::unchecked(app.addr().clone()),
+//     //         &mock_claim_ownership_msg(None),
+//     //         &[],
+//     //     )
+//     //     .unwrap();
+
+//     // let primitive: MockPrimitive =
+//     //     app.query_ado_by_component_name(&router, primitive_component.name);
+
+//     // primitive
+//     //     .execute_set_value(
+//     //         &mut router,
+//     //         owner.clone(),
+//     //         Some("bool".to_string()),
+//     //         Primitive::Bool(true),
+//     //     )
+//     //     .unwrap();
+
+//     // // Check final state
+//     // let get_value_resp: GetValueResponse = router
+//     //     .wrap()
+//     //     .query_wasm_smart(
+//     //         primitive.addr(),
+//     //         &mock_primitive_get_value(Some("bool".to_string())),
+//     //     )
+//     //     .unwrap();
+//     // assert_eq!(get_value_resp.value, Primitive::Bool(true));
+// }


### PR DESCRIPTION
# Motivation
Resolves: #460 

# Implementation
Removed all instances and references to Object and Vector Primitive types.

# Testing
Removed tests related to Object and Vector Primitive types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `MockPrimitive` struct with methods for instantiation and execution, enhancing testing capabilities.

- **Bug Fixes**
  - Removed unused imports and redundant test functions to streamline the codebase.

- **Refactor**
  - Simplified `Primitive` enum by removing `Vec` and `Object` variants, and associated methods, improving code maintainability.
  - Simplified integration tests by removing complex map structures and directly handling boolean values.

- **Chores**
  - Updated dependencies for better testing support, including `andromeda-testing` as an optional dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->