### PR TITLE
fix: Apply Rates to TransferFrom and SendFrom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/mock.rs
@@ -1,6 +1,8 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::cw20::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::ado_base::rates::Rate;
+use andromeda_std::ado_base::rates::RatesMessage;
 use andromeda_std::amp::AndrAddr;
 use andromeda_testing::mock_contract::ExecuteResult;
 use andromeda_testing::MockADO;
@@ -68,6 +70,64 @@ impl MockCW20 {
         )
     }
 
+    pub fn execute_send_from(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        contract: impl Into<String>,
+        amount: Uint128,
+        owner: String,
+        msg: &impl Serialize,
+    ) -> ExecuteResult {
+        self.execute(
+            app,
+            &mock_cw20_send_from(contract, amount, owner, to_json_binary(msg).unwrap()),
+            sender,
+            &[],
+        )
+    }
+
+    pub fn execute_transfer_from(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        recipient: impl Into<String>,
+        amount: Uint128,
+        owner: String,
+    ) -> ExecuteResult {
+        self.execute(
+            app,
+            &mock_cw20_transfer_from(recipient, amount, owner),
+            sender,
+            &[],
+        )
+    }
+
+    pub fn execute_increase_allowance(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        spender: String,
+        amount: Uint128,
+    ) -> ExecuteResult {
+        self.execute(
+            app,
+            &mock_cw20_increase_allowance(spender, amount),
+            sender,
+            &[],
+        )
+    }
+
+    pub fn execute_add_rate(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        action: String,
+        rate: Rate,
+    ) -> ExecuteResult {
+        self.execute(app, &mock_set_rate_msg(action, rate), sender, &[])
+    }
+
     pub fn query_balance(&self, app: &MockApp, address: impl Into<String>) -> Uint128 {
         self.query::<BalanceResponse>(app, mock_get_cw20_balance(address))
             .balance
@@ -122,6 +182,44 @@ pub fn mock_cw20_send(contract: impl Into<String>, amount: Uint128, msg: Binary)
     }
 }
 
+pub fn mock_cw20_send_from(
+    contract: impl Into<String>,
+    amount: Uint128,
+    owner: String,
+    msg: Binary,
+) -> ExecuteMsg {
+    ExecuteMsg::SendFrom {
+        contract: AndrAddr::from_string(contract.into()),
+        amount,
+        msg,
+        owner,
+    }
+}
+
+pub fn mock_cw20_transfer_from(
+    contract: impl Into<String>,
+    amount: Uint128,
+    owner: String,
+) -> ExecuteMsg {
+    ExecuteMsg::TransferFrom {
+        recipient: AndrAddr::from_string(contract.into()),
+        amount,
+        owner,
+    }
+}
+
 pub fn mock_cw20_transfer(recipient: AndrAddr, amount: Uint128) -> ExecuteMsg {
     ExecuteMsg::Transfer { recipient, amount }
+}
+
+pub fn mock_cw20_increase_allowance(spender: String, amount: Uint128) -> ExecuteMsg {
+    ExecuteMsg::IncreaseAllowance {
+        spender,
+        amount,
+        expires: None,
+    }
+}
+
+pub fn mock_set_rate_msg(action: String, rate: Rate) -> ExecuteMsg {
+    ExecuteMsg::Rates(RatesMessage::SetRate { action, rate })
 }

