### PR TITLE
feat: [Primitive] Get Value Type Query

### DIFF
--- a/contracts/data-storage/andromeda-primitive/src/contract.rs
+++ b/contracts/data-storage/andromeda-primitive/src/contract.rs
@@ -12,7 +12,7 @@ use andromeda_std::{
 
 use crate::{
     execute::handle_execute,
-    query::{all_keys, get_value, owner_keys},
+    query::{all_keys, get_type, get_value, owner_keys},
     state::RESTRICTION,
 };
 
@@ -69,6 +69,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::GetValue { key } => encode_binary(&get_value(deps.storage, key)?),
+        QueryMsg::GetType { key } => encode_binary(&get_type(deps.storage, key)?),
         QueryMsg::AllKeys {} => encode_binary(&all_keys(deps.storage)?),
         QueryMsg::OwnerKeys { owner } => encode_binary(&owner_keys(&deps, owner)?),
         _ => ADOContract::default().query(deps, env, msg),

--- a/contracts/data-storage/andromeda-primitive/src/mock.rs
+++ b/contracts/data-storage/andromeda-primitive/src/mock.rs
@@ -83,3 +83,7 @@ pub fn mock_store_address_msgs(key: String, address: Addr) -> ExecuteMsg {
 pub fn mock_primitive_get_value(key: Option<String>) -> QueryMsg {
     QueryMsg::GetValue { key }
 }
+
+pub fn mock_primitive_get_type(key: Option<String>) -> QueryMsg {
+    QueryMsg::GetType { key }
+}

--- a/contracts/data-storage/andromeda-primitive/src/query.rs
+++ b/contracts/data-storage/andromeda-primitive/src/query.rs
@@ -1,5 +1,5 @@
 use crate::state::{DATA, DEFAULT_KEY, KEY_OWNER, RESTRICTION};
-use andromeda_data_storage::primitive::{GetValueResponse, PrimitiveRestriction};
+use andromeda_data_storage::primitive::{GetTypeResponse, GetValueResponse, PrimitiveRestriction};
 use andromeda_std::{ado_contract::ADOContract, amp::AndrAddr, error::ContractError};
 use cosmwasm_std::{Addr, Deps, Storage};
 
@@ -55,4 +55,13 @@ pub fn get_value(
         key: key.to_string(),
         value,
     })
+}
+
+pub fn get_type(
+    storage: &dyn Storage,
+    key: Option<String>,
+) -> Result<GetTypeResponse, ContractError> {
+    let key = get_key_or_default(&key);
+    let value_type = DATA.load(storage, key)?;
+    Ok(GetTypeResponse { value_type })
 }

--- a/contracts/data-storage/andromeda-primitive/src/query.rs
+++ b/contracts/data-storage/andromeda-primitive/src/query.rs
@@ -62,6 +62,6 @@ pub fn get_type(
     key: Option<String>,
 ) -> Result<GetTypeResponse, ContractError> {
     let key = get_key_or_default(&key);
-    let value_type = String::from(DATA.load(storage, key)?);
+    let value_type = DATA.load(storage, key)?.to_string();
     Ok(GetTypeResponse { value_type })
 }

--- a/contracts/data-storage/andromeda-primitive/src/query.rs
+++ b/contracts/data-storage/andromeda-primitive/src/query.rs
@@ -62,6 +62,6 @@ pub fn get_type(
     key: Option<String>,
 ) -> Result<GetTypeResponse, ContractError> {
     let key = get_key_or_default(&key);
-    let value_type = DATA.load(storage, key)?.from_string();
+    let value_type = String::from(DATA.load(storage, key)?);
     Ok(GetTypeResponse { value_type })
 }

