### PR TITLE
ref: Rate Limiting Withdrawal Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.1.1"
+version = "1.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-std",

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -132,24 +132,30 @@ fn execute_deposit(
     let account = ACCOUNTS.may_load(deps.storage, user.clone())?;
 
     // Check if recipient already has an account
-    let new_details = if let Some(account) = account {
+    if let Some(account) = account {
+        // If the user does have an account in that coin
+
         // Calculate new amount of coins
         let new_amount = account.balance.checked_add(funds.amount)?;
 
-        AccountDetails {
+        // add new balance with updated coin
+        let new_details = AccountDetails {
             balance: new_amount,
             latest_withdrawal: account.latest_withdrawal,
-        }
-    }
-    // If user doesn't have an account at all
-    else {
-        AccountDetails {
+        };
+
+        // save changes
+        ACCOUNTS.save(deps.storage, info.sender.to_string(), &new_details)?;
+
+        // If user doesn't have an account at all
+    } else {
+        let new_account_details = AccountDetails {
             balance: funds.amount,
             latest_withdrawal: None,
-        }
-    };
-    // save changes
-    ACCOUNTS.save(deps.storage, info.sender.to_string(), &new_details)?;
+        };
+        // save changes
+        ACCOUNTS.save(deps.storage, user, &new_account_details)?;
+    }
 
     let res = Response::new()
         .add_attribute("action", "funded account")

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -97,8 +97,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     )?;
 
     let res = match msg {
-        ExecuteMsg::Deposits { recipient } => execute_deposit(ctx, recipient),
-        ExecuteMsg::WithdrawFunds { amount } => execute_withdraw(ctx, amount),
+        ExecuteMsg::Deposit { recipient } => execute_deposit(ctx, recipient),
+        ExecuteMsg::Withdraw { amount } => execute_withdraw(ctx, amount),
         _ => ADOContract::default().execute(ctx, msg),
     }?;
     Ok(res

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -133,7 +133,7 @@ fn execute_deposit(
         }
     );
 
-    let user = recipient.unwrap_or_else(|| info.sender.to_string());
+    let user = recipient.unwrap_or(info.sender.to_string());
 
     // Load list of accounts
     let account = ACCOUNTS.may_load(deps.storage, user.clone())?;
@@ -176,91 +176,63 @@ fn execute_withdraw(ctx: ExecuteContext, amount: Uint128) -> Result<Response, Co
     } = ctx;
 
     nonpayable(&info)?;
+
     // check if sender has an account
