### PR TITLE
feat: Reference Address List for Permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Module Redesign [(#452)](https://github.com/andromedaprotocol/andromeda-core/pull/452)
 - Primitive Improvements [(#476)](https://github.com/andromedaprotocol/andromeda-core/pull/476)
 - Crowdfund Restructure  [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
+- Reference Address List contract for Permission  [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "1.1.1"
+version = "1.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",

--- a/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
@@ -1,7 +1,7 @@
 use crate::contract::{execute, instantiate, query};
 use crate::testing::mock_querier::mock_dependencies_custom;
 use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_std::ado_base::permissioning::Permission;
+use andromeda_std::ado_base::permissioning::{LocalPermission, Permission};
 use andromeda_std::ado_base::rates::{LocalRate, LocalRateType, LocalRateValue, PercentRate, Rate};
 use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::amp::{AndrAddr, Recipient};
@@ -112,7 +112,7 @@ fn test_transfer() {
     ]);
 
     // Blacklist the sender who otherwise would have been able to call the function successfully
-    let permission = Permission::blacklisted(None);
+    let permission = Permission::Local(LocalPermission::blacklisted(None));
     let actor = AndrAddr::from_string("sender");
     let action = "Transfer";
     let ctx = ExecuteContext::new(deps.as_mut(), mock_info("owner", &[]), mock_env());
@@ -125,7 +125,7 @@ fn test_transfer() {
     assert_eq!(err, ContractError::Unauthorized {});
 
     // Now whitelist the sender, that should allow him to call the function successfully
-    let permission = Permission::whitelisted(None);
+    let permission = Permission::Local(LocalPermission::whitelisted(None));
     let actor = AndrAddr::from_string("sender");
     let action = "Transfer";
     let ctx = ExecuteContext::new(deps.as_mut(), mock_info("owner", &[]), mock_env());

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
@@ -18,7 +18,10 @@ use andromeda_fungible_tokens::airdrop::{
     MerkleRootResponse, QueryMsg, TotalClaimedResponse,
 };
 use andromeda_std::{
-    ado_base::{permissioning::Permission, InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
+    ado_base::{
+        permissioning::{LocalPermission, Permission},
+        InstantiateMsg as BaseInstantiateMsg, MigrateMsg,
+    },
     ado_contract::ADOContract,
     common::{
         actions::call_action,
@@ -65,7 +68,7 @@ pub fn instantiate(
             deps.storage,
             SEND_CW20_ACTION,
             addr,
-            Permission::Whitelisted(None),
+            Permission::Local(LocalPermission::whitelisted(None)),
         )?;
     }
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "1.1.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -28,7 +28,7 @@ pub fn instantiate(
     // If the user provided an actor and permission, save them.
     if let Some(actor_permission) = msg.actor_permission {
         let verified_address: Addr = deps.api.addr_validate(actor_permission.actor.as_str())?;
-        // Permissions of type "Contract" and Limited local permissions aren't allowed in the address list contract
+        // Permissions of type Limited local permissions aren't allowed in the address list contract
         if let LocalPermission::Limited { .. } = actor_permission.permission {
             return Err(ContractError::InvalidPermission {
                 msg: "Limited permission is not supported in address list contract".to_string(),

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -2,7 +2,7 @@ use andromeda_modules::address_list::{ActorPermissionResponse, IncludesActorResp
 #[cfg(not(feature = "library"))]
 use andromeda_modules::address_list::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
-    ado_base::{permissioning::Permission, InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
+    ado_base::{permissioning::LocalPermission, InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
     ado_contract::ADOContract,
     common::{context::ExecuteContext, encode_binary},
     error::ContractError,
@@ -29,13 +29,17 @@ pub fn instantiate(
     if let Some(actor_permission) = msg.actor_permission {
         let verified_address: Addr = deps.api.addr_validate(actor_permission.actor.as_str())?;
         // Permissions of type "Contract" aren't allowed in the address list contract
+        if let LocalPermission::Limited { .. } = actor_permission.permission {
+            return Err(ContractError::InvalidPermission {
+                msg: "Limited permission is not supported in address list contract".to_string(),
+            });
+        }
         add_actor_permission(
             deps.storage,
             &verified_address,
             &actor_permission.permission,
         )?;
     }
-
     let inst_resp = ADOContract::default().instantiate(
         deps.storage,
         env,
@@ -84,7 +88,7 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
 fn execute_add_actor_permission(
     ctx: ExecuteContext,
     actor: Addr,
-    permission: Permission,
+    permission: LocalPermission,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
     nonpayable(&info)?;
@@ -92,9 +96,12 @@ fn execute_add_actor_permission(
         ADOContract::default().is_owner_or_operator(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {}
     );
-
+    if let LocalPermission::Limited { .. } = permission {
+        return Err(ContractError::InvalidPermission {
+            msg: "Limited permission is not supported in address list contract".to_string(),
+        });
+    }
     add_actor_permission(deps.storage, &actor, &permission)?;
-
     Ok(Response::new().add_attributes(vec![
         attr("action", "add_actor_permission"),
         attr("actor", actor),

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -28,7 +28,7 @@ pub fn instantiate(
     // If the user provided an actor and permission, save them.
     if let Some(actor_permission) = msg.actor_permission {
         let verified_address: Addr = deps.api.addr_validate(actor_permission.actor.as_str())?;
-        // Permissions of type "Contract" aren't allowed in the address list contract
+        // Permissions of type "Contract" and Limited local permissions aren't allowed in the address list contract
         if let LocalPermission::Limited { .. } = actor_permission.permission {
             return Err(ContractError::InvalidPermission {
                 msg: "Limited permission is not supported in address list contract".to_string(),

--- a/contracts/modules/andromeda-address-list/src/mock.rs
+++ b/contracts/modules/andromeda-address-list/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_modules::address_list::{ActorPermission, ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_std::ado_base::permissioning::Permission;
+use andromeda_std::ado_base::permissioning::LocalPermission;
 use andromeda_testing::{
     mock::MockApp, mock_ado, mock_contract::ExecuteResult, MockADO, MockContract,
 };
@@ -40,7 +40,7 @@ impl MockAddressList {
         app: &mut MockApp,
         sender: Addr,
         actor: Addr,
-        permission: Permission,
+        permission: LocalPermission,
     ) -> ExecuteResult {
         self.execute(
             app,
@@ -68,6 +68,6 @@ pub fn mock_address_list_instantiate_msg(
     }
 }
 
-pub fn mock_add_actor_permission_msg(actor: Addr, permission: Permission) -> ExecuteMsg {
+pub fn mock_add_actor_permission_msg(actor: Addr, permission: LocalPermission) -> ExecuteMsg {
     ExecuteMsg::AddActorPermission { actor, permission }
 }

--- a/contracts/modules/andromeda-address-list/src/state.rs
+++ b/contracts/modules/andromeda-address-list/src/state.rs
@@ -1,9 +1,9 @@
-use andromeda_std::ado_base::permissioning::Permission;
+use andromeda_std::ado_base::permissioning::{LocalPermission, Permission};
 use cosmwasm_std::{Addr, StdResult, Storage};
 use cw_storage_plus::Map;
 
 /// A mapping of actor to permission
-pub const PERMISSIONS: Map<&Addr, Permission> = Map::new("permissioning");
+pub const PERMISSIONS: Map<&Addr, LocalPermission> = Map::new("permissioning");
 
 /// Query if a given actor is included in the permissions list.
 pub fn includes_actor(storage: &dyn Storage, actor: &Addr) -> StdResult<bool> {

--- a/contracts/modules/andromeda-address-list/src/state.rs
+++ b/contracts/modules/andromeda-address-list/src/state.rs
@@ -2,7 +2,7 @@ use andromeda_std::ado_base::permissioning::LocalPermission;
 use cosmwasm_std::{Addr, StdResult, Storage};
 use cw_storage_plus::Map;
 
-/// A mapping of actor to permission
+/// A mapping of actor to LocalPermission. Contract Permission is not supported in this contract
 pub const PERMISSIONS: Map<&Addr, LocalPermission> = Map::new("permissioning");
 
 /// Query if a given actor is included in the permissions list.

--- a/contracts/modules/andromeda-address-list/src/state.rs
+++ b/contracts/modules/andromeda-address-list/src/state.rs
@@ -1,4 +1,4 @@
-use andromeda_std::ado_base::permissioning::{LocalPermission, Permission};
+use andromeda_std::ado_base::permissioning::LocalPermission;
 use cosmwasm_std::{Addr, StdResult, Storage};
 use cw_storage_plus::Map;
 
@@ -14,7 +14,7 @@ pub fn includes_actor(storage: &dyn Storage, actor: &Addr) -> StdResult<bool> {
 pub fn add_actor_permission(
     storage: &mut dyn Storage,
     actor: &Addr,
-    permission: &Permission,
+    permission: &LocalPermission,
 ) -> StdResult<()> {
     PERMISSIONS.save(storage, actor, permission)
 }

--- a/contracts/modules/andromeda-address-list/src/testing/tests.rs
+++ b/contracts/modules/andromeda-address-list/src/testing/tests.rs
@@ -5,7 +5,7 @@ use andromeda_modules::address_list::{
     ActorPermission, ActorPermissionResponse, ExecuteMsg, IncludesActorResponse, InstantiateMsg,
     QueryMsg,
 };
-use andromeda_std::ado_base::permissioning::Permission;
+use andromeda_std::ado_base::permissioning::LocalPermission;
 
 use andromeda_std::error::ContractError;
 
@@ -25,7 +25,7 @@ fn init(deps: DepsMut, info: MessageInfo) {
             owner: None,
             actor_permission: Some(ActorPermission {
                 actor: Addr::unchecked("actor"),
-                permission: Permission::whitelisted(None),
+                permission: LocalPermission::whitelisted(None),
             }),
         },
     )
@@ -76,7 +76,7 @@ fn test_add_remove_actor() {
     let info = mock_info(operator, &[]);
 
     let actor = Addr::unchecked("actor");
-    let permission = Permission::default();
+    let permission = LocalPermission::default();
 
     init(deps.as_mut(), info.clone());
 
@@ -145,7 +145,7 @@ fn test_includes_actor_query() {
     let actor = Addr::unchecked("actor");
     let random_actor = Addr::unchecked("random_actor");
 
-    let permission = Permission::default();
+    let permission = LocalPermission::default();
 
     PERMISSIONS
         .save(deps.as_mut().storage, &actor, &permission)
@@ -175,7 +175,7 @@ fn test_actor_permission_query() {
     let actor = Addr::unchecked("actor");
     let random_actor = Addr::unchecked("random_actor");
 
-    let permission = Permission::default();
+    let permission = LocalPermission::default();
 
     PERMISSIONS
         .save(deps.as_mut().storage, &actor, &permission)
@@ -188,7 +188,7 @@ fn test_actor_permission_query() {
 
     assert_eq!(
         ActorPermissionResponse {
-            permission: Permission::default()
+            permission: LocalPermission::default()
         },
         res
     );

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -7,7 +7,10 @@ use andromeda_non_fungible_tokens::auction::{
     IsClaimedResponse, IsClosedResponse, QueryMsg, TokenAuctionState,
 };
 use andromeda_std::{
-    ado_base::{permissioning::Permission, InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
+    ado_base::{
+        permissioning::{LocalPermission, Permission},
+        InstantiateMsg as BaseInstantiateMsg, MigrateMsg,
+    },
     amp::{AndrAddr, Recipient},
     common::{
         actions::call_action,
@@ -69,7 +72,7 @@ pub fn instantiate(
                 deps.storage,
                 SEND_NFT_ACTION,
                 addr,
-                Permission::Whitelisted(None),
+                Permission::Local(LocalPermission::Whitelisted(None)),
             )?;
         }
     }
@@ -80,7 +83,7 @@ pub fn instantiate(
             deps.storage,
             SEND_CW20_ACTION,
             addr,
-            Permission::Whitelisted(None),
+            Permission::Local(LocalPermission::Whitelisted(None)),
         )?;
     }
 
@@ -165,11 +168,11 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
 }
 
 fn handle_receive_cw721(
-    ctx: ExecuteContext,
+    mut ctx: ExecuteContext,
     msg: Cw721ReceiveMsg,
 ) -> Result<Response, ContractError> {
     ADOContract::default().is_permissioned(
-        ctx.deps.storage,
+        ctx.deps.branch(),
         ctx.env.clone(),
         SEND_NFT_ACTION,
         ctx.info.sender.clone(),
@@ -197,12 +200,12 @@ fn handle_receive_cw721(
 }
 
 pub fn handle_receive_cw20(
-    ctx: ExecuteContext,
+    mut ctx: ExecuteContext,
     receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let is_valid_cw20 = ADOContract::default()
         .is_permissioned(
-            ctx.deps.storage,
+            ctx.deps.branch(),
             ctx.env.clone(),
             SEND_CW20_ACTION,
             ctx.info.sender.clone(),
@@ -291,7 +294,7 @@ fn execute_start_auction(
                 deps.storage,
                 auction_id.to_string(),
                 whitelisted_address,
-                Permission::Whitelisted(None),
+                Permission::Local(LocalPermission::Whitelisted(None)),
             )?;
         }
     };
@@ -382,7 +385,7 @@ fn execute_update_auction(
                 deps.storage,
                 token_auction_state.auction_id.to_string(),
                 whitelisted_address,
-                Permission::Whitelisted(None),
+                Permission::Local(LocalPermission::Whitelisted(None)),
             )?;
         }
     };
@@ -419,13 +422,16 @@ fn execute_place_bid(
     token_address: String,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
-        deps, info, env, ..
+        mut deps,
+        info,
+        env,
+        ..
     } = ctx;
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
 
     ADOContract::default().is_permissioned(
-        deps.storage,
+        deps.branch(),
         env.clone(),
         token_auction_state.auction_id,
         info.sender.clone(),
@@ -536,12 +542,12 @@ fn execute_place_bid_cw20(
     // The user who sent the cw20
     sender: &str,
 ) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, env, .. } = ctx;
+    let ExecuteContext { mut deps, env, .. } = ctx;
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
 
     ADOContract::default().is_permissioned(
-        deps.storage,
+        deps.branch(),
         env.clone(),
         token_auction_state.auction_id,
         sender,
@@ -808,9 +814,9 @@ fn execute_authorize_token_contract(
         ContractError::Unauthorized {}
     );
     let permission = if let Some(expiration) = expiration {
-        Permission::whitelisted(Some(expiration))
+        Permission::Local(LocalPermission::Whitelisted(Some(expiration)))
     } else {
-        Permission::whitelisted(None)
+        Permission::Local(LocalPermission::Whitelisted(None))
     };
     ADOContract::set_permission(
         deps.storage,

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -170,7 +170,7 @@ fn execute_cw721(
 }
 
 fn execute_mint(
-    ctx: ExecuteContext,
+    mut ctx: ExecuteContext,
     token_id: String,
     token_uri: Option<String>,
     owner: String,
@@ -182,7 +182,7 @@ fn execute_mint(
     ensure!(
         ctx.contains_sender(minter.as_str())
             | is_context_permissioned_strict(
-                ctx.deps.storage,
+                ctx.deps.branch(),
                 &ctx.info,
                 &ctx.env,
                 &ctx.amp_ctx,
@@ -235,7 +235,7 @@ fn execute_batch_mint(
     ensure!(
         ctx.contains_sender(minter.as_str())
             | is_context_permissioned_strict(
-                ctx.deps.storage,
+                ctx.deps.branch(),
                 &ctx.info,
                 &ctx.env,
                 &ctx.amp_ctx,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
@@ -4,6 +4,8 @@ use crate::contract::{execute, instantiate, query};
 use andromeda_non_fungible_tokens::marketplace::{
     Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
 };
+use andromeda_std::ado_base::permissioning::Permission;
+use andromeda_std::ado_base::permissioning::PermissioningMessage;
 use andromeda_std::ado_base::rates::Rate;
 use andromeda_std::ado_base::rates::RatesMessage;
 use andromeda_std::amp::messages::AMPPkt;
@@ -64,6 +66,22 @@ impl MockMarketplace {
         rate: Rate,
     ) -> ExecuteResult {
         self.execute(app, &mock_set_rates(action, rate), sender, &[])
+    }
+
+    pub fn execute_set_permissions(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        actor: AndrAddr,
+        action: impl Into<String>,
+        permission: Permission,
+    ) -> ExecuteResult {
+        self.execute(
+            app,
+            &mock_set_permissions(actor, action, permission),
+            sender,
+            &[],
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -152,6 +170,18 @@ pub fn mock_set_rates(action: impl Into<String>, rate: Rate) -> ExecuteMsg {
     ExecuteMsg::Rates(RatesMessage::SetRate {
         action: action.into(),
         rate,
+    })
+}
+
+pub fn mock_set_permissions(
+    actor: AndrAddr,
+    action: impl Into<String>,
+    permission: Permission,
+) -> ExecuteMsg {
+    ExecuteMsg::Permissioning(PermissioningMessage::SetPermission {
+        actor,
+        action: action.into(),
+        permission,
     })
 }
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/mock.rs
@@ -68,22 +68,6 @@ impl MockMarketplace {
         self.execute(app, &mock_set_rates(action, rate), sender, &[])
     }
 
-    pub fn execute_set_permissions(
-        &self,
-        app: &mut MockApp,
-        sender: Addr,
-        actor: AndrAddr,
-        action: impl Into<String>,
-        permission: Permission,
-    ) -> ExecuteResult {
-        self.execute(
-            app,
-            &mock_set_permissions(actor, action, permission),
-            sender,
-            &[],
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn execute_update_sale(
         &self,

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -1,4 +1,7 @@
-use andromeda_std::{ado_base::permissioning::Permission, andr_exec, andr_instantiate, andr_query};
+use andromeda_std::{
+    ado_base::permissioning::{LocalPermission, Permission},
+    andr_exec, andr_instantiate, andr_query,
+};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
 
@@ -11,14 +14,17 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub struct ActorPermission {
     pub actor: Addr,
-    pub permission: Permission,
+    pub permission: LocalPermission,
 }
 
 #[andr_exec]
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Adds an actor key and a permission value
-    AddActorPermission { actor: Addr, permission: Permission },
+    AddActorPermission {
+        actor: Addr,
+        permission: LocalPermission,
+    },
     /// Removes actor alongisde his permission
     RemoveActorPermission { actor: Addr },
 }
@@ -45,5 +51,5 @@ pub struct IncludesActorResponse {
 
 #[cw_serde]
 pub struct ActorPermissionResponse {
-    pub permission: Permission,
+    pub permission: LocalPermission,
 }

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -1,6 +1,5 @@
 use andromeda_std::{
-    ado_base::permissioning::{LocalPermission, Permission},
-    andr_exec, andr_instantiate, andr_query,
+    ado_base::permissioning::LocalPermission, andr_exec, andr_instantiate, andr_query,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;

--- a/packages/andromeda-testing/src/mock_contract.rs
+++ b/packages/andromeda-testing/src/mock_contract.rs
@@ -1,9 +1,14 @@
 use core::fmt;
 
-use andromeda_std::ado_base::{
-    ownership::{ContractOwnerResponse, OwnershipMessage},
-    AndromedaMsg, AndromedaQuery,
+use andromeda_std::{
+    ado_base::{
+        ownership::{ContractOwnerResponse, OwnershipMessage},
+        permissioning::{Permission, PermissioningMessage},
+        AndromedaMsg, AndromedaQuery,
+    },
+    amp::AndrAddr,
 };
+
 use cosmwasm_std::{Addr, Coin};
 use cw_multi_test::{AppResponse, Executor};
 use serde::{de::DeserializeOwned, Serialize};
@@ -49,6 +54,26 @@ pub trait MockADO<E: Serialize + fmt::Debug, Q: Serialize + fmt::Debug>:
             sender,
             self.addr().clone(),
             &AndromedaMsg::Ownership(OwnershipMessage::AcceptOwnership {}),
+            &[],
+        )
+    }
+
+    fn execute_set_permissions(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        actor: AndrAddr,
+        action: impl Into<String>,
+        permission: Permission,
+    ) -> ExecuteResult {
+        app.execute_contract(
+            sender,
+            self.addr().clone(),
+            &AndromedaMsg::Permissioning(PermissioningMessage::SetPermission {
+                actor,
+                action: action.into(),
+                permission,
+            }),
             &[],
         )
     }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -48,7 +48,7 @@ pub struct PermissionedActionsResponse {
 ///
 /// Expiration defaults to `Never` if not provided
 #[cw_serde]
-pub enum Permission {
+pub enum LocalPermission {
     Blacklisted(Option<Expiry>),
     Limited {
         expiration: Option<Expiry>,
@@ -57,13 +57,13 @@ pub enum Permission {
     Whitelisted(Option<Expiry>),
 }
 
-impl std::default::Default for Permission {
+impl std::default::Default for LocalPermission {
     fn default() -> Self {
         Self::Whitelisted(None)
     }
 }
 
-impl Permission {
+impl LocalPermission {
     pub fn blacklisted(expiration: Option<Expiry>) -> Self {
         Self::Blacklisted(expiration)
     }
@@ -136,7 +136,7 @@ impl Permission {
     }
 }
 
-impl fmt::Display for Permission {
+impl fmt::Display for LocalPermission {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let self_as_string = match self {
             Self::Blacklisted(expiration) => {
@@ -160,6 +160,22 @@ impl fmt::Display for Permission {
                     "whitelisted".to_string()
                 }
             }
+        };
+        write!(f, "{self_as_string}")
+    }
+}
+
+#[cw_serde]
+pub enum Permission {
+    Local(LocalPermission),
+    Contract(AndrAddr),
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let self_as_string = match self {
+            Self::Local(local_permission) => local_permission.to_string(),
+            Self::Contract(address_list) => address_list.to_string(),
         };
         write!(f, "{self_as_string}")
     }

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -465,7 +465,7 @@ pub fn is_context_permissioned(
 /// - The context does not contain any AMP context and the **sender** is the actor
 /// - The context contains AMP context and the **previous sender** or **origin** are considered the actor
 pub fn is_context_permissioned_strict(
-    deps: &mut DepsMut,
+    mut deps: DepsMut,
     info: &MessageInfo,
     env: &Env,
     ctx: &Option<AMPPkt>,

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -1,10 +1,12 @@
+use crate::ado_base::permissioning::LocalPermission;
+use crate::os::aos_querier::AOSQuerier;
 use crate::{
     ado_base::permissioning::{Permission, PermissionInfo, PermissioningMessage},
     amp::{messages::AMPPkt, AndrAddr},
     common::{context::ExecuteContext, OrderBy},
     error::ContractError,
 };
-use cosmwasm_std::{ensure, Deps, Env, MessageInfo, Order, Response, Storage};
+use cosmwasm_std::{ensure, Deps, DepsMut, Env, MessageInfo, Order, Response, Storage};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, MultiIndex};
 
 use super::ADOContract;
@@ -70,7 +72,7 @@ impl<'a> ADOContract<'a> {
     /// Returns an error if the given action is not permissioned for the given actor
     pub fn is_permissioned(
         &self,
-        store: &mut dyn Storage,
+        deps: DepsMut,
         env: Env,
         action: impl Into<String>,
         actor: impl Into<String>,
@@ -79,35 +81,85 @@ impl<'a> ADOContract<'a> {
         let action_string: String = action.into();
         let actor_string: String = actor.into();
 
-        if self.is_contract_owner(store, actor_string.as_str())? {
+        if self.is_contract_owner(deps.storage, actor_string.as_str())? {
             return Ok(());
         }
 
-        let permission = Self::get_permission(store, action_string.clone(), actor_string.clone())?;
+        let permission =
+            Self::get_permission(deps.storage, action_string.clone(), actor_string.clone())?;
         let permissioned_action = self
             .permissioned_actions
-            .may_load(store, action_string.clone())?
+            .may_load(deps.storage, action_string.clone())?
             .unwrap_or(false);
         match permission {
             Some(mut permission) => {
-                ensure!(
-                    permission.is_permissioned(&env, permissioned_action),
-                    ContractError::Unauthorized {}
-                );
+                match permission {
+                    Permission::Local(mut local_permission) => {
+                        ensure!(
+                            local_permission.is_permissioned(&env, permissioned_action),
+                            ContractError::Unauthorized {}
+                        );
 
-                // Consume a use for a limited permission
-                if let Permission::Limited { .. } = permission {
-                    permission.consume_use()?;
-                    permissions().save(
-                        store,
-                        (action_string.clone() + actor_string.as_str()).as_str(),
-                        &PermissionInfo {
-                            action: action_string,
-                            actor: actor_string,
-                            permission,
-                        },
-                    )?;
-                }
+                        // Consume a use for a limited permission
+                        if let LocalPermission::Limited { .. } = local_permission {
+                            local_permission.consume_use()?;
+                            permissions().save(
+                                deps.storage,
+                                (action_string.clone() + actor_string.as_str()).as_str(),
+                                &PermissionInfo {
+                                    action: action_string,
+                                    actor: actor_string,
+                                    permission,
+                                },
+                            )?;
+                        }
+                    }
+                    Permission::Contract(address_list) => {
+                        // Query address list contract
+                        let addr = address_list.get_raw_address(&deps.as_ref())?;
+                        let mut local_permission =
+                            AOSQuerier::get_permission(&deps.querier, &addr, &actor.into())?;
+
+                        ensure!(
+                            local_permission.is_permissioned(&env, permissioned_action),
+                            ContractError::Unauthorized {}
+                        );
+
+                        if let LocalPermission::Limited { .. } = local_permission {
+                            local_permission.consume_use()?;
+                            // TODO Save updated local_permission in address_list contract
+
+                            permissions().save(
+                                deps.storage,
+                                (action_string.clone() + actor_string.as_str()).as_str(),
+                                &PermissionInfo {
+                                    action: action_string,
+                                    actor: actor_string,
+                                    permission,
+                                },
+                            )?;
+                        }
+                    }
+                };
+                // ensure!(
+                //     local_permission.is_permissioned(&env, permissioned_action),
+                //     ContractError::Unauthorized {}
+                // );
+
+                // // Consume a use for a limited permission
+                // // TODO make a case for Contract permissions
+                // if let LocalPermission::Limited { .. } = local_permission {
+                //     local_permission.consume_use()?;
+                //     permissions().save(
+                //         deps.storage,
+                //         (action_string.clone() + actor_string.as_str()).as_str(),
+                //         &PermissionInfo {
+                //             action: action_string,
+                //             actor: actor_string,
+                //             permission,
+                //         },
+                //     )?;
+                // }
 
                 Ok(())
             }
@@ -141,24 +193,69 @@ impl<'a> ADOContract<'a> {
         let permission = Self::get_permission(store, action_string.clone(), actor_string.clone())?;
         match permission {
             Some(mut permission) => {
-                ensure!(
-                    permission.is_permissioned(&env, true),
-                    ContractError::Unauthorized {}
-                );
+                match permission {
+                    Permission::Local(local_permission) => {
+                        ensure!(
+                            local_permission.is_permissioned(&env, true),
+                            ContractError::Unauthorized {}
+                        );
 
-                // Consume a use for a limited permission
-                if let Permission::Limited { .. } = permission {
-                    permission.consume_use()?;
-                    permissions().save(
-                        store,
-                        (action_string.clone() + actor_string.as_str()).as_str(),
-                        &PermissionInfo {
-                            action: action_string,
-                            actor: actor_string,
-                            permission,
-                        },
-                    )?;
+                        // Consume a use for a limited permission
+                        if let LocalPermission::Limited { .. } = local_permission {
+                            local_permission.consume_use()?;
+                            permissions().save(
+                                store,
+                                (action_string.clone() + actor_string.as_str()).as_str(),
+                                &PermissionInfo {
+                                    action: action_string,
+                                    actor: actor_string,
+                                    permission,
+                                },
+                            )?;
+                        }
+                    }
+                    Permission::Contract(address_list) => {
+                        let addr = address_list.get_raw_address(&deps.as_ref())?;
+                        let mut local_permission =
+                            AOSQuerier::get_permission(&deps.querier, &addr, &actor.into())?;
+                        ensure!(
+                            local_permission.is_permissioned(&env, true),
+                            ContractError::Unauthorized {}
+                        );
+
+                        // Consume a use for a limited permission
+                        if let LocalPermission::Limited { .. } = local_permission {
+                            local_permission.consume_use()?;
+                            permissions().save(
+                                store,
+                                (action_string.clone() + actor_string.as_str()).as_str(),
+                                &PermissionInfo {
+                                    action: action_string,
+                                    actor: actor_string,
+                                    permission,
+                                },
+                            )?;
+                        }
+                    }
                 }
+                // ensure!(
+                //     permission.is_permissioned(&env, true),
+                //     ContractError::Unauthorized {}
+                // );
+
+                // // Consume a use for a limited permission
+                // if let Permission::Limited { .. } = permission {
+                //     permission.consume_use()?;
+                //     permissions().save(
+                //         store,
+                //         (action_string.clone() + actor_string.as_str()).as_str(),
+                //         &PermissionInfo {
+                //             action: action_string,
+                //             actor: actor_string,
+                //             permission,
+                //         },
+                //     )?;
+                // }
 
                 Ok(())
             }
@@ -395,7 +492,7 @@ impl<'a> ADOContract<'a> {
 /// - The context does not contain any AMP context and the **sender** is the actor
 /// - The context contains AMP context and the **previous sender** or **origin** are considered the actor
 pub fn is_context_permissioned(
-    storage: &mut dyn Storage,
+    deps: DepsMut,
     info: &MessageInfo,
     env: &Env,
     ctx: &Option<AMPPkt>,
@@ -407,13 +504,13 @@ pub fn is_context_permissioned(
         Some(amp_ctx) => {
             let action: String = action.into();
             let is_origin_permissioned = contract.is_permissioned(
-                storage,
+                deps,
                 env.clone(),
                 action.clone(),
                 amp_ctx.ctx.get_origin().as_str(),
             );
             let is_previous_sender_permissioned = contract.is_permissioned(
-                storage,
+                deps,
                 env.clone(),
                 action,
                 amp_ctx.ctx.get_previous_sender().as_str(),
@@ -421,7 +518,7 @@ pub fn is_context_permissioned(
             Ok(is_origin_permissioned.is_ok() || is_previous_sender_permissioned.is_ok())
         }
         None => Ok(contract
-            .is_permissioned(storage, env.clone(), action, info.sender.to_string())
+            .is_permissioned(deps, env.clone(), action, info.sender.to_string())
             .is_ok()),
     }
 }
@@ -463,598 +560,598 @@ pub fn is_context_permissioned_strict(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use cosmwasm_std::{
-        testing::{mock_dependencies, mock_env, mock_info},
-        Addr,
-    };
-
-    use crate::{
-        ado_base::AndromedaMsg,
-        amp::messages::AMPPkt,
-        common::{expiration::Expiry, MillisecondsExpiration},
-    };
-
-    use super::*;
-
-    #[test]
-    fn test_permissioned_action() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let action = "action";
-        let actor = "actor";
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-
-        ADOContract::default()
-            .permission_action(action, deps.as_mut().storage)
-            .unwrap();
-
-        // Test Whitelisting
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-
-        assert!(res.is_err());
-        let permission = Permission::whitelisted(None);
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-
-        assert!(res.is_ok());
-
-        ADOContract::remove_permission(deps.as_mut().storage, action, actor).unwrap();
-
-        // Test Limited
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-
-        assert!(res.is_err());
-        let permission = Permission::limited(None, 1);
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-
-        assert!(res.is_ok());
-
-        // Ensure use is consumed
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-        assert!(res.is_err());
-
-        ADOContract::remove_permission(deps.as_mut().storage, action, actor).unwrap();
-
-        // Test Blacklisted
-        let permission = Permission::blacklisted(None);
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
-
-        assert!(res.is_err());
-    }
-
-    #[test]
-    fn test_unpermissioned_action_blacklisted() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let action = "action";
-        let actor = "actor";
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-
-        ADOContract::default()
-            .permission_action(action, deps.as_mut().storage)
-            .unwrap();
-
-        // Test Blacklisted
-        let permission = Permission::blacklisted(None);
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
-
-        assert!(res.is_err());
-    }
-
-    #[test]
-    fn test_strict_permissioning() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let action = "action";
-        let actor = "actor";
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-
-        let res =
-            contract.is_permissioned_strict(deps.as_mut().storage, env.clone(), action, actor);
-        assert!(res.is_err());
-
-        let permission = Permission::whitelisted(None);
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned_strict(deps.as_mut().storage, env, action, actor);
-        assert!(res.is_ok());
-    }
-
-    #[test]
-    fn test_owner_escape_clause() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let action = "action";
-        let actor = "actor";
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked(actor))
-            .unwrap();
-
-        let res =
-            contract.is_permissioned_strict(deps.as_mut().storage, env.clone(), action, actor);
-        assert!(res.is_ok());
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
-        assert!(res.is_ok());
-    }
-
-    #[test]
-    fn test_set_permission_unauthorized() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-        let msg = AndromedaMsg::Permissioning(PermissioningMessage::SetPermission {
-            actor: AndrAddr::from_string("actor"),
-            action: "action".to_string(),
-            permission: Permission::Whitelisted(None),
-        });
-        let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
-        let res = contract.execute(ctx, msg);
-
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
-    }
-
-    #[test]
-    fn test_permission_action_unauthorized() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-        let msg = AndromedaMsg::Permissioning(PermissioningMessage::PermissionAction {
-            action: "action".to_string(),
-        });
-        let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
-        let res = contract.execute(ctx, msg);
-
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
-    }
-
-    #[test]
-    fn test_disable_permissioning_unauthorized() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-        let msg = AndromedaMsg::Permissioning(PermissioningMessage::DisableActionPermissioning {
-            action: "action".to_string(),
-        });
-        let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
-        let res = contract.execute(ctx, msg);
-
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
-    }
-
-    #[test]
-    fn test_remove_permission_unauthorized() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let contract = ADOContract::default();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-        let msg = AndromedaMsg::Permissioning(PermissioningMessage::RemovePermission {
-            action: "action".to_string(),
-            actor: AndrAddr::from_string("actor"),
-        });
-        let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
-        let res = contract.execute(ctx, msg);
-
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
-    }
-
-    #[test]
-    fn test_permission_expiration() {
-        let mut deps = mock_dependencies();
-        let mut env = mock_env();
-        env.block.height = 0;
-        let action = "action";
-        let actor = "actor";
-        let contract = ADOContract::default();
-        let time = 2;
-        let expiration = Expiry::AtTime(MillisecondsExpiration::from_seconds(time));
-
-        env.block.time = MillisecondsExpiration::from_seconds(0).into();
-        contract
-            .owner
-            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
-            .unwrap();
-
-        ADOContract::default()
-            .permission_action(action, deps.as_mut().storage)
-            .unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-
-        assert!(res.is_err());
-
-        // Test Whitelist
-        let permission = Permission::Whitelisted(Some(expiration.clone()));
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-        assert!(res.is_ok());
-
-        env.block.time = MillisecondsExpiration::from_seconds(time + 1).into();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-        assert!(res.is_err());
-
-        env.block.time = MillisecondsExpiration::from_seconds(0).into();
-        // Test Blacklist
-        let permission = Permission::Blacklisted(Some(expiration));
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
-        assert!(res.is_err());
-
-        env.block.time = MillisecondsExpiration::from_seconds(time + 1).into();
-
-        let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
-        assert!(res.is_ok());
-    }
-
-    #[test]
-    fn test_context_permissions() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let actor = "actor";
-        let info = mock_info(actor, &[]);
-        let action = "action";
-
-        let context = ExecuteContext::new(deps.as_mut(), info.clone(), env.clone());
-        let contract = ADOContract::default();
-
-        contract
-            .owner
-            .save(context.deps.storage, &Addr::unchecked("owner"))
-            .unwrap();
-
-        assert!(is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let context = ExecuteContext::new(deps.as_mut(), info.clone(), env.clone());
-        ADOContract::default()
-            .permission_action(action, context.deps.storage)
-            .unwrap();
-
-        assert!(!is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let context = ExecuteContext::new(deps.as_mut(), info, env.clone());
-        let permission = Permission::whitelisted(None);
-        ADOContract::set_permission(context.deps.storage, action, actor, permission).unwrap();
-
-        assert!(is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let unauth_info = mock_info("mock_actor", &[]);
-        let context = ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone());
-
-        assert!(!is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new("mock_actor", actor, vec![]);
-        let context =
-            ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
-
-        assert!(is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new(actor, "mock_actor", vec![]);
-        let context =
-            ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
-
-        assert!(is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new("mock_actor", "mock_actor", vec![]);
-        let context =
-            ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
-
-        assert!(!is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new("owner", "mock_actor", vec![]);
-        let context =
-            ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
-
-        assert!(is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new("mock_actor", "owner", vec![]);
-        let context = ExecuteContext::new(deps.as_mut(), unauth_info, env).with_ctx(amp_ctx);
-
-        assert!(is_context_permissioned(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-    }
-
-    #[test]
-    fn test_context_permissions_strict() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let actor = "actor";
-        let info = mock_info(actor, &[]);
-        let action = "action";
-
-        let context = ExecuteContext::new(deps.as_mut(), info.clone(), env.clone());
-        let contract = ADOContract::default();
-
-        contract
-            .owner
-            .save(context.deps.storage, &Addr::unchecked("owner"))
-            .unwrap();
-
-        assert!(!is_context_permissioned_strict(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let context = ExecuteContext::new(deps.as_mut(), info, env.clone());
-        let permission = Permission::whitelisted(None);
-        ADOContract::set_permission(context.deps.storage, action, actor, permission).unwrap();
-
-        assert!(is_context_permissioned_strict(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let unauth_info = mock_info("mock_actor", &[]);
-        let context = ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone());
-
-        assert!(!is_context_permissioned_strict(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new("mock_actor", actor, vec![]);
-        let context =
-            ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
-
-        assert!(is_context_permissioned_strict(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new(actor, "mock_actor", vec![]);
-        let context =
-            ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
-
-        assert!(is_context_permissioned_strict(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-
-        let amp_ctx = AMPPkt::new("mock_actor", "mock_actor", vec![]);
-        let context = ExecuteContext::new(deps.as_mut(), unauth_info, env).with_ctx(amp_ctx);
-
-        assert!(!is_context_permissioned_strict(
-            context.deps.storage,
-            &context.info,
-            &context.env,
-            &context.amp_ctx,
-            action
-        )
-        .unwrap());
-    }
-
-    #[test]
-    fn test_query_permissions() {
-        let actor = "actor";
-        let mut deps = mock_dependencies();
-
-        let permissions = ADOContract::default()
-            .query_permissions(deps.as_ref(), actor, None, None)
-            .unwrap();
-
-        assert!(permissions.is_empty());
-
-        let permission = Permission::whitelisted(None);
-        let action = "action";
-
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, permission.clone())
-            .unwrap();
-
-        let permissions = ADOContract::default()
-            .query_permissions(deps.as_ref(), actor, None, None)
-            .unwrap();
-
-        assert_eq!(permissions.len(), 1);
-        assert_eq!(permissions[0].action, action);
-        assert_eq!(permissions[0].permission, permission);
-
-        let multi_permissions = vec![
-            ("action2".to_string(), Permission::blacklisted(None)),
-            ("action3".to_string(), Permission::whitelisted(None)),
-            ("action4".to_string(), Permission::blacklisted(None)),
-            ("action5".to_string(), Permission::whitelisted(None)),
-        ];
-
-        for (action, permission) in multi_permissions {
-            ADOContract::set_permission(deps.as_mut().storage, &action, actor, permission).unwrap();
-        }
-
-        let permissions = ADOContract::default()
-            .query_permissions(deps.as_ref(), actor, None, None)
-            .unwrap();
-
-        assert_eq!(permissions.len(), 5);
-    }
-
-    #[test]
-    fn test_query_permissioned_actions() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let info = mock_info("owner", &[]);
-        let ctx = ExecuteContext {
-            deps: deps.as_mut(),
-            env,
-            info: info.clone(),
-            amp_ctx: None,
-        };
-
-        let contract = ADOContract::default();
-
-        contract.owner.save(ctx.deps.storage, &info.sender).unwrap();
-
-        let actions = ADOContract::default()
-            .query_permissioned_actions(ctx.deps.as_ref())
-            .unwrap();
-
-        assert!(actions.is_empty());
-
-        ADOContract::default()
-            .execute_permission_action(ctx, "action")
-            .unwrap();
-
-        let actions = ADOContract::default()
-            .query_permissioned_actions(deps.as_ref())
-            .unwrap();
-
-        assert_eq!(actions.len(), 1);
-        assert_eq!(actions[0], "action");
-    }
-
-    #[test]
-    fn test_query_permissioned_actors() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let info = mock_info("owner", &[]);
-        let ctx = ExecuteContext {
-            deps: deps.as_mut(),
-            env,
-            info: info.clone(),
-            amp_ctx: None,
-        };
-
-        let contract = ADOContract::default();
-
-        contract.owner.save(ctx.deps.storage, &info.sender).unwrap();
-
-        let actor = "actor";
-        let action = "action";
-        ADOContract::default()
-            .execute_permission_action(ctx, action)
-            .unwrap();
-
-        ADOContract::set_permission(deps.as_mut().storage, action, actor, Permission::default())
-            .unwrap();
-        let actors = ADOContract::default()
-            .query_permissioned_actors(deps.as_ref(), action, None, None, None)
-            .unwrap();
-
-        assert_eq!(actors.len(), 1);
-        assert_eq!(actors[0], actor);
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use cosmwasm_std::{
+//         testing::{mock_dependencies, mock_env, mock_info},
+//         Addr,
+//     };
+
+//     use crate::{
+//         ado_base::AndromedaMsg,
+//         amp::messages::AMPPkt,
+//         common::{expiration::Expiry, MillisecondsExpiration},
+//     };
+
+//     use super::*;
+
+//     #[test]
+//     fn test_permissioned_action() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let action = "action";
+//         let actor = "actor";
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+
+//         ADOContract::default()
+//             .permission_action(action, deps.as_mut().storage)
+//             .unwrap();
+
+//         // Test Whitelisting
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+
+//         assert!(res.is_err());
+//         let permission = Permission::whitelisted(None);
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+
+//         assert!(res.is_ok());
+
+//         ADOContract::remove_permission(deps.as_mut().storage, action, actor).unwrap();
+
+//         // Test Limited
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+
+//         assert!(res.is_err());
+//         let permission = Permission::limited(None, 1);
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+
+//         assert!(res.is_ok());
+
+//         // Ensure use is consumed
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+//         assert!(res.is_err());
+
+//         ADOContract::remove_permission(deps.as_mut().storage, action, actor).unwrap();
+
+//         // Test Blacklisted
+//         let permission = Permission::blacklisted(None);
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
+
+//         assert!(res.is_err());
+//     }
+
+//     #[test]
+//     fn test_unpermissioned_action_blacklisted() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let action = "action";
+//         let actor = "actor";
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+
+//         ADOContract::default()
+//             .permission_action(action, deps.as_mut().storage)
+//             .unwrap();
+
+//         // Test Blacklisted
+//         let permission = Permission::blacklisted(None);
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
+
+//         assert!(res.is_err());
+//     }
+
+//     #[test]
+//     fn test_strict_permissioning() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let action = "action";
+//         let actor = "actor";
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+
+//         let res =
+//             contract.is_permissioned_strict(deps.as_mut().storage, env.clone(), action, actor);
+//         assert!(res.is_err());
+
+//         let permission = Permission::whitelisted(None);
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned_strict(deps.as_mut().storage, env, action, actor);
+//         assert!(res.is_ok());
+//     }
+
+//     #[test]
+//     fn test_owner_escape_clause() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let action = "action";
+//         let actor = "actor";
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked(actor))
+//             .unwrap();
+
+//         let res =
+//             contract.is_permissioned_strict(deps.as_mut().storage, env.clone(), action, actor);
+//         assert!(res.is_ok());
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
+//         assert!(res.is_ok());
+//     }
+
+//     #[test]
+//     fn test_set_permission_unauthorized() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+//         let msg = AndromedaMsg::Permissioning(PermissioningMessage::SetPermission {
+//             actor: AndrAddr::from_string("actor"),
+//             action: "action".to_string(),
+//             permission: Permission::Whitelisted(None),
+//         });
+//         let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
+//         let res = contract.execute(ctx, msg);
+
+//         assert!(res.is_err());
+//         assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
+//     }
+
+//     #[test]
+//     fn test_permission_action_unauthorized() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+//         let msg = AndromedaMsg::Permissioning(PermissioningMessage::PermissionAction {
+//             action: "action".to_string(),
+//         });
+//         let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
+//         let res = contract.execute(ctx, msg);
+
+//         assert!(res.is_err());
+//         assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
+//     }
+
+//     #[test]
+//     fn test_disable_permissioning_unauthorized() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+//         let msg = AndromedaMsg::Permissioning(PermissioningMessage::DisableActionPermissioning {
+//             action: "action".to_string(),
+//         });
+//         let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
+//         let res = contract.execute(ctx, msg);
+
+//         assert!(res.is_err());
+//         assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
+//     }
+
+//     #[test]
+//     fn test_remove_permission_unauthorized() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let contract = ADOContract::default();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+//         let msg = AndromedaMsg::Permissioning(PermissioningMessage::RemovePermission {
+//             action: "action".to_string(),
+//             actor: AndrAddr::from_string("actor"),
+//         });
+//         let ctx = ExecuteContext::new(deps.as_mut(), mock_info("attacker", &[]), env);
+//         let res = contract.execute(ctx, msg);
+
+//         assert!(res.is_err());
+//         assert_eq!(res.unwrap_err(), ContractError::Unauthorized {});
+//     }
+
+//     #[test]
+//     fn test_permission_expiration() {
+//         let mut deps = mock_dependencies();
+//         let mut env = mock_env();
+//         env.block.height = 0;
+//         let action = "action";
+//         let actor = "actor";
+//         let contract = ADOContract::default();
+//         let time = 2;
+//         let expiration = Expiry::AtTime(MillisecondsExpiration::from_seconds(time));
+
+//         env.block.time = MillisecondsExpiration::from_seconds(0).into();
+//         contract
+//             .owner
+//             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+//             .unwrap();
+
+//         ADOContract::default()
+//             .permission_action(action, deps.as_mut().storage)
+//             .unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+
+//         assert!(res.is_err());
+
+//         // Test Whitelist
+//         let permission = Permission::Whitelisted(Some(expiration.clone()));
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+//         assert!(res.is_ok());
+
+//         env.block.time = MillisecondsExpiration::from_seconds(time + 1).into();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+//         assert!(res.is_err());
+
+//         env.block.time = MillisecondsExpiration::from_seconds(0).into();
+//         // Test Blacklist
+//         let permission = Permission::Blacklisted(Some(expiration));
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission).unwrap();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env.clone(), action, actor);
+//         assert!(res.is_err());
+
+//         env.block.time = MillisecondsExpiration::from_seconds(time + 1).into();
+
+//         let res = contract.is_permissioned(deps.as_mut().storage, env, action, actor);
+//         assert!(res.is_ok());
+//     }
+
+//     #[test]
+//     fn test_context_permissions() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let actor = "actor";
+//         let info = mock_info(actor, &[]);
+//         let action = "action";
+
+//         let context = ExecuteContext::new(deps.as_mut(), info.clone(), env.clone());
+//         let contract = ADOContract::default();
+
+//         contract
+//             .owner
+//             .save(context.deps.storage, &Addr::unchecked("owner"))
+//             .unwrap();
+
+//         assert!(is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let context = ExecuteContext::new(deps.as_mut(), info.clone(), env.clone());
+//         ADOContract::default()
+//             .permission_action(action, context.deps.storage)
+//             .unwrap();
+
+//         assert!(!is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let context = ExecuteContext::new(deps.as_mut(), info, env.clone());
+//         let permission = Permission::whitelisted(None);
+//         ADOContract::set_permission(context.deps.storage, action, actor, permission).unwrap();
+
+//         assert!(is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let unauth_info = mock_info("mock_actor", &[]);
+//         let context = ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone());
+
+//         assert!(!is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new("mock_actor", actor, vec![]);
+//         let context =
+//             ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
+
+//         assert!(is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new(actor, "mock_actor", vec![]);
+//         let context =
+//             ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
+
+//         assert!(is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new("mock_actor", "mock_actor", vec![]);
+//         let context =
+//             ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
+
+//         assert!(!is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new("owner", "mock_actor", vec![]);
+//         let context =
+//             ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
+
+//         assert!(is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new("mock_actor", "owner", vec![]);
+//         let context = ExecuteContext::new(deps.as_mut(), unauth_info, env).with_ctx(amp_ctx);
+
+//         assert!(is_context_permissioned(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+//     }
+
+//     #[test]
+//     fn test_context_permissions_strict() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let actor = "actor";
+//         let info = mock_info(actor, &[]);
+//         let action = "action";
+
+//         let context = ExecuteContext::new(deps.as_mut(), info.clone(), env.clone());
+//         let contract = ADOContract::default();
+
+//         contract
+//             .owner
+//             .save(context.deps.storage, &Addr::unchecked("owner"))
+//             .unwrap();
+
+//         assert!(!is_context_permissioned_strict(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let context = ExecuteContext::new(deps.as_mut(), info, env.clone());
+//         let permission = Permission::whitelisted(None);
+//         ADOContract::set_permission(context.deps.storage, action, actor, permission).unwrap();
+
+//         assert!(is_context_permissioned_strict(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let unauth_info = mock_info("mock_actor", &[]);
+//         let context = ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone());
+
+//         assert!(!is_context_permissioned_strict(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new("mock_actor", actor, vec![]);
+//         let context =
+//             ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
+
+//         assert!(is_context_permissioned_strict(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new(actor, "mock_actor", vec![]);
+//         let context =
+//             ExecuteContext::new(deps.as_mut(), unauth_info.clone(), env.clone()).with_ctx(amp_ctx);
+
+//         assert!(is_context_permissioned_strict(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+
+//         let amp_ctx = AMPPkt::new("mock_actor", "mock_actor", vec![]);
+//         let context = ExecuteContext::new(deps.as_mut(), unauth_info, env).with_ctx(amp_ctx);
+
+//         assert!(!is_context_permissioned_strict(
+//             context.deps.storage,
+//             &context.info,
+//             &context.env,
+//             &context.amp_ctx,
+//             action
+//         )
+//         .unwrap());
+//     }
+
+//     #[test]
+//     fn test_query_permissions() {
+//         let actor = "actor";
+//         let mut deps = mock_dependencies();
+
+//         let permissions = ADOContract::default()
+//             .query_permissions(deps.as_ref(), actor, None, None)
+//             .unwrap();
+
+//         assert!(permissions.is_empty());
+
+//         let permission = Permission::whitelisted(None);
+//         let action = "action";
+
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, permission.clone())
+//             .unwrap();
+
+//         let permissions = ADOContract::default()
+//             .query_permissions(deps.as_ref(), actor, None, None)
+//             .unwrap();
+
+//         assert_eq!(permissions.len(), 1);
+//         assert_eq!(permissions[0].action, action);
+//         assert_eq!(permissions[0].permission, permission);
+
+//         let multi_permissions = vec![
+//             ("action2".to_string(), Permission::blacklisted(None)),
+//             ("action3".to_string(), Permission::whitelisted(None)),
+//             ("action4".to_string(), Permission::blacklisted(None)),
+//             ("action5".to_string(), Permission::whitelisted(None)),
+//         ];
+
+//         for (action, permission) in multi_permissions {
+//             ADOContract::set_permission(deps.as_mut().storage, &action, actor, permission).unwrap();
+//         }
+
+//         let permissions = ADOContract::default()
+//             .query_permissions(deps.as_ref(), actor, None, None)
+//             .unwrap();
+
+//         assert_eq!(permissions.len(), 5);
+//     }
+
+//     #[test]
+//     fn test_query_permissioned_actions() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let info = mock_info("owner", &[]);
+//         let ctx = ExecuteContext {
+//             deps: deps.as_mut(),
+//             env,
+//             info: info.clone(),
+//             amp_ctx: None,
+//         };
+
+//         let contract = ADOContract::default();
+
+//         contract.owner.save(ctx.deps.storage, &info.sender).unwrap();
+
+//         let actions = ADOContract::default()
+//             .query_permissioned_actions(ctx.deps.as_ref())
+//             .unwrap();
+
+//         assert!(actions.is_empty());
+
+//         ADOContract::default()
+//             .execute_permission_action(ctx, "action")
+//             .unwrap();
+
+//         let actions = ADOContract::default()
+//             .query_permissioned_actions(deps.as_ref())
+//             .unwrap();
+
+//         assert_eq!(actions.len(), 1);
+//         assert_eq!(actions[0], "action");
+//     }
+
+//     #[test]
+//     fn test_query_permissioned_actors() {
+//         let mut deps = mock_dependencies();
+//         let env = mock_env();
+//         let info = mock_info("owner", &[]);
+//         let ctx = ExecuteContext {
+//             deps: deps.as_mut(),
+//             env,
+//             info: info.clone(),
+//             amp_ctx: None,
+//         };
+
+//         let contract = ADOContract::default();
+
+//         contract.owner.save(ctx.deps.storage, &info.sender).unwrap();
+
+//         let actor = "actor";
+//         let action = "action";
+//         ADOContract::default()
+//             .execute_permission_action(ctx, action)
+//             .unwrap();
+
+//         ADOContract::set_permission(deps.as_mut().storage, action, actor, Permission::default())
+//             .unwrap();
+//         let actors = ADOContract::default()
+//             .query_permissioned_actors(deps.as_ref(), action, None, None, None)
+//             .unwrap();
+
+//         assert_eq!(actors.len(), 1);
+//         assert_eq!(actors[0], actor);
+//     }
+// }

--- a/packages/std/src/common/actions.rs
+++ b/packages/std/src/common/actions.rs
@@ -6,14 +6,14 @@ use crate::{
 use cosmwasm_std::{ensure, DepsMut, Env, MessageInfo, Response};
 
 pub fn call_action(
-    deps: &mut DepsMut,
+    deps: DepsMut,
     info: &MessageInfo,
     env: &Env,
     amp_ctx: &Option<AMPPkt>,
     action: &str,
 ) -> Result<Response, ContractError> {
     ensure!(
-        is_context_permissioned(deps.storage, info, env, amp_ctx, action)?,
+        is_context_permissioned(deps, info, env, amp_ctx, action)?,
         ContractError::Unauthorized {}
     );
 

--- a/packages/std/src/common/actions.rs
+++ b/packages/std/src/common/actions.rs
@@ -6,7 +6,7 @@ use crate::{
 use cosmwasm_std::{ensure, DepsMut, Env, MessageInfo, Response};
 
 pub fn call_action(
-    deps: DepsMut,
+    deps: &mut DepsMut,
     info: &MessageInfo,
     env: &Env,
     amp_ctx: &Option<AMPPkt>,

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -28,7 +28,7 @@ impl Asset {
                     ContractError::InvalidZeroAmount {}
                 );
                 let valid_cw20_auction = ADOContract::default()
-                    .is_permissioned(deps.storage, env, SEND_CW20_ACTION, cw20_token.clone())
+                    .is_permissioned(deps, env, SEND_CW20_ACTION, cw20_token.clone())
                     .is_ok();
                 ensure!(
                     valid_cw20_auction,

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -1,4 +1,4 @@
-use crate::ado_base::permissioning::Permission;
+use crate::ado_base::permissioning::LocalPermission;
 use crate::amp::{ADO_DB_KEY, VFS_KEY};
 use crate::error::ContractError;
 use cosmwasm_schema::cw_serde;
@@ -218,9 +218,9 @@ impl AOSQuerier {
         querier: &QuerierWrapper,
         contract_addr: &Addr,
         actor: &str,
-    ) -> Result<Permission, ContractError> {
+    ) -> Result<LocalPermission, ContractError> {
         let key = AOSQuerier::get_map_storage_key("permissioning", &[actor.as_bytes()])?;
-        let permission: Option<Permission> =
+        let permission: Option<LocalPermission> =
             AOSQuerier::query_storage(querier, contract_addr, key.as_str())?;
         match permission {
             Some(permission) => Ok(permission),

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -17,7 +17,7 @@ use andromeda_splitter::mock::{
 };
 use andromeda_std::{
     ado_base::{
-        permissioning::Permission,
+        permissioning::{LocalPermission, Permission},
         rates::{LocalRate, LocalRateType, LocalRateValue, PercentRate, Rate},
     },
     amp::{AndrAddr, Recipient},
@@ -603,7 +603,7 @@ fn test_auction_app_cw20_restricted() {
     // Blacklist bidder now
     let actor = AndrAddr::from_string(buyer_one.clone());
     let action = "PlaceBid".to_string();
-    let permission = Permission::blacklisted(None);
+    let permission = Permission::Local(LocalPermission::blacklisted(None));
     auction
         .execute_set_permission(&mut router, owner.clone(), actor, action, permission)
         .unwrap();
@@ -626,7 +626,7 @@ fn test_auction_app_cw20_restricted() {
     // Now whitelist bidder one
     let actor = AndrAddr::from_string(buyer_one.clone());
     let action = "PlaceBid".to_string();
-    let permission = Permission::whitelisted(None);
+    let permission = Permission::Local(LocalPermission::whitelisted(None));
     auction
         .execute_set_permission(&mut router, owner.clone(), actor, action, permission)
         .unwrap();

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -235,5 +235,5 @@ fn test_crowdfund_app() {
         )
         .unwrap();
 
-    assert_eq!(ado_base_version.version, "1.0.0".to_string())
+    assert_eq!(ado_base_version.version, "1.1.0".to_string())
 }

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -12,21 +12,21 @@ use andromeda_marketplace::mock::{
     mock_andromeda_marketplace, mock_buy_token, mock_marketplace_instantiate_msg,
     mock_receive_packet, mock_start_sale, MockMarketplace,
 };
-use andromeda_std::ado_base::permissioning::{LocalPermission, Permission};
-use andromeda_std::ado_base::rates::{LocalRateType, LocalRateValue, PercentRate, Rate};
-
 use andromeda_non_fungible_tokens::marketplace::Cw20HookMsg;
 use andromeda_rates::mock::{mock_andromeda_rates, mock_rates_instantiate_msg, MockRates};
 use andromeda_splitter::mock::{
     mock_andromeda_splitter, mock_splitter_instantiate_msg, mock_splitter_send_msg,
 };
+use andromeda_std::ado_base::permissioning::{LocalPermission, Permission};
 use andromeda_std::ado_base::rates::LocalRate;
+use andromeda_std::ado_base::rates::{LocalRateType, LocalRateValue, PercentRate, Rate};
 use andromeda_std::amp::messages::{AMPMsg, AMPPkt};
 use andromeda_std::amp::{AndrAddr, Recipient};
 use andromeda_std::common::denom::Asset;
 use andromeda_std::error::ContractError;
 use andromeda_testing::mock::mock_app;
 use andromeda_testing::mock_builder::MockAndromedaBuilder;
+use andromeda_testing::MockADO;
 use andromeda_testing::MockContract;
 use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal, Uint128};
 use cw20::Cw20Coin;

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -12,7 +12,7 @@ use andromeda_marketplace::mock::{
     mock_andromeda_marketplace, mock_buy_token, mock_marketplace_instantiate_msg,
     mock_receive_packet, mock_start_sale, MockMarketplace,
 };
-use andromeda_std::ado_base::permissioning::Permission;
+use andromeda_std::ado_base::permissioning::LocalPermission;
 use andromeda_std::ado_base::rates::{LocalRateType, LocalRateValue, PercentRate, Rate};
 
 use andromeda_non_fungible_tokens::marketplace::Cw20HookMsg;
@@ -151,7 +151,7 @@ fn test_marketplace_app() {
             &mut router,
             owner.clone(),
             cw721.addr().clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -160,7 +160,7 @@ fn test_marketplace_app() {
             &mut router,
             owner.clone(),
             buyer.clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -544,7 +544,7 @@ fn test_marketplace_app_cw20_restricted() {
             &mut router,
             owner.clone(),
             cw721.addr().clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -553,7 +553,7 @@ fn test_marketplace_app_cw20_restricted() {
             &mut router,
             owner.clone(),
             cw20.addr().clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -562,7 +562,7 @@ fn test_marketplace_app_cw20_restricted() {
             &mut router,
             owner.clone(),
             buyer.clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -571,7 +571,7 @@ fn test_marketplace_app_cw20_restricted() {
             &mut router,
             owner.clone(),
             owner.clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -848,7 +848,7 @@ fn test_marketplace_app_cw20_unrestricted() {
             &mut router,
             owner.clone(),
             cw721.addr().clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -857,7 +857,7 @@ fn test_marketplace_app_cw20_unrestricted() {
             &mut router,
             owner.clone(),
             cw20.addr().clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -866,7 +866,7 @@ fn test_marketplace_app_cw20_unrestricted() {
             &mut router,
             owner.clone(),
             second_cw20.addr().clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -875,7 +875,7 @@ fn test_marketplace_app_cw20_unrestricted() {
             &mut router,
             owner.clone(),
             buyer.clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 
@@ -884,7 +884,7 @@ fn test_marketplace_app_cw20_unrestricted() {
             &mut router,
             owner.clone(),
             owner.clone(),
-            Permission::whitelisted(None),
+            LocalPermission::whitelisted(None),
         )
         .unwrap();
 

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -180,6 +180,25 @@ fn test_marketplace_app() {
         chain_id: block_info.chain_id,
     });
 
+    // Try adding limited permission in address list, should error
+    let err: ContractError = address_list
+        .execute_actor_permission(
+            &mut router,
+            owner.clone(),
+            buyer.clone(),
+            LocalPermission::limited(None, 1),
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+
+    assert_eq!(
+        err,
+        ContractError::InvalidPermission {
+            msg: "Limited permission is not supported in address list contract".to_string(),
+        }
+    );
+
     // Blacklist buyer in address list
     address_list
         .execute_actor_permission(


### PR DESCRIPTION
# Motivation
Added the ability to reference an Address List contract to get its permissions, similar to the way it's done with rates.

# Implementation
`LocalPermission` is what used to be `Permission`, Contract references the address list contract.
```rust
pub enum Permission {
    Local(LocalPermission),
    Contract(AndrAddr),
}
```

In case of `Contract` permission, fetch it from the address list contract and then handle it like a `LocalPermission`.
```rust
    pub fn get_permission(
        querier: &QuerierWrapper,
        contract_addr: &Addr,
        actor: &str,
    ) -> Result<LocalPermission, ContractError> {
        let key = AOSQuerier::get_map_storage_key("permissioning", &[actor.as_bytes()])?;
        let permission: Option<LocalPermission> =
            AOSQuerier::query_storage(querier, contract_addr, key.as_str())?;
        match permission {
            Some(permission) => Ok(permission),
            None => Err(ContractError::InvalidAddress {}),
        }
    }
```
   
Limitation: `Limited` Permission is not supported on the address list contract since it requires state changes which significantly complicates the operation.
# Testing
Blacklisted address using `Contract` permission in Marketplace Integration Test, also tried adding `Limited` permission to address list.

# Notes
There's a heavy use of `.branch()`, would be nice if we can reduce our reliance on it.

# Future work
Could add `Limited` permission support for address list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated permissioning logic across various contracts and modules to use `LocalPermission` instead of `Permission`.
  - Modified function signatures and calls to handle the new `LocalPermission` type.

- **New Features**
  - Introduced the `LocalPermission` type to enhance permission management.

- **Documentation**
  - Updated `CHANGELOG.md` to include reference to the Address List contract changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->