--- a/tests-integration/tests/cw20_app.rs
+++ b/tests-integration/tests/cw20_app.rs
@@ -1,0 +1,148 @@
+#![cfg(not(target_arch = "wasm32"))]
+use andromeda_app::app::AppComponent;
+use andromeda_app_contract::mock::{mock_andromeda_app, mock_claim_ownership_msg, MockAppContract};
+use andromeda_cw20::mock::{mock_andromeda_cw20, mock_cw20_instantiate_msg, mock_minter, MockCW20};
+use andromeda_std::{
+    ado_base::rates::{LocalRate, LocalRateType, LocalRateValue, PercentRate, Rate},
+    amp::Recipient,
+};
+
+use andromeda_testing::{
+    mock::mock_app, mock_builder::MockAndromedaBuilder, mock_contract::MockContract,
+};
+use cosmwasm_std::{coin, to_json_binary, Addr, Decimal, Uint128};
+use cw20::Cw20Coin;
+use cw_multi_test::Executor;
+
+#[test]
+fn test_cw20_with_rates() {
+    let mut router = mock_app(None);
+    let andr = MockAndromedaBuilder::new(&mut router, "admin")
+        .with_wallets(vec![
+            ("owner", vec![]),
+            ("buyer_one", vec![coin(1000, "uandr")]),
+            ("buyer_two", vec![coin(1000, "uandr")]),
+            ("recipient_one", vec![]),
+            ("recipient_two", vec![]),
+        ])
+        .with_contracts(vec![
+            ("cw20", mock_andromeda_cw20()),
+            ("app-contract", mock_andromeda_app()),
+        ])
+        .build(&mut router);
+    let owner = andr.get_wallet("owner");
+    let buyer_one = andr.get_wallet("buyer_one");
+    let buyer_two = andr.get_wallet("buyer_two");
+    let recipient_one = andr.get_wallet("recipient_one");
+    let recipient_two = andr.get_wallet("recipient_two");
+
+    // Generate App Components
+    let initial_balances = vec![
+        Cw20Coin {
+            address: buyer_one.to_string(),
+            amount: Uint128::from(1000u128),
+        },
+        Cw20Coin {
+            address: buyer_two.to_string(),
+            amount: Uint128::from(2000u128),
+        },
+        Cw20Coin {
+            address: owner.to_string(),
+            amount: Uint128::from(10000u128),
+        },
+    ];
+    let buyer_two_original_balance = Uint128::from(2000u128);
+
+    let cw20_init_msg = mock_cw20_instantiate_msg(
+        None,
+        "Test Tokens".to_string(),
+        "TTT".to_string(),
+        6,
+        initial_balances,
+        Some(mock_minter(
+            owner.to_string(),
+            Some(Uint128::from(1000000u128)),
+        )),
+        andr.kernel.addr().to_string(),
+    );
+    let cw20_component = AppComponent::new(
+        "cw20".to_string(),
+        "cw20".to_string(),
+        to_json_binary(&cw20_init_msg).unwrap(),
+    );
+
+    // Create App
+    let app_components = vec![cw20_component.clone()];
+    let app = MockAppContract::instantiate(
+        andr.get_code_id(&mut router, "app-contract"),
+        owner,
+        &mut router,
+        "Auction App",
+        app_components,
+        andr.kernel.addr(),
+        Some(owner.to_string()),
+    );
+
+    router
+        .execute_contract(
+            owner.clone(),
+            Addr::unchecked(app.addr().clone()),
+            &mock_claim_ownership_msg(None),
+            &[],
+        )
+        .unwrap();
+
+    let cw20: MockCW20 = app.query_ado_by_component_name(&router, cw20_component.name);
+
+    // Set rates to SendFrom
+    cw20.execute_add_rate(
+        &mut router,
+        owner.clone(),
+        "Cw20TransferFrom".to_string(),
+        Rate::Local(LocalRate {
+            rate_type: LocalRateType::Deductive,
+            recipients: vec![
+                Recipient::new(recipient_one, None),
+                Recipient::new(recipient_two, None),
+            ],
+            value: LocalRateValue::Percent(PercentRate {
+                percent: Decimal::percent(10),
+            }),
+            description: None,
+        }),
+    )
+    .unwrap();
+
+    // Increase allowance for owner
+    cw20.execute_increase_allowance(
+        &mut router,
+        owner.clone(),
+        buyer_one.clone().into_string(),
+        Uint128::new(100000),
+    )
+    .unwrap();
+
+    // Execute SendFrom
+    cw20.execute_transfer_from(
+        &mut router,
+        buyer_one.clone(),
+        buyer_two,
+        Uint128::new(10),
+        owner.clone().into_string(),
+    )
+    .unwrap();
+    // Rates are 10% , so we expect a balance of one for recipients one and two and the leftover 8 will be sent to buyer two
+    let recip_one_balance = cw20.query_balance(&router, recipient_one);
+    assert_eq!(Uint128::one(), recip_one_balance);
+
+    let recip_two_balance = cw20.query_balance(&router, recipient_two);
+    assert_eq!(Uint128::one(), recip_two_balance);
+
+    let buyer_two_balance = cw20.query_balance(&router, buyer_two);
+    assert_eq!(
+        buyer_two_original_balance
+            .checked_add(Uint128::new(8))
+            .unwrap(),
+        buyer_two_balance
+    );
+}

--- a/tests-integration/tests/cw20_staking.rs
+++ b/tests-integration/tests/cw20_staking.rs
@@ -143,7 +143,7 @@ fn test_cw20_staking_app() {
         .wrap()
         .query_wasm_smart(cw20_addr.clone(), &mock_get_version())
         .unwrap();
-    assert_eq!(version.version, "2.0.0");
+    assert_eq!(version.version, "2.0.1");
 
     assert_eq!(balance_one.balance, Uint128::from(1000u128));
     let balance_two: BalanceResponse = router

--- a/tests-integration/tests/mod.rs
+++ b/tests-integration/tests/mod.rs
@@ -18,3 +18,6 @@ mod lockdrop;
 
 #[cfg(test)]
 mod validator_staking;
+
+#[cfg(test)]
+mod cw20_app;


### PR DESCRIPTION
# Motivation
Resolves #496 

# Implementation
A check for rates has been applied to `TransferFrom` and `SendFrom` the same way as it's applied to `Send` and `Transfer`.

# Testing
Integration test for cw20 `TransferFrom` with rates.
# Version Changes
Bumped from 2.0.0 to 2.0.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for `TransferFrom` in CW20 token operations.
	- Introduced rate functionality for token transfers in CW20 contracts.
	- Added new mock functions for executing `send_from` and `transfer_from`.

- **Bug Fixes**
	- Fixed version comparison assertion to match updated version.

- **Tests**
	- Added comprehensive tests for CW20 token contracts with rate functionality.
	- Added new test module `cw20_app` to validate rates and allowances in token transfers.

- **Chores**
	- Updated package version from "2.0.0" to "2.0.1".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->