### PR TITLE
fix: Remove CW721 Extra Pay Fee 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.1.1"
+version = "1.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-std",

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -101,21 +101,6 @@ fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
         msg.as_ref(),
     )?;
 
-    let payee = if let Some(amp_ctx) = ctx.amp_ctx.clone() {
-        ctx.deps
-            .api
-            .addr_validate(amp_ctx.ctx.get_origin().as_str())?
-    } else {
-        ctx.info.sender.clone()
-    };
-
-    let _fee_msg = ADOContract::default().pay_fee(
-        ctx.deps.storage,
-        &ctx.deps.querier,
-        msg.as_ref().to_string(),
-        payee,
-    )?;
-
     if let ExecuteMsg::Approve { token_id, .. } = &msg {
         ensure!(
             !is_archived(ctx.deps.storage, token_id)?.is_archived,


### PR DESCRIPTION
# Motivation
CW721's  `handle_execute` function had an extra pay fee message.

# Implementation
The below code is already handled in `call_action`.
```rust
    let payee = if let Some(amp_ctx) = ctx.amp_ctx.clone() {
        ctx.deps
            .api
            .addr_validate(amp_ctx.ctx.get_origin().as_str())?
    } else {
        ctx.info.sender.clone()
    };

    let _fee_msg = ADOContract::default().pay_fee(
        ctx.deps.storage,
        &ctx.deps.querier,
        msg.as_ref().to_string(),
        payee,
    )?;
```
So I removed it. 

# Testing
No tests were affected

# Version Changes
Bumped from 2.0.0 to 2.0.1

# Notes
This bug was reported by @daniel-wehbe 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified fee payment handling within the contract, streamlining transaction processing.

- **Impact**
  - Changes may affect how approvals and other messages are processed due to the removal of previous fee attribution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->