### PR TITLE
ref: ActionFee Recipient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/os/adodb.rs
+++ b/packages/std/src/os/adodb.rs
@@ -1,12 +1,12 @@
 use std::str::FromStr;
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Addr, Api, Uint128};
+use cosmwasm_std::{ensure, Api, Uint128};
 use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::{ado_base::ownership::OwnershipMessage, error::ContractError};
+use crate::{ado_base::ownership::OwnershipMessage, amp::Recipient, error::ContractError};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -48,7 +48,7 @@ pub struct ActionFee {
     pub action: String,
     pub asset: String,
     pub amount: Uint128,
-    pub receiver: Option<Addr>,
+    pub receiver: Option<Recipient>,
 }
 
 impl ActionFee {
@@ -61,7 +61,7 @@ impl ActionFee {
         }
     }
 
-    pub fn with_receive(&self, receiver: Addr) -> Self {
+    pub fn with_receive(&self, receiver: Recipient) -> Self {
         Self {
             action: self.action.clone(),
             asset: self.asset.clone(),


### PR DESCRIPTION
# Motivation
Provide more flexibility for `ActionFee`'s recipient. This was referenced in @leifasorensen 's economics engine video. 

# Implementation
Changed `ActionFee`'s recipient from `Option<Addr>` to `Option<Recipient>`
Any message attached to recipient will be sent with `pay_fee`'s response. 

# Testing
No tests were made nor affected. 

# Version Changes
Bumped `economics` and `andromeda-std` to 1.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the payment function for improved address management and robust recipient handling.
  - Introduced conditional messaging for recipients, allowing for more complex interactions based on their state.
  
- **Bug Fixes**
  - Improved clarity and accuracy in loading and saving recipient balances through updated address references.
  
- **Refactor**
  - Updated the ActionFee structure to utilize a new recipient type, enhancing type specificity and usage throughout the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->