### PR TITLE
feat: Skip running changelog check when labeled with 'ci: skip-changelog'

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,10 +9,9 @@ on:
     branches:
       - development
       - main
-
 jobs:
-  # Enforces the update of a changelog file on every pull request
   changelog:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
     runs-on: ubuntu-latest
     steps:
       - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ on:
       - main
 jobs:
   changelog:
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci: skip-changelog')"
     runs-on: ubuntu-latest
     steps:
       - uses: dangoslen/changelog-enforcer@v3


### PR DESCRIPTION
# Motivation
Currently all of our PRs to the development branch require a changelog entry. This change is to allow skipping this check (when necessary) by tagging the PR with 'ci: skip-changelog'

# Implementation

Explain the details of the change.

# Testing
Added the following line to `changelog.yml`:

```yaml
if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to skip changelog updates if the pull request is labeled with `'ci: skip-changelog'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->