### PR TITLE
feat: Primitive Rates for Set Value

### DIFF
--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -34,7 +34,7 @@ cw-utils = { workspace = true }
 cw20 = { workspace = true }
 
 
-andromeda-std = { workspace = true, features = [] }
+andromeda-std = { workspace = true, features = ["rates"] }
 andromeda-data-storage = { workspace = true }
 
 

--- a/contracts/data-storage/andromeda-primitive/src/execute.rs
+++ b/contracts/data-storage/andromeda-primitive/src/execute.rs
@@ -1,18 +1,20 @@
 use andromeda_data_storage::primitive::{ExecuteMsg, Primitive, PrimitiveRestriction};
 use andromeda_std::{
     ado_contract::ADOContract,
-    common::{actions::call_action, context::ExecuteContext},
+    common::{actions::call_action, call_action::get_action_name, context::ExecuteContext, Funds},
     error::ContractError,
 };
-use cosmwasm_std::{ensure, Response, StdError};
+use cosmwasm_std::{coin, ensure, Coin, Deps, MessageInfo, Response, StdError, SubMsg};
 use cw_utils::nonpayable;
 
 use crate::{
     query::{get_key_or_default, has_key_permission},
     state::{DATA, KEY_OWNER, RESTRICTION},
 };
+const CONTRACT_NAME: &str = "crates.io:andromeda-primitive";
 
 pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+    let action = get_action_name(CONTRACT_NAME, msg.as_ref());
     call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -22,7 +24,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     )?;
     match msg {
         ExecuteMsg::UpdateRestriction { restriction } => update_restriction(ctx, restriction),
-        ExecuteMsg::SetValue { key, value } => set_value(ctx, key, value),
+        ExecuteMsg::SetValue { key, value } => set_value(ctx, key, value, action),
         ExecuteMsg::DeleteValue { key } => delete_value(ctx, key),
         _ => ADOContract::default().execute(ctx, msg),
     }
@@ -48,9 +50,9 @@ pub fn set_value(
     ctx: ExecuteContext,
     key: Option<String>,
     value: Primitive,
+    action: String,
 ) -> Result<Response, ContractError> {
-    nonpayable(&ctx.info)?;
-    let sender = ctx.info.sender;
+    let sender = ctx.info.sender.clone();
     let key: &str = get_key_or_default(&key);
     ensure!(
         has_key_permission(ctx.deps.storage, &sender, key)?,
@@ -58,6 +60,8 @@ pub fn set_value(
     );
     // Validate the primitive value
     value.validate(ctx.deps.api)?;
+
+    let tax_response = tax_set_value(ctx.deps.as_ref(), &ctx.info, action)?;
 
     DATA.update::<_, StdError>(ctx.deps.storage, key, |old| match old {
         Some(_) => Ok(value.clone()),
@@ -69,11 +73,17 @@ pub fn set_value(
         None => Ok(sender.clone()),
     })?;
 
-    Ok(Response::new()
+    let response = Response::new()
         .add_attribute("method", "set_value")
         .add_attribute("sender", sender)
         .add_attribute("key", key)
-        .add_attribute("value", format!("{value:?}")))
+        .add_attribute("value", format!("{value:?}"));
+
+    if let Some(tax_response) = tax_response {
+        Ok(response.add_submessages(tax_response.1))
+    } else {
+        Ok(response)
+    }
 }
 
 pub fn delete_value(ctx: ExecuteContext, key: Option<String>) -> Result<Response, ContractError> {
@@ -91,4 +101,33 @@ pub fn delete_value(ctx: ExecuteContext, key: Option<String>) -> Result<Response
         .add_attribute("method", "delete_value")
         .add_attribute("sender", sender)
         .add_attribute("key", key))
+}
+
+fn tax_set_value(
+    deps: Deps,
+    info: &MessageInfo,
+    action: String,
+) -> Result<Option<(Funds, Vec<SubMsg>)>, ContractError> {
+    let default_coin = coin(0_u128, "uandr".to_string());
+    let sent_funds = info.funds.first().unwrap_or(&default_coin);
+
+    let transfer_response = ADOContract::default().query_deducted_funds(
+        deps,
+        action,
+        Funds::Native(sent_funds.clone()),
+    )?;
+
+    if let Some(transfer_response) = transfer_response {
+        let remaining_funds = transfer_response.leftover_funds.try_get_coin()?;
+        let after_tax_payment = Coin {
+            denom: remaining_funds.denom,
+            amount: remaining_funds.amount,
+        };
+        Ok(Some((
+            Funds::Native(after_tax_payment),
+            transfer_response.msgs,
+        )))
+    } else {
+        Ok(None)
+    }
 }

--- a/contracts/data-storage/andromeda-primitive/src/testing/mock.rs
+++ b/contracts/data-storage/andromeda-primitive/src/testing/mock.rs
@@ -8,7 +8,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    Deps, DepsMut, MessageInfo, OwnedDeps, Response,
+    Coin, Deps, DepsMut, MessageInfo, OwnedDeps, Response,
 };
 
 use crate::contract::{execute, instantiate, query};
