### PR TITLE
fix: Rates Recipient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rates"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rates"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -30,7 +30,12 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     let action = msg.action;
-    let rate = msg.rate;
+    let mut rate = msg.rate;
+
+    if rate.recipients.is_empty() {
+        rate.recipients = vec![Recipient::new(info.sender.clone(), None)];
+    };
+
     RATES.save(deps.storage, &action, &rate)?;
 
     let inst_resp = ADOContract::default().instantiate(

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_contract/rates.rs
+++ b/packages/std/src/ado_contract/rates.rs
@@ -1,11 +1,6 @@
-use crate::ado_base::rates::AllRatesResponse;
-use crate::ado_base::rates::LocalRate;
-use crate::ado_base::rates::Rate;
-use crate::ado_base::rates::RatesMessage;
-use crate::ado_base::rates::RatesResponse;
+use crate::ado_base::rates::{AllRatesResponse, Rate, RatesMessage, RatesResponse};
 use crate::amp::Recipient;
-use crate::common::context::ExecuteContext;
-use crate::common::Funds;
+use crate::common::{context::ExecuteContext, Funds};
 use crate::error::ContractError;
 use crate::os::aos_querier::AOSQuerier;
 use cosmwasm_std::{coin as create_coin, ensure, Coin, Deps, Response, Storage};


### PR DESCRIPTION
# Motivation
We didn't handle the case when the user provides an empty vector of Recipients in Rates.

# Implementation
If the recipients vector is empty, it is populated by the message sender, automatically making him the recipient of the rate.

# Testing
A unit test was made to test behavior with empty recipients vector

# Version Changes
std and rates bumped by 0.0.1

# Notes
This unhandled case was spotted by @daniel-wehbe 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced functionality for setting rates by ensuring that if no recipients are provided, the sender is automatically included as a recipient.

- **Bug Fixes**
  - Improved test coverage by adding a new case to validate contract behavior when the recipients vector is empty, preventing potential issues.

- **Chores**
  - Incremented version numbers for the `andromeda-rates` package and the Andromeda standard library to reflect minor updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->