### PR TITLE
Enhance/airdrop asset using vfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merkle Root: stage expiration now uses `Milliseconds`[(#417)](https://github.com/andromedaprotocol/andromeda-core/pull/417)
 - Module Redesign [(#452)](https://github.com/andromedaprotocol/andromeda-core/pull/452)
 - Primitive Improvements [(#476)](https://github.com/andromedaprotocol/andromeda-core/pull/476)
+- Merkle Root: Andromeda Asset is used now as a `asset_info`[(#480)](https://github.com/andromedaprotocol/andromeda-core/pull/480)
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Primitive Improvements [(#476)](https://github.com/andromedaprotocol/andromeda-core/pull/476)
 - Merkle Root: Andromeda Asset is used now as a `asset_info`[(#480)](https://github.com/andromedaprotocol/andromeda-core/pull/480)
 
-
 ### Fixed
 
 - Splitter: avoid zero send messages, owner updates lock any time [(#457)](https://github.com/andromedaprotocol/andromeda-core/pull/457)

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
@@ -23,7 +23,7 @@ use andromeda_fungible_tokens::airdrop::{
 use andromeda_std::{
     ado_base::{InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
     ado_contract::ADOContract,
-    common::{actions::call_action, context::ExecuteContext, encode_binary, expiration::Expiry},
+    common::{actions::call_action, context::ExecuteContext, encode_binary, expiration::Expiry, denom::validate_denom},
     error::ContractError,
 };
 
@@ -33,14 +33,18 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
-    deps: DepsMut,
+    mut deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
+
+    let (coin_denom, uses_cw20) = msg.asset_info.get_verified_asset(deps.branch(), env)?;
+
     let config = Config {
-        asset_info: msg.asset_info.check(deps.api, None)?,
+        asset_info: msg.asset_info,
     };
+
     CONFIG.save(deps.storage, &config)?;
 
     let stage = 0;

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/state.rs
@@ -1,4 +1,4 @@
-use andromeda_std::common::{MillisecondsExpiration, denom::Asset};
+use andromeda_std::common::{denom::Asset, MillisecondsExpiration};
 use cosmwasm_schema::cw_serde;
 
 use cosmwasm_std::{Addr, Uint128};

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/state.rs
@@ -1,13 +1,12 @@
-use andromeda_std::common::MillisecondsExpiration;
+use andromeda_std::common::{MillisecondsExpiration, denom::Asset};
 use cosmwasm_schema::cw_serde;
 
 use cosmwasm_std::{Addr, Uint128};
-use cw_asset::AssetInfo;
 use cw_storage_plus::{Item, Map};
 
 #[cw_serde]
 pub struct Config {
-    pub asset_info: AssetInfo,
+    pub asset_info: Asset,
 }
 
 pub const CONFIG_KEY: &str = "config";

--- a/packages/andromeda-fungible-tokens/src/airdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/airdrop.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{
     andr_exec, andr_instantiate, andr_query,
-    common::{expiration::Expiry, denom::Asset, MillisecondsExpiration},
+    common::{denom::Asset, expiration::Expiry, MillisecondsExpiration},
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;

--- a/packages/andromeda-fungible-tokens/src/airdrop.rs
+++ b/packages/andromeda-fungible-tokens/src/airdrop.rs
@@ -1,15 +1,14 @@
 use andromeda_std::{
     andr_exec, andr_instantiate, andr_query,
-    common::{expiration::Expiry, MillisecondsExpiration},
+    common::{expiration::Expiry, denom::Asset, MillisecondsExpiration},
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
-use cw_asset::{AssetInfo, AssetInfoUnchecked};
 
 #[andr_instantiate]
 #[cw_serde]
 pub struct InstantiateMsg {
-    pub asset_info: AssetInfoUnchecked,
+    pub asset_info: Asset,
 }
 
 #[andr_exec]
@@ -51,7 +50,7 @@ pub enum QueryMsg {
 #[cw_serde]
 #[serde(rename_all = "snake_case")]
 pub struct ConfigResponse {
-    pub asset_info: AssetInfo,
+    pub asset_info: Asset,
 }
 
 #[cw_serde]

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -1,7 +1,10 @@
 use crate::{ado_contract::ADOContract, amp::AndrAddr, error::ContractError};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{ensure, to_json_binary, Deps, DepsMut, Env, QueryRequest, WasmQuery};
-use cw20::{Cw20QueryMsg, TokenInfoResponse};
+use cosmwasm_std::{
+    coin, ensure, to_json_binary, wasm_execute, BankMsg, Deps, DepsMut, Env, QueryRequest, SubMsg,
+    Uint128, WasmQuery,
+};
+use cw20::{Cw20ExecuteMsg, Cw20QueryMsg, TokenInfoResponse};
 pub const SEND_CW20_ACTION: &str = "SEND_CW20";
 
 #[cw_serde]
@@ -43,6 +46,41 @@ impl Asset {
                 Ok((native.to_string(), false))
             }
         }
+    }
+    pub fn transfer(
+        &self,
+        to_address: impl Into<String>,
+        amount: Uint128,
+    ) -> Result<SubMsg, ContractError> {
+        let to_address: String = to_address.into();
+
+        Ok(match self {
+            Asset::NativeToken(denom) => SubMsg::new(BankMsg::Send {
+                to_address: to_address,
+                amount: vec![coin(amount.u128(), denom)],
+            }),
+            Asset::Cw20Token(denom) => {
+                let transfer_msg = Cw20ExecuteMsg::Transfer {
+                    recipient: to_address,
+                    amount,
+                };
+                let wasm_msg = wasm_execute(denom, &transfer_msg, vec![])?;
+                SubMsg::new(wasm_msg)
+            }
+        })
+    }
+
+    pub fn burn(&self, amount: Uint128) -> Result<SubMsg, ContractError> {
+        Ok(match self {
+            Asset::NativeToken(denom) => SubMsg::new(BankMsg::Burn {
+                amount: vec![coin(amount.u128(), denom)],
+            }),
+            Asset::Cw20Token(denom) => {
+                let burn_msg = Cw20ExecuteMsg::Burn { amount };
+                let wasm_msg = wasm_execute(denom, &burn_msg, vec![])?;
+                SubMsg::new(wasm_msg)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/468

# Implementation

- Updated `airdrop.rs` and `state.rs` to use `Asset`.
- Added `transfer` and `burn` trait in `denom.rs` for easy asset transfer/burn.
- Updated `instantiate` function.
  - Called the basic `instantiate` function in order to set permission for the cw20 token to mark valid cw20 token as verified 
- Updated `execute_claim` and `execute_burn` to use the trait of the `Asset`

# Testing

Unit tests are updated to use `Asset`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced permission settings for CW20 tokens.

- **Improvements**
  - Enhanced token transfer and burn operations.
  - Improved validation of asset information.
  
- **Testing**
  - Updated test scenarios to accommodate changes in asset information and contract addresses.

- **Documentation**
  - Updated CHANGELOG.md to reflect use of Andromeda Asset for Merkle Root.

- **Refactor**
  - Replaced `AssetInfoUnchecked` with `Asset` type in key structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->