@@ -47,6 +47,21 @@ pub fn set_value(
         value: value.clone(),
     };
     let info = mock_info(sender, &[]);
+    execute(deps, mock_env(), info, msg)
+}
+
+pub fn set_value_with_funds(
+    deps: DepsMut<'_>,
+    key: &Option<String>,
+    value: &Primitive,
+    sender: &str,
+    coin: Coin,
+) -> Result<Response, ContractError> {
+    let msg = ExecuteMsg::SetValue {
+        key: key.clone(),
+        value: value.clone(),
+    };
+    let info = mock_info(sender, &[coin]);
     execute(deps, mock_env(), info, msg)
 }
 

--- a/packages/std/src/ado_base/rates.rs
+++ b/packages/std/src/ado_base/rates.rs
@@ -93,6 +93,12 @@ impl LocalRateValue {
         }
         Ok(())
     }
+    pub fn is_flat(&self) -> bool {
+        match self {
+            LocalRateValue::Percent(_) => false,
+            LocalRateValue::Flat(_) => true,
+        }
+    }
 }
 
 #[cw_serde]

--- a/tests-integration/tests/primitive.rs
+++ b/tests-integration/tests/primitive.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use andromeda_app::app::AppComponent;
-use andromeda_app_contract::mock::{mock_andromeda_app, mock_claim_ownership_msg, MockAppContract};
+use andromeda_app_contract::mock::{mock_andromeda_app, MockAppContract};
 use andromeda_data_storage::primitive::{GetTypeResponse, GetValueResponse, Primitive};
 
 use andromeda_primitive::mock::{
@@ -13,8 +13,7 @@ use andromeda_std::{
     error::ContractError,
 };
 use andromeda_testing::{mock::mock_app, mock_builder::MockAndromedaBuilder, MockContract};
-use cosmwasm_std::{coin, to_json_binary, Addr, Decimal, Uint128};
-use cw_multi_test::Executor;
+use cosmwasm_std::{coin, to_json_binary, Decimal, Uint128};
 
 #[test]
 fn test_primitive() {
@@ -56,15 +55,6 @@ fn test_primitive() {
         andr.kernel.addr(),
         Some(owner.to_string()),
     );
-
-    router
-        .execute_contract(
-            owner.clone(),
-            Addr::unchecked(app.addr().clone()),
-            &mock_claim_ownership_msg(None),
-            &[],
-        )
-        .unwrap();
 
     let primitive: MockPrimitive =
         app.query_ado_by_component_name(&router, primitive_component.name);


### PR DESCRIPTION
# Motivation
Resolves #463 

# Implementation
Apply rates for `Set Value` msg, refund excess funds to sender, disable `Percent` rates.

# Testing
Unit tests were created for cases where funds were exact, insufficient, and in excess. 

# Notes
Users can still access `Percent` rates through setting a `Contract` Rate.
