### PR TITLE
chore: Version Bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-adodb"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.0.1"
+version = "1.1.1"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cross-chain-swap"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-exchange"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-staking"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-lockdrop"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-merkle-airdrop"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-shunting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vault"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-ecosystem",
  "andromeda-std",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.1.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.0.1"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/ecosystem/andromeda-vault/Cargo.toml
+++ b/contracts/ecosystem/andromeda-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vault"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
+++ b/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cross-chain-swap"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-exchange"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-staking"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-lockdrop"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-merkle-airdrop"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-shunting/Cargo.toml
+++ b/contracts/modules/andromeda-shunting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-shunting"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/contracts/os/andromeda-adodb/Cargo.toml
+++ b/contracts/os/andromeda-adodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-adodb"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"


### PR DESCRIPTION
# Motivation
Update versions for our contracts.

# Version Changes
Changes the versions according to @SlayerAnsh's list:
```rust
    "address-list": "2.0.0",
    "adodb": "1.1.0",
    "app-contract": "1.1.1",
    "auction": "2.0.0",
    "conditional-splitter": "1.1.0",
    "cross-chain-swap": "1.1.0",
    "crowdfund": "2.0.0",
    "cw20": "2.0.0",
    "cw20-exchange": "2.0.0",
    "cw20-staking": "2.0.0",
    "cw721": "2.0.0",
    "economics": "1.1.0",
    "kernel": "1.1.0",
    "lockdrop": "2.0.0",
    "marketplace": "2.0.0",
    "merkle-airdrop": "2.0.0",
    "primitive": "2.0.0",
    "rate-limiting-withdrawals": "2.0.0",
    "rates": "2.0.0",
    "shunting": "0.2.0",
    "splitter": "2.0.0",
    "timelock": "2.0.0",
    "validator-staking": "0.2.0",
    "vault": "1.1.0",
    "vesting": "2.0.0",
    "vfs": "1.1.0",
    "weighted-distribution-splitter": "2.0.0"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated package versions for multiple components to ensure compatibility and stability.
  - `andromeda-app-contract`: version `1.0.1` → `1.1.0`
  - `andromeda-vault`: version `1.0.0` → `1.1.0`
  - `andromeda-cross-chain-swap`: version `1.0.0` → `1.1.0`
  - `andromeda-rate-limiting-withdrawals`: version `1.0.0` → `2.0.0`
  - `andromeda-splitter`: version `1.0.0` → `2.0.0`
  - `andromeda-timelock`: version `1.0.0` → `2.0.0`
  - `andromeda-validator-staking`: version `0.1.0` → `0.2.0`
  - `andromeda-vesting`: version `1.0.0` → `2.0.0`
  - `andromeda-weighted-distribution-splitter`: version `1.0.0` → `2.0.0`
  - `andromeda-cw20-exchange`: version `1.0.0` → `2.0.0`
  - `andromeda-cw20-staking`: version `1.0.0` → `2.0.0`
  - `andromeda-lockdrop`: version `1.0.0` → `2.0.0`
  - `andromeda-merkle-airdrop`: version `1.0.0` → `2.0.0`
  - `andromeda-shunting`: version `0.1.0` → `0.2.0`
  - `andromeda-adodb`: version `1.0.0` → `1.1.0`
  - `andromeda-economics`: version `1.0.0` → `1.1.0`
  - `andromeda-kernel`: version `1.0.0` → `1.1.0`
  - `andromeda-vfs`: version `1.0.0` → `1.1.0`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->