### PR TITLE
feat: CustomError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.1.1"
+version = "1.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-std",

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -28,6 +28,10 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
+    /// Used by external developers in case they don't find their desired error message
+    #[error("CustomError: {msg}")]
+    CustomError { msg: String },
+
     #[error("ActionNotFound")]
     ActionNotFound {},
     #[error("UnpublishedCodeID")]


### PR DESCRIPTION
# Motivation
Addresses Issue #500 

# Implementation
Add a `CustomError` variant to our `ContractError` Enum. This new variant takes a custom message as input, so external developers can display any error message they want in case they didn't find their desired Error variant in our `ContractError`

# Testing
N/A

# Version Changes
No version changes

# Notes
This solution is based off the assumption that external developers will import our `ContractError` enum.

# Future work
We can easily add the most used custom errors as new variants to `ContractError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced custom error messages for external developers, enhancing error handling flexibility.
  - Enhanced the `ADOContract` to support a broader range of error types, improving versatility in error management during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->