### PR TITLE
fix: Rates Queries Accessibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -151,16 +151,24 @@ pub fn andr_query(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                 Permissions { actor: String, limit: Option<u32>, start_after: Option<String> },
                 #[returns(Vec<String>)]
                 PermissionedActions { },
-                #[cfg(feature = "rates")]
-                #[returns(Option<::andromeda_std::ado_base::rates::Rate>)]
-                Rates {action: String},
-                #[cfg(feature = "rates")]
-                #[returns(::andromeda_std::ado_base::rates::AllRatesResponse)]
-                AllRates {}
-
             }
         }
         .into(),
     );
+    #[cfg(feature = "rates")]
+    {
+        merged = merge_variants(
+            merged,
+            quote! {
+                enum Right {
+                    #[returns(Option<::andromeda_std::ado_base::rates::Rate>)]
+                    Rates {action: String},
+                    #[returns(::andromeda_std::ado_base::rates::AllRatesResponse)]
+                    AllRates {}
+                }
+            }
+            .into(),
+        )
+    }
     merged
 }


### PR DESCRIPTION
# Motivation
Closes #532 

# Implementation
Merged rates-specific variants on `andr_query` the same way as `andr_exec`

# Testing
Uploaded the following [contract](https://explorer.testnet.andromedaprotocol.io/galileo-4/tx/2584AAC6269BD274860575676DECAD3751D7E444DD310B8DC3210FD1A8493869) and the queries appear as expected

# Version Changes
Bumped `std` by 0.0.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved handling of rate-related variants, enhancing feature toggle clarity in the application.
- **Bug Fixes**
	- Ensured that `Rates` and `AllRates` variants are only included when the "rates" feature is enabled, preventing potential issues when the feature is inactive.
- **Chores**
	- Updated the version of `andromeda-std` from 1.1.0 to 1.1.1 to reflect minor improvements and ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->