### PR TITLE
ci: Added version check 

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,4 +1,4 @@
-name: Version Bump
+name: Check Version Bump
 
 on:
   pull_request:
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -27,11 +29,14 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      - name: Fetch all branches
+        run: git fetch --all
+
       - name: Get changed files
         id: changes
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git diff --name-only origin/${{ github.base_ref }}... > changes.txt
+          BASE_BRANCH=${{ github.base_ref }}
+          git diff --name-only origin/$BASE_BRANCH > changes.txt
           cat changes.txt
 
       - name: Check for version bumps
@@ -48,7 +53,7 @@ jobs:
             # Check if any file within the crate directory has changed
             if grep -q "^$crate/" changes.txt; then
               # Check if the version has changed in the crate's Cargo.toml
-              if git diff --unified=0 origin/${{ github.base_ref }}... -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then
+              if git diff origin/$BASE_BRANCH -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then
                 echo "Version bumped for $crate"
               else
                 echo "::error::Version not bumped for $crate"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Check for version bumps
         id: version-bump
         run: |
+          echo "Getting the list of crates..."
           # Get the list of crates
           IFS=$'\n' read -rd '' -a crates <<< "${{ steps.identify-crates.outputs.crates }}"
 
@@ -65,10 +66,8 @@ jobs:
           # Loop through all crates and check for changes in the crate directory
           for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"