-    let account = ACCOUNTS.may_load(deps.storage, info.sender.to_string())?;
-    if let Some(account) = account {
-        // Calculate time since last withdrawal
-        if let Some(latest_withdrawal) = account.latest_withdrawal {
-            let minimum_withdrawal_frequency = ALLOWED_COIN
-                .load(deps.storage)?
-                .minimal_withdrawal_frequency;
-            let current_time = Milliseconds::from_seconds(env.block.time.seconds());
-            let seconds_since_withdrawal = current_time.minus_seconds(latest_withdrawal.seconds());
+    let account = ACCOUNTS
+        .load(deps.storage, info.sender.to_string())
+        .map_err(|_err| ContractError::AccountNotFound {})?;
 
-            // make sure enough time has elapsed since the latest withdrawal
-            ensure!(
-                seconds_since_withdrawal >= minimum_withdrawal_frequency,
-                ContractError::FundsAreLocked {}
-            );
+    let allowed_coin = ALLOWED_COIN.load(deps.storage)?;
 
-            // make sure the funds requested don't exceed the user's balance
-            ensure!(
-                account.balance >= amount,
-                ContractError::InsufficientFunds {}
-            );
+    // Calculate time since last withdrawal
+    if let Some(latest_withdrawal) = account.latest_withdrawal {
+        let minimum_withdrawal_frequency = allowed_coin.minimal_withdrawal_frequency;
+        let current_time = Milliseconds::from_seconds(env.block.time.seconds());
+        let seconds_since_withdrawal = current_time.minus_seconds(latest_withdrawal.seconds());
 
-            // make sure the funds don't exceed the withdrawal limit
-            let limit = ALLOWED_COIN.load(deps.storage)?;
-            ensure!(
-                limit.limit >= amount,
-                ContractError::WithdrawalLimitExceeded {}
-            );
-
-            // Update amount
-            let new_amount = account.balance - amount;
-
-            // Update account details
-            let new_details = AccountDetails {
-                balance: new_amount,
-                latest_withdrawal: Some(env.block.time),
-            };
-
-            // Save changes
-            ACCOUNTS.save(deps.storage, info.sender.to_string(), &new_details)?;
-        } else {
-            // make sure the funds requested don't exceed the user's balance
-            ensure!(
-                account.balance >= amount,
-                ContractError::InsufficientFunds {}
-            );
-
-            // make sure the funds don't exceed the withdrawal limit
-            let limit = ALLOWED_COIN.load(deps.storage)?;
-            ensure!(
-                limit.limit >= amount,
-                ContractError::WithdrawalLimitExceeded {}
-            );
-
-            // Update amount
-            let new_amount = account.balance - amount;
-
-            // Update account details
-            let new_details = AccountDetails {
-                balance: new_amount,
-                latest_withdrawal: Some(env.block.time),
-            };
-
-            // Save changes
-            ACCOUNTS.save(deps.storage, info.sender.to_string(), &new_details)?;
-        }
-
-        let coin = Coin {
-            denom: ALLOWED_COIN.load(deps.storage)?.coin,
-            amount,
-        };
-
-        // Transfer funds
-        let res = Response::new()
-            .add_message(CosmosMsg::Bank(BankMsg::Send {
-                to_address: info.sender.to_string(),
-                amount: vec![coin.clone()],
-            }))
-            .add_attribute("action", "withdrew funds")
-            .add_attribute("coin", coin.to_string());
-        Ok(res)
-    } else {
-        Err(ContractError::AccountNotFound {})
+        // make sure enough time has elapsed since the latest withdrawal
+        ensure!(
+            seconds_since_withdrawal >= minimum_withdrawal_frequency,
+            ContractError::FundsAreLocked {}
+        );
     }
+
+    // make sure the funds requested don't exceed the user's balance
+    ensure!(
+        account.balance >= amount,
+        ContractError::InsufficientFunds {}
+    );
+
+    // make sure the funds don't exceed the withdrawal limit
+    let limit = allowed_coin.limit;
+    ensure!(limit >= amount, ContractError::WithdrawalLimitExceeded {});
+
+    // Update amount
+    let new_amount = account.balance.checked_sub(amount)?;
+
+    // Update account details
+    let new_details = AccountDetails {
+        balance: new_amount,
+        latest_withdrawal: Some(env.block.time),
+    };
+
+    // Save changes
+    ACCOUNTS.save(deps.storage, info.sender.to_string(), &new_details)?;
+
+    let coin = Coin {
+        denom: allowed_coin.coin,
+        amount,
+    };
+
+    // Transfer funds
+    let res = Response::new()
+        .add_message(CosmosMsg::Bank(BankMsg::Send {
+            to_address: info.sender.to_string(),
+            amount: vec![coin.clone()],
+        }))
+        .add_attribute("action", "withdrew funds")
+        .add_attribute("coin", coin.to_string());
+    Ok(res)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/testing/tests.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/testing/tests.rs
@@ -47,7 +47,7 @@ fn test_deposit_zero_funds() {
     let info = mock_info("creator", &[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits { recipient: None };
+    let exec = ExecuteMsg::Deposit { recipient: None };
     let _err = execute(deps.as_mut(), mock_env(), info, exec).unwrap_err();
 }
 
@@ -56,7 +56,7 @@ fn test_deposit_invalid_funds() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("me".to_string()),
     };
 
@@ -76,7 +76,7 @@ fn test_deposit_new_account_works() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
@@ -98,14 +98,14 @@ fn test_deposit_existing_account_works() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
     let info = mock_info("creator", &[coin(30, "junox")]);
 
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
-    let exec = ExecuteMsg::Deposits { recipient: None };
+    let exec = ExecuteMsg::Deposit { recipient: None };
 
     let info = mock_info("andromedauser", &[coin(70, "junox")]);
 
@@ -125,7 +125,7 @@ fn test_withdraw_account_not_found() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
@@ -134,7 +134,7 @@ fn test_withdraw_account_not_found() {
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
 
     let info = mock_info("random", &[]);
-    let exec = ExecuteMsg::WithdrawFunds {
+    let exec = ExecuteMsg::Withdraw {
         amount: Uint128::from(19_u16),
     };
     let err = execute(deps.as_mut(), mock_env(), info, exec).unwrap_err();
@@ -146,7 +146,7 @@ fn test_withdraw_over_account_limit() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
@@ -155,7 +155,7 @@ fn test_withdraw_over_account_limit() {
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
 
     let info = mock_info("andromedauser", &[]);
-    let exec = ExecuteMsg::WithdrawFunds {
+    let exec = ExecuteMsg::Withdraw {
         amount: Uint128::from(31_u16),
     };
     let err = execute(deps.as_mut(), mock_env(), info, exec).unwrap_err();
@@ -167,7 +167,7 @@ fn test_withdraw_funds_locked() {
     let mut deps = mock_dependencies_custom(&[]);
     let _res = init(deps.as_mut());
 
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
@@ -176,13 +176,13 @@ fn test_withdraw_funds_locked() {
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
 
     let info = mock_info("andromedauser", &[]);
-    let exec = ExecuteMsg::WithdrawFunds {
+    let exec = ExecuteMsg::Withdraw {
         amount: Uint128::from(10_u16),
     };
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
 
     let info = mock_info("andromedauser", &[]);
-    let exec = ExecuteMsg::WithdrawFunds {
+    let exec = ExecuteMsg::Withdraw {
         amount: Uint128::from(10_u16),
     };
 
@@ -208,7 +208,7 @@ fn test_withdraw_over_allowed_limit() {
         owner: None,
     };
     let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
@@ -217,7 +217,7 @@ fn test_withdraw_over_allowed_limit() {
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
 
     let info = mock_info("andromedauser", &[]);
-    let exec = ExecuteMsg::WithdrawFunds {
+    let exec = ExecuteMsg::Withdraw {
         amount: Uint128::from(21_u16),
     };
     let err = execute(deps.as_mut(), mock_env(), info, exec).unwrap_err();
@@ -241,7 +241,7 @@ fn test_withdraw_works() {
         owner: None,
     };
     let _res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
-    let exec = ExecuteMsg::Deposits {
+    let exec = ExecuteMsg::Deposit {
         recipient: Some("andromedauser".to_string()),
     };
 
@@ -250,7 +250,7 @@ fn test_withdraw_works() {
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();
 
     let info = mock_info("andromedauser", &[]);
-    let exec = ExecuteMsg::WithdrawFunds {
+    let exec = ExecuteMsg::Withdraw {
         amount: Uint128::from(10_u16),
     };
     let _res = execute(deps.as_mut(), mock_env(), info, exec).unwrap();

--- a/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
+++ b/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
@@ -48,10 +48,9 @@ pub enum MinimumFrequency {
 
 #[andr_exec]
 #[cw_serde]
-//NOTE can't name Deposit and Withdraw while implementing andr_exec
 pub enum ExecuteMsg {
-    Deposits { recipient: Option<String> },
-    WithdrawFunds { amount: Uint128 },
+    Deposit { recipient: Option<String> },
+    Withdraw { amount: Uint128 },
 }
 
 #[andr_query]

--- a/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
+++ b/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
@@ -44,7 +44,6 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum MinimumFrequency {
     Time { time: MillisecondsDuration },
-    // AddressAndKey { address_and_key: ContractAndKey },
 }
 
 #[andr_exec]


### PR DESCRIPTION
# Motivation
Minor improvements to the Rate Limiting Withdrawals ADO

# Implementation
Made the code more concise by removing duplicate code.
Deleted commented code.
Added an attribute that reflects the amount deposited.
Improved the naming of the `ExecuteMsgs`. From `Deposits` to `Deposit` and `WithdrawFunds` to `Withdraw`.

# Testing
No tests were altered. 

# Version Changes
Bumped from 2.0.0 to 2.0.1

# Notes
Do we want add support to CW20 or multiple funds per account?

Using Seconds or Minutes instead of Milliseconds would be more intuitive from the user's point of view while setting the withdrawal frequency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced validation for withdrawal and deposit operations to ensure input integrity.
  - Streamlined message handling with clearer naming conventions for deposit and withdrawal actions.

- **Bug Fixes**
  - Improved logic prevents underflow errors during withdrawal arithmetic operations.

- **Refactor**
  - Simplified code structure in withdrawal and deposit handling for better readability and maintainability.

- **Chores**
  - Updated package version from 2.0.0 to 2.0.1, indicating minor improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->