--- a/contracts/data-storage/andromeda-primitive/src/query.rs
+++ b/contracts/data-storage/andromeda-primitive/src/query.rs
@@ -62,6 +62,6 @@ pub fn get_type(
     key: Option<String>,
 ) -> Result<GetTypeResponse, ContractError> {
     let key = get_key_or_default(&key);
-    let value_type = DATA.load(storage, key)?;
+    let value_type = DATA.load(storage, key)?.from_string();
     Ok(GetTypeResponse { value_type })
 }

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -50,6 +50,20 @@ pub enum Primitive {
     Binary(Binary),
 }
 
+impl Primitive {
+    pub fn from_string(&self) -> String {
+        match self {
+            Primitive::Uint128(_) => "Uint128".to_string(),
+            Primitive::Decimal(_) => "Decimal".to_string(),
+            Primitive::Coin(_) => "Coin".to_string(),
+            Primitive::Addr(_) => "Addr".to_string(),
+            Primitive::String(_) => "String".to_string(),
+            Primitive::Bool(_) => "Bool".to_string(),
+            Primitive::Binary(_) => "Binary".to_string(),
+        }
+    }
+}
+
 #[cw_serde]
 pub enum PrimitiveRestriction {
     Private,
@@ -167,13 +181,51 @@ pub struct GetValueResponse {
 
 #[cw_serde]
 pub struct GetTypeResponse {
-    pub value_type: Primitive,
+    pub value_type: String,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use cosmwasm_std::to_json_binary;
+
+    #[test]
+    fn test_from_string() {
+        let cases = vec![
+            (
+                Primitive::Uint128(Uint128::from(5_u128)),
+                "Uint128".to_string(),
+            ),
+            (
+                Primitive::Decimal(Decimal::new(Uint128::one())),
+                "Decimal".to_string(),
+            ),
+            (
+                Primitive::Coin(Coin {
+                    amount: Uint128::new(100),
+                    denom: "uatom".to_string(),
+                }),
+                "Coin".to_string(),
+            ),
+            (
+                Primitive::Addr(Addr::unchecked("cosmos1...v937")),
+                "Addr".to_string(),
+            ),
+            (
+                Primitive::String("Some string".to_string()),
+                "String".to_string(),
+            ),
+            (Primitive::Bool(true), "Bool".to_string()),
+            (
+                Primitive::Binary(to_json_binary(&"data").unwrap()),
+                "Binary".to_string(),
+            ),
+        ];
+
+        for (value, expected_str) in cases.iter() {
+            assert_eq!(&value.from_string(), expected_str);
+        }
+    }
 
     #[test]
     fn test_parse_error() {

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -50,9 +50,9 @@ pub enum Primitive {
     Binary(Binary),
 }
 
-impl Primitive {
-    pub fn from_string(&self) -> String {
-        match self {
+impl From<Primitive> for String {
+    fn from(primitive: Primitive) -> Self {
+        match primitive {
             Primitive::Uint128(_) => "Uint128".to_string(),
             Primitive::Decimal(_) => "Decimal".to_string(),
             Primitive::Coin(_) => "Coin".to_string(),
@@ -61,12 +61,6 @@ impl Primitive {
             Primitive::Bool(_) => "Bool".to_string(),
             Primitive::Binary(_) => "Binary".to_string(),
         }
-    }
-}
-
-impl From<Primitive> for String {
-    fn from(primitive: Primitive) -> Self {
-        primitive.from_string()
     }
 }
 
@@ -229,7 +223,7 @@ mod tests {
         ];
 
         for (value, expected_str) in cases.iter() {
-            assert_eq!(&value.from_string(), expected_str);
+            assert_eq!(String::from(value.to_owned()), expected_str.to_owned());
         }
 
         let decimal_primitive = Primitive::Decimal(Decimal::new(Uint128::one()));

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -31,6 +31,8 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(GetValueResponse)]
     GetValue { key: Option<String> },
+    #[returns(GetTypeResponse)]
+    GetType { key: Option<String> },
     #[returns(Vec<String>)]
     AllKeys {},
     #[returns(Vec<String>)]
@@ -161,6 +163,11 @@ impl Primitive {
 pub struct GetValueResponse {
     pub key: String,
     pub value: Primitive,
+}
+
+#[cw_serde]
+pub struct GetTypeResponse {
+    pub value_type: Primitive,
 }
 
 #[cfg(test)]

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use andromeda_std::{amp::AndrAddr, andr_exec, andr_instantiate, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Binary, Coin, Decimal, StdError, Uint128};
@@ -61,6 +63,13 @@ impl From<Primitive> for String {
             Primitive::Bool(_) => "Bool".to_string(),
             Primitive::Binary(_) => "Binary".to_string(),
         }
+    }
+}
+
+impl fmt::Display for Primitive {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let variant_name: String = self.clone().into();
+        write!(f, "{}", variant_name)
     }
 }
 

--- a/packages/andromeda-data-storage/src/primitive.rs
+++ b/packages/andromeda-data-storage/src/primitive.rs
@@ -64,6 +64,12 @@ impl Primitive {
     }
 }
 
+impl From<Primitive> for String {
+    fn from(primitive: Primitive) -> Self {
+        primitive.from_string()
+    }
+}
+
 #[cw_serde]
 pub enum PrimitiveRestriction {
     Private,
@@ -225,6 +231,9 @@ mod tests {
         for (value, expected_str) in cases.iter() {
             assert_eq!(&value.from_string(), expected_str);
         }
+
+        let decimal_primitive = Primitive::Decimal(Decimal::new(Uint128::one()));
+        assert_eq!("Decimal".to_string(), String::from(decimal_primitive));
     }
 
     #[test]

--- a/tests-integration/tests/primtive.rs
+++ b/tests-integration/tests/primtive.rs
@@ -1,10 +1,10 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use andromeda_data_storage::primitive::{GetValueResponse, Primitive};
+use andromeda_data_storage::primitive::{GetTypeResponse, GetValueResponse, Primitive};
 
 use andromeda_primitive::mock::{
-    mock_andromeda_primitive, mock_primitive_get_value, mock_primitive_instantiate_msg,
-    mock_store_value_msg,
+    mock_andromeda_primitive, mock_primitive_get_type, mock_primitive_get_value,
+    mock_primitive_instantiate_msg, mock_store_value_msg,
 };
 use andromeda_testing::{mock::mock_app, mock_builder::MockAndromedaBuilder, MockContract};
 use cw_multi_test::Executor;
@@ -54,11 +54,20 @@ fn test_primtive() {
     let get_value_resp: GetValueResponse = router
         .wrap()
         .query_wasm_smart(
-            primitive_addr,
+            primitive_addr.clone(),
             &mock_primitive_get_value(Some("key".to_string())),
         )
         .unwrap();
     assert_eq!(get_value_resp.value, Primitive::Bool(true));
+
+    let get_type_resp: GetTypeResponse = router
+        .wrap()
+        .query_wasm_smart(
+            primitive_addr,
+            &mock_primitive_get_type(Some("key".to_string())),
+        )
+        .unwrap();
+    assert_eq!(get_type_resp.value_type, Primitive::Bool(true));
 }
 
 // #![cfg(not(target_arch = "wasm32"))]

--- a/tests-integration/tests/primtive.rs
+++ b/tests-integration/tests/primtive.rs
@@ -67,7 +67,7 @@ fn test_primtive() {
             &mock_primitive_get_type(Some("key".to_string())),
         )
         .unwrap();
-    assert_eq!(get_type_resp.value_type, Primitive::Bool(true));
+    assert_eq!(get_type_resp.value_type, "Bool".to_string());
 }
 
 // #![cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
# Motivation
Resolves #461 

# Implementation
As requested in above issue

# Testing
Added `GetType` query as part of the primitive integration test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new query functionality to retrieve the type associated with a key in storage.
  - Added new query message `GetType` to fetch the type of a value.

- **Improvements**
  - Enhanced integration tests to include type querying for primitives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->