-            # Remove leading ./ from crate path if present
-            crate=${crate#./}
             # Normalize the crate path for use in the grep command
-            crate_path="${crate//\//\\/}"
+            crate_path=$(echo "$crate" | sed 's/\//\\\//g')
             # Check if any file within the crate directory has changed
             echo "Searching for changes in crate path: $crate_path"
             if grep -qE "^$crate_path/" changes.txt; then

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Check for version bumps
         id: version-bump
         run: |
-          set -e
           # Get the list of crates
           IFS=$'\n' read -rd '' -a crates <<< "${{ steps.identify-crates.outputs.crates }}"
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,67 @@
+name: Version Bump
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    branches:
+      - development
+      - main
+    paths:
+      - "**/*"
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Get changed files
+        id: changes
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git diff --name-only origin/${{ github.base_ref }}... > changes.txt
+          cat changes.txt
+
+      - name: Check for version bumps
+        id: version-bump
+        run: |
+          # Get a list of all crates in the workspace
+          crates=$(cargo workspaces list --json | jq -r '.[] | .name')
+
+          # Initialize a flag for detecting version bumps
+          version_bumped="true"
+
+          # Loop through all crates and check for changes in the crate directory
+          for crate in $crates; do
+            # Check if any file within the crate directory has changed
+            if grep -q "^$crate/" changes.txt; then
+              # Check if the version has changed in the crate's Cargo.toml
+              if git diff --unified=0 origin/${{ github.base_ref }}... -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then
+                echo "Version bumped for $crate"
+              else
+                echo "::error::Version not bumped for $crate"
+                version_bumped="false"
+              fi
+            fi
+          done
+
+          # If any crate had changes and the version was not bumped, fail the job
+          if [ "$version_bumped" = "false" ]; then
+            exit 1
+          fi
+
+      - name: Success message
+        if: success()
+        run: echo "All crates with changes have their versions bumped!"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -73,7 +73,7 @@ jobs:
             crate_path=$(echo "$crate" | sed 's/\//\\\//g')
             # Check if any file within the crate directory has changed
             echo "Searching for changes in crate path: $crate_path"
-            if grep -qE "^$crate_path/" changes.txt; then
+            if grep -qE "$crate_path" changes.txt; then
               echo "Changes detected in $crate"
               # Check if the version has changed in the crate's Cargo.toml
               if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -71,7 +71,7 @@ jobs:
             crate_path=$(echo "$crate" | sed 's/\//\\\//g')
             # Check if any file within the crate directory has changed
             echo "Searching for changes in crate path: $crate_path"
-            if grep -qE "^$crate_path/" changes.txt; then
+            if grep -qE "$crate_path" changes.txt; then
               echo "Changes detected in $crate"
               # Check if the version has changed in any file within the crate directory
               if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate" | grep -E '^\+'; then

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -62,7 +62,7 @@ jobs:
 
           # Initialize a flag for detecting version bumps
           version_bumped="true"
-
+          echo "Checking for version bumps in all crates..."
           # Loop through all crates and check for changes in the crate directory
           for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -67,14 +67,14 @@ jobs:
           # Loop through all crates
           for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"
-            # Search for the Crate.toml file in all possible paths within the crate
-            crate_path=$(find . -type f -name Cargo.toml | grep "/$crate/Cargo.toml" | head -n 1)
+            # Normalize the crate path for use in the grep command
+            crate_path=$(echo "$crate" | sed 's/\//\\\//g')
             # Check if any file within the crate directory has changed
             echo "Searching for changes in crate path: $crate_path"
             if grep -qE "^$crate_path/" changes.txt; then
               echo "Changes detected in $crate"
-              # Check if the version has changed in the crate's Cargo.toml
-              if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate_path" | grep -E '^\+version\s*=\s*\"'; then
+              # Check if the version has changed in any file within the crate directory
+              if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate" | grep -E '^\+'; then
                 echo "Version bumped for $crate"
               else
                 echo "::error::Version not bumped for $crate"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces
+
       - name: Install jq
         run: sudo apt-get install -y jq
 
@@ -43,7 +46,7 @@ jobs:
         id: identify-crates
         run: |
           echo "Identifying crates in the workspace"
-          crates=$(find . -name 'Cargo.toml' -exec dirname {} \; | grep -v '^.$')
+          crates=$(cargo workspaces list --json | jq -r '.[] | .name')
           echo "Found crates: $crates"
           echo "::set-output name=crates::$crates"
 
@@ -59,7 +62,7 @@ jobs:
           # Loop through all crates and check for changes in the crate directory
           for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"
-            # Remove leading ./ from crate path
+            # Remove leading ./ from crate path if present
             crate=${crate#./}
             # Normalize the crate path for use in the grep command
             crate_path="${crate//\//\\/}"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -58,25 +58,23 @@ jobs:
       - name: Check for version bumps
         id: version-bump
         run: |
-          echo "Getting the list of crates..."
           # Get the list of crates
           IFS=',' read -ra crates <<< "${{ steps.split-crates.outputs.crates }}"
 
           # Initialize a flag for detecting version bumps
           version_bumped="true"
 
-          echo "Checking each crate..."
-          # Loop through all crates and check for changes in the crate directory
+          # Loop through all crates
           for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"
-            # Normalize the crate path for use in the grep command
-            crate_path=$(echo "$crate" | sed 's/\//\\\//g')
+            # Search for the Crate.toml file in all possible paths within the crate
+            crate_path=$(find . -type f -name Cargo.toml | grep "/$crate/Cargo.toml" | head -n 1)
             # Check if any file within the crate directory has changed
             echo "Searching for changes in crate path: $crate_path"
-            if grep -qE "$crate_path" changes.txt; then
+            if grep -qE "^$crate_path/" changes.txt; then
               echo "Changes detected in $crate"
               # Check if the version has changed in the crate's Cargo.toml
-              if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then
+              if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate_path" | grep -E '^\+version\s*=\s*\"'; then
                 echo "Version bumped for $crate"
               else
                 echo "::error::Version not bumped for $crate"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
+          echo "Fetching changed files..."
           git diff --name-only origin/${{ steps.vars.outputs.BASE_BRANCH }} > changes.txt
+          echo "Changed files:"
           cat changes.txt
 
       - name: Identify crates
@@ -47,12 +49,14 @@ jobs:
         run: |
           echo "Identifying crates in the workspace"
           crates=$(cargo workspaces list --json | jq -r '.[] | .name')
-          echo "Found crates: $crates"
+          echo "Found crates:"
+          echo "$crates"
           echo "::set-output name=crates::$crates"
 
       - name: Check for version bumps
         id: version-bump
         run: |
+          set -e
           # Get the list of crates
           IFS=$'\n' read -rd '' -a crates <<< "${{ steps.identify-crates.outputs.crates }}"
 
@@ -67,6 +71,7 @@ jobs:
             # Normalize the crate path for use in the grep command
             crate_path="${crate//\//\\/}"
             # Check if any file within the crate directory has changed
+            echo "Searching for changes in crate path: $crate_path"
             if grep -qE "^$crate_path/" changes.txt; then
               echo "Changes detected in $crate"
               # Check if the version has changed in the crate's Cargo.toml
@@ -83,7 +88,10 @@ jobs:
 
           # If any crate had changes and the version was not bumped, fail the job
           if [ "$version_bumped" = "false" ]; then
+            echo "Some crates did not have their versions bumped."
             exit 1
+          else
+            echo "All crates with changes have their versions bumped."
           fi
 
       - name: Success message

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
-
       - name: Install jq
         run: sudo apt-get install -y jq
 
@@ -42,20 +39,32 @@ jobs:
           git diff --name-only origin/${{ steps.vars.outputs.BASE_BRANCH }} > changes.txt
           cat changes.txt
 
+      - name: Identify crates
+        id: identify-crates
+        run: |
+          echo "Identifying crates in the workspace"
+          crates=$(find . -name 'Cargo.toml' -exec dirname {} \; | grep -v '^.$')
+          echo "Found crates: $crates"
+          echo "::set-output name=crates::$crates"
+
       - name: Check for version bumps
         id: version-bump
         run: |
-          # Get a list of all crates in the workspace
-          crates=$(cargo workspaces list --json | jq -r '.[] | .name')
+          # Get the list of crates
+          IFS=$'\n' read -rd '' -a crates <<< "${{ steps.identify-crates.outputs.crates }}"
 
           # Initialize a flag for detecting version bumps
           version_bumped="true"
 
           # Loop through all crates and check for changes in the crate directory
-          for crate in $crates; do
+          for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"
+            # Remove leading ./ from crate path
+            crate=${crate#./}
+            # Normalize the crate path for use in the grep command
+            crate_path="${crate//\//\\/}"
             # Check if any file within the crate directory has changed
-            if grep -q "^$crate/" changes.txt; then
+            if grep -qE "^$crate_path/" changes.txt; then
               echo "Changes detected in $crate"
               # Check if the version has changed in the crate's Cargo.toml
               if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -49,20 +49,23 @@ jobs:
         run: |
           echo "Identifying crates in the workspace"
           crates=$(cargo workspaces list --json | jq -r '.[] | .name')
-          echo "Found crates:"
-          echo "$crates"
           echo "::set-output name=crates::$crates"
+
+      - name: Split crate names into an array
+        id: split-crates
+        run: echo "::set-output name=crates::$(echo \"${{ steps.identify-crates.outputs.crates }}\" | tr '\n' ',')"
 
       - name: Check for version bumps
         id: version-bump
         run: |
           echo "Getting the list of crates..."
           # Get the list of crates
-          IFS=$'\n' read -rd '' -a crates <<< "${{ steps.identify-crates.outputs.crates }}"
+          IFS=',' read -ra crates <<< "${{ steps.split-crates.outputs.crates }}"
 
           # Initialize a flag for detecting version bumps
           version_bumped="true"
-          echo "Checking for version bumps in all crates..."
+
+          echo "Checking each crate..."
           # Loop through all crates and check for changes in the crate directory
           for crate in "${crates[@]}"; do
             echo "Checking crate: $crate"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
+      - name: Get base branch
+        id: vars
+        run: echo "::set-output name=BASE_BRANCH::${{ github.event.pull_request.base.ref }}"
+
       - name: Get changed files
         id: changes
         run: |
-          BASE_BRANCH=${{ github.base_ref }}
-          git diff --name-only origin/$BASE_BRANCH > changes.txt
+          git diff --name-only origin/${{ steps.vars.outputs.BASE_BRANCH }} > changes.txt
           cat changes.txt
 
       - name: Check for version bumps
@@ -50,15 +53,19 @@ jobs:
 
           # Loop through all crates and check for changes in the crate directory
           for crate in $crates; do
+            echo "Checking crate: $crate"
             # Check if any file within the crate directory has changed
             if grep -q "^$crate/" changes.txt; then
+              echo "Changes detected in $crate"
               # Check if the version has changed in the crate's Cargo.toml
-              if git diff origin/$BASE_BRANCH -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then
+              if git diff origin/${{ steps.vars.outputs.BASE_BRANCH }} -- "$crate/Cargo.toml" | grep -E '^\+version\s*=\s*\"'; then
                 echo "Version bumped for $crate"
               else
                 echo "::error::Version not bumped for $crate"
                 version_bumped="false"
               fi
+            else
+              echo "No changes detected in $crate"
             fi
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Expiry Enum [(#419)](https://github.com/andromedaprotocol/andromeda-core/pull/419)
 - Added Conditional Splitter [(#441)](https://github.com/andromedaprotocol/andromeda-core/pull/441)
 - Validator Staking: Added the option to set an amount while unstaking [(#458)](https://github.com/andromedaprotocol/andromeda-core/pull/458)
+- Version bump added to CI checks [(#474)](https://github.com/andromedaprotocol/andromeda-core/pull/474)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-std",

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -31,7 +31,6 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     APP_NAME.save(deps.storage, &msg.name)?;
-    deps.api.debug("temporary, will remove");
     ensure!(
         msg.app_components.len() <= 50,
         ContractError::TooManyAppComponents {}

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -31,7 +31,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     APP_NAME.save(deps.storage, &msg.name)?;
-
+    deps.api.debug("temporary, will remove");
     ensure!(
         msg.app_components.len() <= 50,
         ContractError::TooManyAppComponents {}

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -31,6 +31,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     APP_NAME.save(deps.storage, &msg.name)?;
+    deps.api.debug("temporary, will remove");
     ensure!(
         msg.app_components.len() <= 50,
         ContractError::TooManyAppComponents {}


### PR DESCRIPTION
# Motivation

These changes add a simple version check to pull requests for the `development` branch, ensuring that any updated contracts or packages have their versions bumped.

# Implementation
See [`.github/workflows/version-check.yml`](./.github/workflows/version-check.yml)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented a "Version Bump" GitHub Actions workflow to ensure version bumps in Rust crates when changes are made on `development` and `main` branches.

- **Chores**
  - Added version bump checks to the CI process in the Andromeda Core project.

- **Style**
  - Minor formatting change in the `instantiate` function to improve code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->