### PR TITLE
ref: CustomQuery for ExecuteContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.1.1"
+version = "1.2.1"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/contracts/app/andromeda-app-contract/src/contract.rs
+++ b/contracts/app/andromeda-app-contract/src/contract.rs
@@ -13,8 +13,8 @@ use andromeda_std::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, wasm_execute, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
-    SubMsg,
+    ensure, wasm_execute, Addr, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Reply,
+    Response, StdError, SubMsg,
 };
 
 use crate::{execute, query};
@@ -181,7 +181,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::AddAppComponent { component } => {
             execute::handle_add_app_component(ctx, component)

--- a/contracts/app/andromeda-app-contract/src/execute.rs
+++ b/contracts/app/andromeda-app-contract/src/execute.rs
@@ -10,12 +10,12 @@ use andromeda_std::os::vfs::ExecuteMsg as VFSExecuteMsg;
 use andromeda_std::{ado_contract::ADOContract, amp::AndrAddr};
 
 use cosmwasm_std::{
-    ensure, to_json_binary, Addr, Binary, CosmosMsg, QuerierWrapper, ReplyOn, Response, Storage,
-    SubMsg, WasmMsg,
+    ensure, to_json_binary, Addr, Binary, CosmosMsg, CustomQuery, QuerierWrapper, ReplyOn,
+    Response, Storage, SubMsg, WasmMsg,
 };
 
-pub fn handle_add_app_component(
-    ctx: ExecuteContext,
+pub fn handle_add_app_component<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     component: AppComponent,
 ) -> Result<Response, ContractError> {
     let querier = &ctx.deps.querier;
@@ -107,8 +107,8 @@ pub fn handle_add_app_component(
     Ok(resp)
 }
 
-pub fn claim_ownership(
-    ctx: ExecuteContext,
+pub fn claim_ownership<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     name_opt: Option<String>,
     new_owner: Option<AndrAddr>,
 ) -> Result<Response, ContractError> {
@@ -147,7 +147,11 @@ pub fn claim_ownership(
         .add_attribute("method", "claim_ownership"))
 }
 
-pub fn message(ctx: ExecuteContext, name: String, msg: Binary) -> Result<Response, ContractError> {
+pub fn message<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    name: String,
+    msg: Binary,
+) -> Result<Response, ContractError> {
     let ExecuteContext { info, deps, .. } = ctx;
     //Temporary until message sender attached to Andromeda Comms
     ensure!(
@@ -181,8 +185,8 @@ pub fn has_update_address_privilege(
     Ok(ADOContract::default().is_contract_owner(storage, sender)? || sender == current_addr)
 }
 
-pub fn update_address(
-    ctx: ExecuteContext,
+pub fn update_address<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     name: String,
     addr: String,
 ) -> Result<Response, ContractError> {
@@ -217,9 +221,9 @@ pub fn update_address(
     Ok(resp)
 }
 
-pub fn register_component_path(
+pub fn register_component_path<C: CustomQuery>(
     kernel_address: Addr,
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<C>,
     name: impl Into<String>,
     address: Addr,
 ) -> Result<SubMsg, ContractError> {
@@ -242,7 +246,9 @@ pub fn register_component_path(
     ))
 }
 
-pub fn assign_app_to_components(ctx: ExecuteContext) -> Result<Response, ContractError> {
+pub fn assign_app_to_components<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, env, info, ..
     } = ctx;

--- a/contracts/data-storage/andromeda-primitive/src/execute.rs
+++ b/contracts/data-storage/andromeda-primitive/src/execute.rs
@@ -6,7 +6,8 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_std::{
-    coin, ensure, BankMsg, Coin, CosmosMsg, Deps, MessageInfo, Response, StdError, SubMsg, Uint128,
+    coin, ensure, BankMsg, Coin, CosmosMsg, CustomQuery, Deps, MessageInfo, Response, StdError,
+    SubMsg, Uint128,
 };
 use cw_utils::nonpayable;
 
@@ -15,7 +16,10 @@ use crate::{
     state::{DATA, KEY_OWNER, RESTRICTION},
 };
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action = msg.as_ref().to_string();
     call_action(
         &mut ctx.deps,
@@ -44,8 +48,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     }
 }
 
-pub fn update_restriction(
-    ctx: ExecuteContext,
+pub fn update_restriction<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     restriction: PrimitiveRestriction,
 ) -> Result<Response, ContractError> {
     nonpayable(&ctx.info)?;
@@ -60,8 +64,8 @@ pub fn update_restriction(
         .add_attribute("sender", sender))
 }
 
-pub fn set_value(
-    ctx: ExecuteContext,
+pub fn set_value<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     key: Option<String>,
     value: Primitive,
     action: String,
@@ -107,7 +111,10 @@ pub fn set_value(
     Ok(response)
 }
 
-pub fn delete_value(ctx: ExecuteContext, key: Option<String>) -> Result<Response, ContractError> {
+pub fn delete_value<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    key: Option<String>,
+) -> Result<Response, ContractError> {
     nonpayable(&ctx.info)?;
     let sender = ctx.info.sender;
 
@@ -124,8 +131,8 @@ pub fn delete_value(ctx: ExecuteContext, key: Option<String>) -> Result<Response
         .add_attribute("key", key))
 }
 
-fn tax_set_value(
-    deps: Deps,
+fn tax_set_value<C: CustomQuery>(
+    deps: Deps<C>,
     info: &MessageInfo,
     action: String,
 ) -> Result<Option<(Funds, Vec<SubMsg>)>, ContractError> {

--- a/contracts/ecosystem/andromeda-vault/src/contract.rs
+++ b/contracts/ecosystem/andromeda-vault/src/contract.rs
@@ -16,8 +16,9 @@ use andromeda_std::{
 
 use cosmwasm_std::{
     attr, coin, ensure, entry_point, from_json, to_json_binary, BankMsg, Binary, Coin,
-    ContractResult, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Order, QueryRequest, Reply,
-    ReplyOn, Response, StdError, SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
+    ContractResult, CosmosMsg, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo, Order,
+    QueryRequest, Reply, ReplyOn, Response, StdError, SubMsg, SystemResult, Uint128, WasmMsg,
+    WasmQuery,
 };
 use cw_utils::nonpayable;
 
@@ -75,7 +76,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -100,8 +104,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     }
 }
 
-fn execute_deposit(
-    ctx: ExecuteContext,
+fn execute_deposit<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: Option<AndrAddr>,
     msg: Option<Binary>,
 ) -> Result<Response, ContractError> {
@@ -209,8 +213,8 @@ fn execute_deposit(
     ]))
 }
 
-pub fn execute_withdraw(
-    ctx: ExecuteContext,
+pub fn execute_withdraw<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: Option<Recipient>,
     withdrawals: Vec<Withdrawal>,
     strategy: Option<StrategyType>,
@@ -230,8 +234,8 @@ pub fn execute_withdraw(
     }
 }
 
-pub fn withdraw_vault(
-    deps: DepsMut,
+pub fn withdraw_vault<C: CustomQuery>(
+    deps: DepsMut<C>,
     info: MessageInfo,
     recipient: Option<Recipient>,
     withdrawals: Vec<Withdrawal>,
@@ -300,8 +304,8 @@ pub fn withdraw_vault(
     Ok(res.add_message(withdrawal_msg))
 }
 
-pub fn withdraw_strategy(
-    deps: DepsMut,
+pub fn withdraw_strategy<C: CustomQuery>(
+    deps: DepsMut<C>,
     info: MessageInfo,
     strategy: StrategyType,
     withdrawals: Vec<Withdrawal>,
@@ -334,8 +338,8 @@ pub fn withdraw_strategy(
     Ok(res.add_submessage(withdraw_submsg))
 }
 
-fn execute_update_strategy(
-    ctx: ExecuteContext,
+fn execute_update_strategy<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     strategy: StrategyType,
     address: AndrAddr,
 ) -> Result<Response, ContractError> {

--- a/contracts/finance/andromeda-conditional-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/contract.rs
@@ -13,8 +13,8 @@ use andromeda_std::{
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
-    attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdError, SubMsg, Uint128,
+    attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, Env,
+    MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
 };
 use cw_utils::nonpayable;
 
@@ -104,7 +104,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -124,7 +127,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_send<C: CustomQuery>(ctx: ExecuteContext<C>) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
     ensure!(
@@ -202,8 +205,8 @@ fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
         .add_attribute("sender", info.sender.to_string()))
 }
 
-fn execute_update_thresholds(
-    ctx: ExecuteContext,
+fn execute_update_thresholds<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     thresholds: Vec<Threshold>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -239,8 +242,8 @@ fn execute_update_thresholds(
     Ok(Response::default().add_attributes(vec![attr("action", "update_thresholds")]))
 }
 
-fn execute_update_lock(
-    ctx: ExecuteContext,
+fn execute_update_lock<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     lock_time: MillisecondsDuration,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {

--- a/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
+++ b/contracts/finance/andromeda-cross-chain-swap/src/contract.rs
@@ -12,8 +12,8 @@ use andromeda_std::{
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
-    attr, entry_point, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdError, SubMsg,
+    attr, entry_point, Binary, Coin, CustomQuery, Decimal, Deps, DepsMut, Env, MessageInfo, Reply,
+    Response, StdError, SubMsg,
 };
 
 use cw_utils::one_coin;
@@ -135,7 +135,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let _contract = ADOContract::default();
     call_action(
         &mut ctx.deps,
@@ -165,8 +168,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     }
 }
 
-fn execute_swap_and_forward(
-    ctx: ExecuteContext,
+fn execute_swap_and_forward<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     dex: String,
     to_denom: String,
     forward_addr: AndrAddr,

--- a/contracts/finance/andromeda-cross-chain-swap/src/dex.rs
+++ b/contracts/finance/andromeda-cross-chain-swap/src/dex.rs
@@ -4,7 +4,8 @@ use andromeda_std::{
     error::ContractError, os::aos_querier::AOSQuerier,
 };
 use cosmwasm_std::{
-    from_json, wasm_execute, Coin, Decimal, Reply, StdError, SubMsg, SubMsgResponse, SubMsgResult,
+    from_json, wasm_execute, Coin, CustomQuery, Decimal, Reply, StdError, SubMsg, SubMsgResponse,
+    SubMsgResult,
 };
 use serde::de::DeserializeOwned;
 
@@ -27,8 +28,8 @@ pub(crate) fn parse_swap_reply<T: DeserializeOwned>(msg: Reply) -> Result<T, Con
     Ok(swap_response)
 }
 
-pub(crate) fn execute_swap_osmo(
-    ctx: ExecuteContext,
+pub(crate) fn execute_swap_osmo<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     input_coin: Coin,
     to_denom: String,
     slippage_percentage: Decimal,

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -11,8 +11,8 @@ use andromeda_std::common::Milliseconds;
 use andromeda_std::{common::encode_binary, error::ContractError};
 
 use cosmwasm_std::{
-    ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Response, Uint128,
+    ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, Env,
+    MessageInfo, Response, Uint128,
 };
 
 use cw_utils::{nonpayable, one_coin};
@@ -87,7 +87,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -107,8 +110,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn execute_deposit(
-    ctx: ExecuteContext,
+fn execute_deposit<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: Option<String>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
@@ -164,7 +167,10 @@ fn execute_deposit(
     Ok(res)
 }
 
-fn execute_withdraw(ctx: ExecuteContext, amount: Uint128) -> Result<Response, ContractError> {
+fn execute_withdraw<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -11,8 +11,8 @@ use andromeda_std::{
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
-    attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdError, SubMsg, Uint128,
+    attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, Env,
+    MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
 };
 use cw_utils::nonpayable;
 
@@ -108,7 +108,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -128,7 +131,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_send<C: CustomQuery>(ctx: ExecuteContext<C>) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
     ensure!(
@@ -210,8 +213,8 @@ fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
         .add_attribute("sender", info.sender.to_string()))
 }
 
-fn execute_update_recipients(
-    ctx: ExecuteContext,
+fn execute_update_recipients<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipients: Vec<AddressPercent>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -246,8 +249,8 @@ fn execute_update_recipients(
     Ok(Response::default().add_attributes(vec![attr("action", "update_recipients")]))
 }
 
-fn execute_update_lock(
-    ctx: ExecuteContext,
+fn execute_update_lock<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     lock_time: MillisecondsDuration,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {

--- a/contracts/finance/andromeda-timelock/src/contract.rs
+++ b/contracts/finance/andromeda-timelock/src/contract.rs
@@ -10,7 +10,8 @@ use andromeda_std::{
 };
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
-    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, SubMsg,
+    attr, ensure, entry_point, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Response,
+    SubMsg,
 };
 
 use crate::state::{escrows, get_key, get_keys_for_recipient};
@@ -61,7 +62,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -92,8 +96,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn execute_hold_funds(
-    ctx: ExecuteContext,
+fn execute_hold_funds<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     condition: Option<EscrowCondition>,
     recipient: Option<Recipient>,
 ) -> Result<Response, ContractError> {
@@ -135,8 +139,8 @@ fn execute_hold_funds(
     ]))
 }
 
-fn execute_release_funds(
-    ctx: ExecuteContext,
+fn execute_release_funds<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient_addr: Option<String>,
     start_after: Option<String>,
     limit: Option<u32>,
@@ -170,8 +174,8 @@ fn execute_release_funds(
     ]))
 }
 
-fn execute_release_specific_funds(
-    ctx: ExecuteContext,
+fn execute_release_specific_funds<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     owner: String,
     recipient: Option<String>,
 ) -> Result<Response, ContractError> {

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::state::{DEFAULT_VALIDATOR, UNSTAKING_QUEUE};
 use cosmwasm_std::{
-    coin, ensure, entry_point, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut,
+    coin, ensure, entry_point, Addr, BankMsg, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut,
     DistributionMsg, Env, FullDelegation, MessageInfo, Reply, Response, StakingMsg, StdError,
     SubMsg, Timestamp, Uint128,
 };
@@ -76,7 +76,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::Stake { validator } => execute_stake(ctx, validator),
         ExecuteMsg::Unstake { validator, amount } => execute_unstake(ctx, validator, amount),
@@ -107,7 +110,10 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
     }
 }
 
-fn execute_stake(ctx: ExecuteContext, validator: Option<Addr>) -> Result<Response, ContractError> {
+fn execute_stake<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    validator: Option<Addr>,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
     // Ensure only one type of coin is received
@@ -141,8 +147,8 @@ fn execute_stake(ctx: ExecuteContext, validator: Option<Addr>) -> Result<Respons
     Ok(res)
 }
 
-fn execute_unstake(
-    ctx: ExecuteContext,
+fn execute_unstake<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     validator: Option<Addr>,
     amount: Option<Uint128>,
 ) -> Result<Response, ContractError> {
@@ -199,8 +205,8 @@ fn execute_unstake(
     Ok(res)
 }
 
-fn execute_claim(
-    ctx: ExecuteContext,
+fn execute_claim<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     validator: Option<Addr>,
     recipient: Option<AndrAddr>,
 ) -> Result<Response, ContractError> {
@@ -257,7 +263,9 @@ fn execute_claim(
     Ok(res)
 }
 
-fn execute_withdraw_fund(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_withdraw_fund<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -6,8 +6,8 @@ use andromeda_std::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, Binary, Coin, CosmosMsg, Deps, DepsMut, DistributionMsg, Env, GovMsg, MessageInfo,
-    QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
+    ensure, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, DistributionMsg, Env, GovMsg,
+    MessageInfo, QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
 };
 use cw_asset::AssetInfo;
 use cw_utils::nonpayable;
@@ -76,7 +76,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -114,8 +117,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     }
 }
 
-fn execute_create_batch(
-    ctx: ExecuteContext,
+fn execute_create_batch<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     lockup_duration: Option<u64>,
     release_unit: u64,
     release_amount: WithdrawalType,
@@ -214,8 +217,8 @@ fn execute_create_batch(
     Ok(response)
 }
 
-fn execute_claim(
-    ctx: ExecuteContext,
+fn execute_claim<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     number_of_claims: Option<u64>,
     batch_id: u64,
 ) -> Result<Response, ContractError> {
@@ -257,8 +260,8 @@ fn execute_claim(
         .add_attribute("amount_left", batch.amount - batch.amount_claimed))
 }
 
-fn execute_claim_all(
-    ctx: ExecuteContext,
+fn execute_claim_all<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     limit: Option<u32>,
     up_to_time: Option<u64>,
 ) -> Result<Response, ContractError> {
@@ -321,8 +324,8 @@ fn execute_claim_all(
         .add_attribute("last_batch_id_processed", last_batch_id))
 }
 
-fn execute_delegate(
-    deps: DepsMut,
+fn execute_delegate<C: CustomQuery>(
+    deps: DepsMut<C>,
     env: Env,
     info: MessageInfo,
     amount: Option<Uint128>,
@@ -356,8 +359,8 @@ fn execute_delegate(
         .add_attribute("amount", amount))
 }
 
-fn execute_redelegate(
-    ctx: ExecuteContext,
+fn execute_redelegate<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     amount: Option<Uint128>,
     from: String,
     to: String,
@@ -398,8 +401,8 @@ fn execute_redelegate(
         .add_attribute("amount", amount))
 }
 
-fn execute_undelegate(
-    ctx: ExecuteContext,
+fn execute_undelegate<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     amount: Option<Uint128>,
     validator: String,
 ) -> Result<Response, ContractError> {
@@ -437,7 +440,9 @@ fn execute_undelegate(
         .add_attribute("amount", amount))
 }
 
-fn execute_withdraw_rewards(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_withdraw_rewards<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
@@ -465,8 +470,8 @@ fn execute_withdraw_rewards(ctx: ExecuteContext) -> Result<Response, ContractErr
         .add_messages(withdraw_rewards_msgs))
 }
 
-fn claim_batch(
-    querier: &QuerierWrapper,
+fn claim_batch<C: CustomQuery>(
+    querier: &QuerierWrapper<C>,
     env: &Env,
     batch: &mut Batch,
     config: &Config,
@@ -520,8 +525,8 @@ fn claim_batch(
     Ok(amount_to_send)
 }
 
-fn execute_vote(
-    ctx: ExecuteContext,
+fn execute_vote<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     proposal_id: u64,
     vote: VoteOption,
 ) -> Result<Response, ContractError> {
@@ -542,8 +547,8 @@ fn execute_vote(
         .add_attribute("vote", format!("{vote:?}")))
 }
 
-fn get_amount_delegated(
-    querier: &QuerierWrapper,
+fn get_amount_delegated<C: CustomQuery>(
+    querier: &QuerierWrapper<C>,
     delegator: String,
     validator: String,
 ) -> Result<Uint128, ContractError> {

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -6,8 +6,8 @@ use andromeda_std::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, DistributionMsg, Env, GovMsg,
-    MessageInfo, QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
+    ensure, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, DistributionMsg, Empty, Env,
+    GovMsg, MessageInfo, QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
 };
 use cw_asset::AssetInfo;
 use cw_utils::nonpayable;
@@ -76,8 +76,8 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute<C: CustomQuery>(
-    mut ctx: ExecuteContext<C>,
+pub fn handle_execute(
+    mut ctx: ExecuteContext<Empty>,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     call_action(
@@ -117,8 +117,8 @@ pub fn handle_execute<C: CustomQuery>(
     }
 }
 
-fn execute_create_batch<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn execute_create_batch(
+    ctx: ExecuteContext<Empty>,
     lockup_duration: Option<u64>,
     release_unit: u64,
     release_amount: WithdrawalType,
@@ -217,8 +217,8 @@ fn execute_create_batch<C: CustomQuery>(
     Ok(response)
 }
 
-fn execute_claim<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn execute_claim(
+    ctx: ExecuteContext<Empty>,
     number_of_claims: Option<u64>,
     batch_id: u64,
 ) -> Result<Response, ContractError> {
@@ -260,8 +260,8 @@ fn execute_claim<C: CustomQuery>(
         .add_attribute("amount_left", batch.amount - batch.amount_claimed))
 }
 
-fn execute_claim_all<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn execute_claim_all(
+    ctx: ExecuteContext<Empty>,
     limit: Option<u32>,
     up_to_time: Option<u64>,
 ) -> Result<Response, ContractError> {
@@ -324,8 +324,8 @@ fn execute_claim_all<C: CustomQuery>(
         .add_attribute("last_batch_id_processed", last_batch_id))
 }
 
-fn execute_delegate<C: CustomQuery>(
-    deps: DepsMut<C>,
+fn execute_delegate(
+    deps: DepsMut<Empty>,
     env: Env,
     info: MessageInfo,
     amount: Option<Uint128>,
@@ -470,8 +470,8 @@ fn execute_withdraw_rewards<C: CustomQuery>(
         .add_messages(withdraw_rewards_msgs))
 }
 
-fn claim_batch<C: CustomQuery>(
-    querier: &QuerierWrapper<C>,
+fn claim_batch(
+    querier: &QuerierWrapper<Empty>,
     env: &Env,
     batch: &mut Batch,
     config: &Config,

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -12,8 +12,8 @@ use andromeda_std::{
 };
 
 use cosmwasm_std::{
-    attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Response, SubMsg, Timestamp, Uint128,
+    attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, Env,
+    MessageInfo, Response, SubMsg, Timestamp, Uint128,
 };
 
 use cw_utils::{nonpayable, Expiration};
@@ -100,7 +100,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -123,8 +126,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
     }
 }
 
-pub fn execute_update_recipient_weight(
-    ctx: ExecuteContext,
+pub fn execute_update_recipient_weight<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: AddressWeight,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -170,8 +173,8 @@ pub fn execute_update_recipient_weight(
     Ok(Response::default().add_attribute("action", "updated_recipient_weight"))
 }
 
-pub fn execute_add_recipient(
-    ctx: ExecuteContext,
+pub fn execute_add_recipient<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: AddressWeight,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -228,7 +231,7 @@ pub fn execute_add_recipient(
     Ok(Response::default().add_attributes(vec![attr("action", "added_recipient")]))
 }
 
-fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_send<C: CustomQuery>(ctx: ExecuteContext<C>) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
     // Amount of coins sent should be at least 1
     ensure!(
@@ -313,8 +316,8 @@ fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
         .add_attributes(vec![attr("action", "send"), attr("sender", info.sender)]))
 }
 
-fn execute_update_recipients(
-    ctx: ExecuteContext,
+fn execute_update_recipients<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipients: Vec<AddressWeight>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -360,8 +363,8 @@ fn execute_update_recipients(
     Ok(Response::default().add_attributes(vec![attr("action", "update_recipients")]))
 }
 
-fn execute_remove_recipient(
-    ctx: ExecuteContext,
+fn execute_remove_recipient<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: Recipient,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -407,7 +410,10 @@ fn execute_remove_recipient(
     Ok(Response::default().add_attributes(vec![attr("action", "removed_recipient")]))
 }
 
-fn execute_update_lock(ctx: ExecuteContext, lock_time: u64) -> Result<Response, ContractError> {
+fn execute_update_lock<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    lock_time: u64,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -15,7 +15,8 @@ use andromeda_std::{
 };
 use cosmwasm_std::{
     attr, coin, ensure, entry_point, from_json, to_json_binary, wasm_execute, BankMsg, Binary,
-    CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
+    CosmosMsg, CustomQuery, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg,
+    Uint128,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
@@ -90,7 +91,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -110,8 +114,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-pub fn execute_receive(
-    ctx: ExecuteContext,
+pub fn execute_receive<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { ref info, .. } = ctx;
@@ -156,8 +160,8 @@ pub fn execute_receive(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn execute_start_sale(
-    ctx: ExecuteContext,
+pub fn execute_start_sale<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     amount: Uint128,
     asset: AssetInfo,
     exchange_rate: Uint128,
@@ -267,8 +271,8 @@ fn generate_transfer_message(
     }
 }
 
-pub fn execute_purchase(
-    ctx: ExecuteContext,
+pub fn execute_purchase<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     amount_sent: Uint128,
     asset_sent: AssetInfo,
     recipient: &str,
@@ -354,8 +358,8 @@ pub fn execute_purchase(
     ]))
 }
 
-pub fn execute_purchase_native(
-    ctx: ExecuteContext,
+pub fn execute_purchase_native<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: Option<String>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -377,8 +381,8 @@ pub fn execute_purchase_native(
     execute_purchase(ctx, amount, asset, &recipient, &sender)
 }
 
-pub fn execute_cancel_sale(
-    ctx: ExecuteContext,
+pub fn execute_cancel_sale<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     asset: AssetInfo,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -122,8 +122,8 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute<C: CustomQuery>(
-    mut ctx: ExecuteContext<C>,
+pub fn handle_execute(
+    mut ctx: ExecuteContext<Empty>,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     let _contract = ADOContract::default();
@@ -178,8 +178,8 @@ pub fn handle_execute<C: CustomQuery>(
         .add_events(action_response.events))
 }
 
-fn receive_cw20<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn receive_cw20(
+    ctx: ExecuteContext<Empty>,
     msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -207,8 +207,8 @@ fn receive_cw20<C: CustomQuery>(
     }
 }
 
-fn execute_add_reward_token<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn execute_add_reward_token(
+    ctx: ExecuteContext<Empty>,
     reward_token: RewardTokenUnchecked,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -272,8 +272,8 @@ fn execute_add_reward_token<C: CustomQuery>(
         .add_attribute("added_token", reward_token_string))
 }
 
-fn execute_remove_reward_token<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn execute_remove_reward_token(
+    ctx: ExecuteContext<Empty>,
     reward_token_string: String,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -323,8 +323,8 @@ fn execute_remove_reward_token<C: CustomQuery>(
         .add_attribute("removed_token", reward_token_string))
 }
 
-fn execute_replace_reward_token<C: CustomQuery>(
-    ctx: ExecuteContext<C>,
+fn execute_replace_reward_token(
+    ctx: ExecuteContext<Empty>,
     origin_reward_token_string: String,
     reward_token: RewardTokenUnchecked,
 ) -> Result<Response, ContractError> {
@@ -414,7 +414,7 @@ fn execute_replace_reward_token<C: CustomQuery>(
 }
 /// The foundation for this approach is inspired by Anchor's staking implementation:
 /// https://github.com/Anchor-Protocol/anchor-token-contracts/blob/15c9d6f9753bd1948831f4e1b5d2389d3cf72c93/contracts/gov/src/staking.rs#L15
-fn execute_stake_tokens<C: CustomQuery>(
+fn execute_stake_tokens(
     deps: DepsMut<Empty>,
     env: Env,
     sender: String,
@@ -472,7 +472,7 @@ fn execute_stake_tokens<C: CustomQuery>(
         .add_attribute("amount", amount))
 }
 
-fn execute_unstake_tokens<C: CustomQuery>(
+fn execute_unstake_tokens(
     ctx: ExecuteContext<Empty>,
     amount: Option<Uint128>,
 ) -> Result<Response, ContractError> {
@@ -540,9 +540,7 @@ fn execute_unstake_tokens<C: CustomQuery>(
     }
 }
 
-fn execute_claim_rewards<C: CustomQuery>(
-    ctx: ExecuteContext<Empty>,
-) -> Result<Response, ContractError> {
+fn execute_claim_rewards(ctx: ExecuteContext<Empty>) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
@@ -627,7 +625,7 @@ fn execute_claim_rewards<C: CustomQuery>(
     }
 }
 
-fn update_global_indexes<C: CustomQuery>(
+fn update_global_indexes(
     storage: &mut dyn Storage,
     block_info: &BlockInfo,
     querier: &QuerierWrapper<Empty>,
@@ -673,7 +671,7 @@ fn update_global_indexes<C: CustomQuery>(
     Ok(Response::new().add_attributes(attributes))
 }
 
-fn update_global_index<C: CustomQuery>(
+fn update_global_index(
     block_info: &BlockInfo,
     querier: &QuerierWrapper<Empty>,
     current_timestamp: Milliseconds,

--- a/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/src/contract.rs
@@ -7,7 +7,8 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_std::{
-    attr, entry_point, Attribute, BlockInfo, Decimal, Decimal256, Order, QuerierWrapper, Uint256,
+    attr, entry_point, Attribute, BlockInfo, CustomQuery, Decimal, Decimal256, Empty, Order,
+    QuerierWrapper, Uint256,
 };
 use cosmwasm_std::{
     ensure, from_json, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, Storage,
@@ -121,7 +122,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let _contract = ADOContract::default();
     let action_response = call_action(
         &mut ctx.deps,
@@ -174,7 +178,10 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn receive_cw20(ctx: ExecuteContext, msg: Cw20ReceiveMsg) -> Result<Response, ContractError> {
+fn receive_cw20<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    msg: Cw20ReceiveMsg,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
@@ -200,8 +207,8 @@ fn receive_cw20(ctx: ExecuteContext, msg: Cw20ReceiveMsg) -> Result<Response, Co
     }
 }
 
-fn execute_add_reward_token(
-    ctx: ExecuteContext,
+fn execute_add_reward_token<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     reward_token: RewardTokenUnchecked,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -265,8 +272,8 @@ fn execute_add_reward_token(
         .add_attribute("added_token", reward_token_string))
 }
 
-fn execute_remove_reward_token(
-    ctx: ExecuteContext,
+fn execute_remove_reward_token<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     reward_token_string: String,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -316,8 +323,8 @@ fn execute_remove_reward_token(
         .add_attribute("removed_token", reward_token_string))
 }
 
-fn execute_replace_reward_token(
-    ctx: ExecuteContext,
+fn execute_replace_reward_token<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     origin_reward_token_string: String,
     reward_token: RewardTokenUnchecked,
 ) -> Result<Response, ContractError> {
@@ -407,8 +414,8 @@ fn execute_replace_reward_token(
 }
 /// The foundation for this approach is inspired by Anchor's staking implementation:
 /// https://github.com/Anchor-Protocol/anchor-token-contracts/blob/15c9d6f9753bd1948831f4e1b5d2389d3cf72c93/contracts/gov/src/staking.rs#L15
-fn execute_stake_tokens(
-    deps: DepsMut,
+fn execute_stake_tokens<C: CustomQuery>(
+    deps: DepsMut<Empty>,
     env: Env,
     sender: String,
     token_address: String,
@@ -465,8 +472,8 @@ fn execute_stake_tokens(
         .add_attribute("amount", amount))
 }
 
-fn execute_unstake_tokens(
-    ctx: ExecuteContext,
+fn execute_unstake_tokens<C: CustomQuery>(
+    ctx: ExecuteContext<Empty>,
     amount: Option<Uint128>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -533,7 +540,9 @@ fn execute_unstake_tokens(
     }
 }
 
-fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_claim_rewards<C: CustomQuery>(
+    ctx: ExecuteContext<Empty>,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
@@ -618,10 +627,10 @@ fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractError>
     }
 }
 
-fn update_global_indexes(
+fn update_global_indexes<C: CustomQuery>(
     storage: &mut dyn Storage,
     block_info: &BlockInfo,
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<Empty>,
     current_timestamp: Milliseconds,
     contract_address: Addr,
     asset_infos: Option<Vec<AssetInfo>>,
@@ -664,9 +673,9 @@ fn update_global_indexes(
     Ok(Response::new().add_attributes(attributes))
 }
 
-fn update_global_index(
+fn update_global_index<C: CustomQuery>(
     block_info: &BlockInfo,
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<Empty>,
     current_timestamp: Milliseconds,
     contract_address: Addr,
     state: &State,
@@ -716,7 +725,7 @@ fn update_global_index(
 /// https://github.com/lidofinance/lido-terra-contracts/tree/d7026b9142d718f9b5b6be03b1af33040499553c/contracts/lido_terra_reward/src
 fn update_nonallocated_index(
     state: &State,
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<Empty>,
     reward_token: &mut RewardToken,
     previous_reward_balance: Uint128,
     contract_address: Addr,
@@ -784,7 +793,7 @@ fn update_staker_reward_info(
     staker_reward_info.pending_rewards += Decimal256::from_ratio(rewards, 1u128);
 }
 
-pub(crate) fn get_staking_token(deps: Deps) -> Result<AssetInfo, ContractError> {
+pub(crate) fn get_staking_token<C: CustomQuery>(deps: Deps<C>) -> Result<AssetInfo, ContractError> {
     let _contract = ADOContract::default();
     let config = CONFIG.load(deps.storage)?;
 

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -6,7 +6,7 @@ use andromeda_std::{
     common::{actions::call_action, context::ExecuteContext, encode_binary, Funds},
     error::ContractError,
 };
-use cosmwasm_std::entry_point;
+use cosmwasm_std::{entry_point, CustomQuery, Empty};
 use cosmwasm_std::{
     from_json, to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
@@ -52,7 +52,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<Empty>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -67,7 +67,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<Empty>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action = msg.as_ref().to_string();
 
     let _contract = ADOContract::default();
@@ -116,7 +119,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
 }
 
 fn execute_transfer(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     recipient: AndrAddr,
     amount: Uint128,
     action: String,
@@ -125,7 +128,7 @@ fn execute_transfer(
 }
 
 fn execute_transfer_from(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     recipient: AndrAddr,
     owner: String,
     amount: Uint128,
@@ -134,8 +137,8 @@ fn execute_transfer_from(
     handle_transfer(ctx, recipient, Some(owner), amount, action, true)
 }
 
-fn handle_transfer(
-    ctx: ExecuteContext,
+fn handle_transfer<C: CustomQuery>(
+    ctx: ExecuteContext<Empty>,
     recipient: AndrAddr,
     owner: Option<String>,
     amount: Uint128,
@@ -230,7 +233,7 @@ fn transfer_tokens(
     Ok(())
 }
 
-fn execute_burn(ctx: ExecuteContext, amount: Uint128) -> Result<Response, ContractError> {
+fn execute_burn(ctx: ExecuteContext<Empty>, amount: Uint128) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
@@ -244,7 +247,7 @@ fn execute_burn(ctx: ExecuteContext, amount: Uint128) -> Result<Response, Contra
 }
 
 fn execute_send(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     contract: AndrAddr,
     amount: Uint128,
     msg: Binary,
@@ -254,7 +257,7 @@ fn execute_send(
 }
 
 fn execute_send_from(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     contract: AndrAddr,
     amount: Uint128,
     msg: Binary,
@@ -265,7 +268,7 @@ fn execute_send_from(
 }
 
 fn handle_send(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     contract: AndrAddr,
     amount: Uint128,
     msg: Binary,
@@ -346,7 +349,7 @@ fn handle_send(
 }
 
 fn execute_mint(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     recipient: String,
     amount: Uint128,
 ) -> Result<Response, ContractError> {

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -6,7 +6,7 @@ use andromeda_std::{
     common::{actions::call_action, context::ExecuteContext, encode_binary, Funds},
     error::ContractError,
 };
-use cosmwasm_std::{entry_point, CustomQuery, Empty};
+use cosmwasm_std::{entry_point, Empty};
 use cosmwasm_std::{
     from_json, to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
@@ -67,7 +67,7 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute<C: CustomQuery>(
+pub fn handle_execute(
     mut ctx: ExecuteContext<Empty>,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
@@ -137,7 +137,7 @@ fn execute_transfer_from(
     handle_transfer(ctx, recipient, Some(owner), amount, action, true)
 }
 
-fn handle_transfer<C: CustomQuery>(
+fn handle_transfer(
     ctx: ExecuteContext<Empty>,
     recipient: AndrAddr,
     owner: Option<String>,

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -14,7 +14,9 @@ use andromeda_std::{
     },
     error::ContractError,
 };
-use cosmwasm_std::{ensure, from_json, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
+use cosmwasm_std::{
+    ensure, from_json, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Response, Uint128,
+};
 use cosmwasm_std::{entry_point, Decimal};
 use cw_asset::Asset;
 
@@ -104,7 +106,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let _contract = ADOContract::default();
     let action_response = call_action(
         &mut ctx.deps,
@@ -134,8 +139,8 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     ADOContract::default().migrate(deps, CONTRACT_NAME, CONTRACT_VERSION)
 }
 
-pub fn receive_cw20(
-    ctx: ExecuteContext,
+pub fn receive_cw20<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     // CHECK :: Tokens sent > 0
@@ -170,8 +175,8 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
 
 /// @dev Facilitates increasing token incentives that are to be distributed as Lockdrop participation reward
 /// @params amount : Number of tokens which are to be added to current incentives
-pub fn execute_increase_incentives(
-    ctx: ExecuteContext,
+pub fn execute_increase_incentives<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     amount: Uint128,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -202,7 +207,9 @@ pub fn execute_increase_incentives(
 }
 
 /// @dev Facilitates NATIVE deposits.
-pub fn execute_deposit_native(ctx: ExecuteContext) -> Result<Response, ContractError> {
+pub fn execute_deposit_native<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, env, info, ..
     } = ctx;
@@ -264,8 +271,8 @@ pub fn execute_deposit_native(ctx: ExecuteContext) -> Result<Response, ContractE
 
 /// @dev Facilitates NATIVE withdrawal from an existing Lockup position. Can only be called when deposit / withdrawal window is open
 /// @param withdraw_amount : NATIVE amount to be withdrawn
-pub fn execute_withdraw_native(
-    ctx: ExecuteContext,
+pub fn execute_withdraw_native<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     withdraw_amount: Option<Uint128>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -340,7 +347,9 @@ pub fn execute_withdraw_native(
 /// Function callable only by Bootstrap contract (if it is specified) to enable TOKEN Claims by users.
 /// Called along-with Bootstrap contract's LP Pool provide liquidity tx. If it is not
 /// specified then anyone can execute this when the phase has ended.
-pub fn execute_enable_claims(ctx: ExecuteContext) -> Result<Response, ContractError> {
+pub fn execute_enable_claims<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, env, info, ..
     } = ctx;
@@ -381,7 +390,9 @@ pub fn execute_enable_claims(ctx: ExecuteContext) -> Result<Response, ContractEr
 }
 
 /// @dev Function to claim Rewards from lockdrop.
-pub fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractError> {
+pub fn execute_claim_rewards<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
     let config = CONFIG.load(deps.storage)?;
     let state = STATE.load(deps.storage)?;

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
@@ -3,7 +3,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, ensure, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+    attr, ensure, Addr, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+    Uint128,
 };
 use cw_utils::nonpayable;
 use sha2::Digest;
@@ -104,7 +105,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -132,8 +136,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-pub fn execute_register_merkle_root(
-    ctx: ExecuteContext,
+pub fn execute_register_merkle_root<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     merkle_root: String,
     expiration: Option<Expiry>,
     total_amount: Option<Uint128>,
@@ -177,8 +181,8 @@ pub fn execute_register_merkle_root(
     ]))
 }
 
-pub fn execute_claim(
-    ctx: ExecuteContext,
+pub fn execute_claim<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     stage: u8,
     amount: Uint128,
     proof: Vec<String>,
@@ -251,7 +255,10 @@ pub fn execute_claim(
     Ok(res)
 }
 
-pub fn execute_burn(ctx: ExecuteContext, stage: u8) -> Result<Response, ContractError> {
+pub fn execute_burn<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    stage: u8,
+) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -9,7 +9,7 @@ use andromeda_std::{
 };
 
 use cosmwasm_std::{
-    attr, ensure, entry_point, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    attr, ensure, entry_point, Addr, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Response,
 };
 use cw_utils::nonpayable;
 
@@ -75,7 +75,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::AddActorPermission { actor, permission } => {
             execute_add_actor_permission(ctx, actor, permission)
@@ -85,8 +88,8 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
     }
 }
 
-fn execute_add_actor_permission(
-    ctx: ExecuteContext,
+fn execute_add_actor_permission<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     actor: Addr,
     permission: LocalPermission,
 ) -> Result<Response, ContractError> {
@@ -109,8 +112,8 @@ fn execute_add_actor_permission(
     ]))
 }
 
-fn execute_remove_actor_permission(
-    ctx: ExecuteContext,
+fn execute_remove_actor_permission<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     actor: Addr,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -13,7 +13,8 @@ use andromeda_std::{
 };
 
 use cosmwasm_std::{
-    attr, coin, ensure, Binary, Coin, Deps, DepsMut, Env, Event, MessageInfo, Response, SubMsg,
+    attr, coin, ensure, Binary, Coin, CustomQuery, Deps, DepsMut, Env, Event, MessageInfo,
+    Response, SubMsg,
 };
 use cosmwasm_std::{entry_point, from_json};
 use cw20::Cw20Coin;
@@ -72,7 +73,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::SetRate { action, rate } => execute_set_rate(ctx, action, rate),
         ExecuteMsg::RemoveRate { action } => execute_remove_rate(ctx, action),
@@ -80,8 +84,8 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
     }
 }
 
-fn execute_set_rate(
-    ctx: ExecuteContext,
+fn execute_set_rate<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     action: String,
     mut rate: LocalRate,
 ) -> Result<Response, ContractError> {
@@ -105,7 +109,10 @@ fn execute_set_rate(
     Ok(Response::new().add_attributes(vec![attr("action", "set_rate")]))
 }
 
-fn execute_remove_rate(ctx: ExecuteContext, action: String) -> Result<Response, ContractError> {
+fn execute_remove_rate<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    action: String,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
     nonpayable(&info)?;
 

--- a/contracts/modules/andromeda-shunting/src/contract.rs
+++ b/contracts/modules/andromeda-shunting/src/contract.rs
@@ -10,7 +10,8 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_std::{
-    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, WasmQuery,
+    attr, ensure, entry_point, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Response,
+    WasmQuery,
 };
 use cw2::set_contract_version;
 use cw_utils::nonpayable;
@@ -69,7 +70,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::UpdateExpressions { expressions } => {
             execute_update_expression(ctx, expressions)
@@ -78,8 +82,8 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
     }
 }
 
-fn execute_update_expression(
-    ctx: ExecuteContext,
+fn execute_update_expression<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     expressions: Vec<String>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -25,8 +25,8 @@ use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 
 use cosmwasm_std::{
     attr, coins, ensure, entry_point, from_json, wasm_execute, Addr, BankMsg, Binary, Coin,
-    CosmosMsg, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, QueryRequest, Response, Storage,
-    SubMsg, Uint128, WasmMsg, WasmQuery,
+    CosmosMsg, CustomQuery, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, QueryRequest,
+    Response, Storage, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw20::{Cw20Coin, Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, OwnerOfResponse};
@@ -106,7 +106,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action = msg.as_ref().to_string();
 
     let action_response = call_action(
@@ -168,8 +171,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn handle_receive_cw721(
-    mut ctx: ExecuteContext,
+fn handle_receive_cw721<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
     msg: Cw721ReceiveMsg,
 ) -> Result<Response, ContractError> {
     ADOContract::default().is_permissioned(
@@ -202,8 +205,8 @@ fn handle_receive_cw721(
     }
 }
 
-pub fn handle_receive_cw20(
-    mut ctx: ExecuteContext,
+pub fn handle_receive_cw20<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
     receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let is_valid_cw20 = ADOContract::default()
@@ -252,8 +255,8 @@ pub fn handle_receive_cw20(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_start_auction(
-    ctx: ExecuteContext,
+fn execute_start_auction<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     sender: String,
     token_id: String,
     start_time: Option<Expiry>,
@@ -337,8 +340,8 @@ fn execute_start_auction(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_update_auction(
-    ctx: ExecuteContext,
+fn execute_update_auction<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
     start_time: Option<Expiry>,
@@ -443,8 +446,8 @@ fn execute_update_auction(
     ]))
 }
 
-fn execute_place_bid(
-    ctx: ExecuteContext,
+fn execute_place_bid<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
 ) -> Result<Response, ContractError> {
@@ -570,8 +573,8 @@ fn execute_place_bid(
     ]))
 }
 
-fn execute_place_bid_cw20(
-    ctx: ExecuteContext,
+fn execute_place_bid_cw20<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
     amount_sent: Uint128,
@@ -694,8 +697,8 @@ fn execute_place_bid_cw20(
         ]))
 }
 
-fn execute_cancel(
-    ctx: ExecuteContext,
+fn execute_cancel<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
 ) -> Result<Response, ContractError> {
@@ -755,8 +758,8 @@ fn execute_cancel(
     Ok(Response::new().add_messages(messages))
 }
 
-fn execute_claim(
-    ctx: ExecuteContext,
+fn execute_claim<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
     action: String,
@@ -846,8 +849,8 @@ fn execute_claim(
     Ok(resp)
 }
 
-fn execute_authorize_token_contract(
-    deps: DepsMut,
+fn execute_authorize_token_contract<C: CustomQuery>(
+    deps: DepsMut<C>,
     info: MessageInfo,
     token_address: AndrAddr,
     expiration: Option<Expiry>,
@@ -877,8 +880,8 @@ fn execute_authorize_token_contract(
     ]))
 }
 
-fn execute_deauthorize_token_contract(
-    deps: DepsMut,
+fn execute_deauthorize_token_contract<C: CustomQuery>(
+    deps: DepsMut<C>,
     info: MessageInfo,
     token_address: AndrAddr,
 ) -> Result<Response, ContractError> {
@@ -897,8 +900,8 @@ fn execute_deauthorize_token_contract(
     ]))
 }
 
-fn purchase_token(
-    deps: Deps,
+fn purchase_token<C: CustomQuery>(
+    deps: Deps<C>,
     _info: &MessageInfo,
     state: TokenAuctionState,
     action: String,
@@ -1161,8 +1164,8 @@ fn query_auction_state(
     Ok(token_auction_state.into())
 }
 
-fn query_owner_of(
-    querier: QuerierWrapper,
+fn query_owner_of<C: CustomQuery>(
+    querier: QuerierWrapper<C>,
     token_addr: String,
     token_id: String,
 ) -> Result<OwnerOfResponse, ContractError> {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -23,8 +23,8 @@ use andromeda_std::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, ensure, from_json, wasm_execute, Addr, BankMsg, Binary, Coin, Deps, DepsMut, Env,
-    MessageInfo, Reply, Response, StdError, Storage, SubMsg, Uint128, Uint64, WasmMsg,
+    coin, ensure, from_json, wasm_execute, Addr, BankMsg, Binary, Coin, CustomQuery, Deps, DepsMut,
+    Env, MessageInfo, Reply, Response, StdError, Storage, SubMsg, Uint128, Uint64, WasmMsg,
 };
 
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
@@ -116,7 +116,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
@@ -148,7 +151,10 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn execute_add_tier(ctx: ExecuteContext, tier: Tier) -> Result<Response, ContractError> {
+fn execute_add_tier<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    tier: Tier,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
     let contract = ADOContract::default();
@@ -183,7 +189,10 @@ fn execute_add_tier(ctx: ExecuteContext, tier: Tier) -> Result<Response, Contrac
     Ok(resp)
 }
 
-fn execute_update_tier(ctx: ExecuteContext, tier: Tier) -> Result<Response, ContractError> {
+fn execute_update_tier<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    tier: Tier,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
     let contract = ADOContract::default();
@@ -218,7 +227,10 @@ fn execute_update_tier(ctx: ExecuteContext, tier: Tier) -> Result<Response, Cont
     Ok(resp)
 }
 
-fn execute_remove_tier(ctx: ExecuteContext, level: Uint64) -> Result<Response, ContractError> {
+fn execute_remove_tier<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
+    level: Uint64,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
 
     let contract = ADOContract::default();
@@ -245,8 +257,8 @@ fn execute_remove_tier(ctx: ExecuteContext, level: Uint64) -> Result<Response, C
     Ok(resp)
 }
 
-fn execute_start_campaign(
-    ctx: ExecuteContext,
+fn execute_start_campaign<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     start_time: Option<MillisecondsExpiration>,
     end_time: MillisecondsExpiration,
     presale: Option<Vec<PresaleTierOrder>>,
@@ -308,8 +320,8 @@ fn execute_start_campaign(
     Ok(resp)
 }
 
-fn execute_purchase_tiers(
-    ctx: ExecuteContext,
+fn execute_purchase_tiers<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     orders: Vec<SimpleTierOrder>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -336,8 +348,8 @@ fn execute_purchase_tiers(
     purchase_tiers(ctx, Asset::NativeToken(denom), amount, sender, orders)
 }
 
-fn handle_receive_cw20(
-    ctx: ExecuteContext,
+fn handle_receive_cw20<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { ref info, .. } = ctx;
@@ -352,8 +364,8 @@ fn handle_receive_cw20(
     }
 }
 
-fn execute_end_campaign(
-    mut ctx: ExecuteContext,
+fn execute_end_campaign<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
     is_discard: bool,
 ) -> Result<Response, ContractError> {
     nonpayable(&ctx.info)?;
@@ -442,8 +454,8 @@ fn execute_end_campaign(
     Ok(resp)
 }
 
-fn purchase_tiers(
-    ctx: ExecuteContext,
+fn purchase_tiers<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     denom: Asset,
     amount: Uint128,
     sender: String,
@@ -561,8 +573,8 @@ fn transfer_asset_msg(
     })
 }
 
-fn withdraw_to_recipient(
-    ctx: ExecuteContext,
+fn withdraw_to_recipient<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     recipient: Recipient,
     amount: Uint128,
     denom: Asset,
@@ -592,7 +604,7 @@ fn withdraw_to_recipient(
     }
 }
 
-fn execute_claim(ctx: ExecuteContext) -> Result<Response, ContractError> {
+fn execute_claim<C: CustomQuery>(ctx: ExecuteContext<C>) -> Result<Response, ContractError> {
     let ExecuteContext { mut deps, info, .. } = ctx;
 
     let curr_stage = get_current_stage(deps.storage);
@@ -617,7 +629,10 @@ fn execute_claim(ctx: ExecuteContext) -> Result<Response, ContractError> {
     Ok(resp)
 }
 
-fn handle_successful_claim(deps: DepsMut, sender: &Addr) -> Result<Response, ContractError> {
+fn handle_successful_claim<C: CustomQuery>(
+    deps: DepsMut<C>,
+    sender: &Addr,
+) -> Result<Response, ContractError> {
     let campaign_config = get_config(deps.storage)?;
 
     let orders = get_user_orders(deps.storage, sender.clone(), None, None, true, None);
@@ -646,7 +661,10 @@ fn handle_successful_claim(deps: DepsMut, sender: &Addr) -> Result<Response, Con
     Ok(resp)
 }
 
-fn handle_failed_claim(deps: DepsMut, sender: &Addr) -> Result<Response, ContractError> {
+fn handle_failed_claim<C: CustomQuery>(
+    deps: DepsMut<C>,
+    sender: &Addr,
+) -> Result<Response, ContractError> {
     let campaign_config = get_config(deps.storage)?;
 
     let orders = get_user_orders(deps.storage, sender.clone(), None, None, false, None);

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -88,7 +88,10 @@ pub fn execute(
     }
 }
 
-fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+fn handle_execute(
+    mut ctx: ExecuteContext<Empty>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
     let action = msg.as_ref().to_string();
 
@@ -146,7 +149,7 @@ fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
 }
 
 fn execute_cw721(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     msg: Cw721ExecuteMsg<TokenExtension, ExecuteMsg>,
 ) -> Result<Response, ContractError> {
     let contract = AndrCW721Contract::default();
@@ -154,7 +157,7 @@ fn execute_cw721(
 }
 
 fn execute_mint(
-    mut ctx: ExecuteContext,
+    mut ctx: ExecuteContext<Empty>,
     token_id: String,
     token_uri: Option<String>,
     owner: String,
@@ -178,7 +181,7 @@ fn execute_mint(
 }
 
 fn mint(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     token_id: String,
     token_uri: Option<String>,
     owner: String,
@@ -209,7 +212,7 @@ fn mint(
 }
 
 fn execute_batch_mint(
-    mut ctx: ExecuteContext,
+    mut ctx: ExecuteContext<Empty>,
     tokens_to_mint: Vec<MintMsg>,
 ) -> Result<Response, ContractError> {
     let mut resp = Response::default();
@@ -250,7 +253,7 @@ fn execute_batch_mint(
 }
 
 fn execute_transfer(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     recipient: AndrAddr,
     token_id: String,
     action: &str,
@@ -388,7 +391,7 @@ fn check_can_send(
 }
 
 fn execute_update_transfer_agreement(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     token_id: String,
     agreement: Option<TransferAgreement>,
 ) -> Result<Response, ContractError> {
@@ -416,7 +419,10 @@ fn execute_update_transfer_agreement(
     Ok(Response::default())
 }
 
-fn execute_archive(ctx: ExecuteContext, token_id: String) -> Result<Response, ContractError> {
+fn execute_archive(
+    ctx: ExecuteContext<Empty>,
+    token_id: String,
+) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
     ensure!(
         !is_archived(deps.storage, &token_id)?.is_archived,
@@ -433,7 +439,7 @@ fn execute_archive(ctx: ExecuteContext, token_id: String) -> Result<Response, Co
     Ok(Response::default())
 }
 
-fn execute_burn(ctx: ExecuteContext, token_id: String) -> Result<Response, ContractError> {
+fn execute_burn(ctx: ExecuteContext<Empty>, token_id: String) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
     let contract = AndrCW721Contract::default();
     let token = contract.tokens.load(deps.storage, &token_id)?;
@@ -457,7 +463,7 @@ fn execute_burn(ctx: ExecuteContext, token_id: String) -> Result<Response, Contr
 }
 
 fn execute_send_nft(
-    ctx: ExecuteContext,
+    ctx: ExecuteContext<Empty>,
     token_id: String,
     contract_addr: AndrAddr,
     msg: Binary,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -32,8 +32,9 @@ use cw721::{Cw721ExecuteMsg, Cw721QueryMsg, Cw721ReceiveMsg, OwnerOfResponse};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, coin, ensure, from_json, Addr, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    QuerierWrapper, QueryRequest, Response, Storage, SubMsg, Uint128, WasmMsg, WasmQuery,
+    attr, coin, ensure, from_json, Addr, Binary, Coin, CosmosMsg, CustomQuery, Deps, DepsMut, Env,
+    MessageInfo, QuerierWrapper, QueryRequest, Response, Storage, SubMsg, Uint128, WasmMsg,
+    WasmQuery,
 };
 
 use cw_utils::{nonpayable, Expiration};
@@ -94,7 +95,10 @@ pub fn execute(
     }
 }
 
-pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+pub fn handle_execute<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
     let action = msg.as_ref().to_string();
 
     let action_response = call_action(
@@ -130,8 +134,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         .add_events(action_response.events))
 }
 
-fn handle_receive_cw721(
-    ctx: ExecuteContext,
+fn handle_receive_cw721<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     msg: Cw721ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -160,8 +164,8 @@ fn handle_receive_cw721(
     }
 }
 
-pub fn handle_receive_cw20(
-    mut ctx: ExecuteContext,
+pub fn handle_receive_cw20<C: CustomQuery>(
+    mut ctx: ExecuteContext<C>,
     receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     ADOContract::default().is_permissioned(
@@ -201,8 +205,8 @@ pub fn handle_receive_cw20(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_start_sale(
-    mut deps: DepsMut,
+fn execute_start_sale<C: CustomQuery>(
+    mut deps: DepsMut<C>,
     env: Env,
     sender: String,
     token_id: String,
@@ -269,8 +273,8 @@ fn execute_start_sale(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_update_sale(
-    ctx: ExecuteContext,
+fn execute_update_sale<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
     price: Uint128,
@@ -318,8 +322,8 @@ fn execute_update_sale(
     ]))
 }
 
-fn execute_buy(
-    ctx: ExecuteContext,
+fn execute_buy<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
     action: String,
@@ -453,8 +457,8 @@ fn execute_buy(
     Ok(resp)
 }
 
-fn execute_buy_cw20(
-    ctx: ExecuteContext,
+fn execute_buy_cw20<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
     amount_sent: Uint128,
@@ -593,8 +597,8 @@ fn execute_buy_cw20(
     Ok(resp)
 }
 
-fn execute_cancel(
-    ctx: ExecuteContext,
+fn execute_cancel<C: CustomQuery>(
+    ctx: ExecuteContext<C>,
     token_id: String,
     token_address: String,
 ) -> Result<Response, ContractError> {
@@ -641,8 +645,8 @@ fn execute_cancel(
         .add_attribute("recipient", info.sender))
 }
 
-fn purchase_token(
-    deps: Deps,
+fn purchase_token<C: CustomQuery>(
+    deps: Deps<C>,
     info: &MessageInfo,
     amount_sent: Option<Uint128>,
     state: TokenSaleState,
@@ -842,8 +846,8 @@ fn query_sale_state(deps: Deps, sale_id: Uint128) -> Result<SaleStateResponse, C
     Ok(token_sale_state.into())
 }
 
-fn query_owner_of(
-    querier: QuerierWrapper,
+fn query_owner_of<C: CustomQuery>(
+    querier: QuerierWrapper<C>,
     token_addr: String,
     token_id: String,
 ) -> Result<OwnerOfResponse, ContractError> {

--- a/contracts/os/andromeda-kernel/src/ibc.rs
+++ b/contracts/os/andromeda-kernel/src/ibc.rs
@@ -14,7 +14,7 @@ use cosmwasm_schema::cw_serde;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, from_json, to_json_binary, Addr, Binary, Coin, Deps, DepsMut, Empty, Env,
+    ensure, from_json, to_json_binary, Addr, Binary, Coin, CustomQuery, Deps, DepsMut, Empty, Env,
     Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcOrder, IbcPacketAckMsg, IbcPacketReceiveMsg,
     IbcPacketTimeoutMsg, IbcReceiveResponse, MessageInfo, SubMsg, Timestamp, WasmMsg,
@@ -163,8 +163,8 @@ pub fn do_ibc_packet_receive(
     }
 }
 
-pub fn ibc_create_ado(
-    _execute_ctx: ExecuteContext,
+pub fn ibc_create_ado<C: CustomQuery>(
+    _execute_ctx: ExecuteContext<C>,
     _owner: AndrAddr,
     _ado_type: String,
     _msg: Binary,
@@ -178,8 +178,8 @@ pub fn ibc_create_ado(
     //     .set_ack(make_ack_create_ado_success()))
 }
 
-pub fn ibc_register_username(
-    execute_ctx: ExecuteContext,
+pub fn ibc_register_username<C: CustomQuery>(
+    execute_ctx: ExecuteContext<C>,
     username: String,
     addr: String,
 ) -> Result<IbcReceiveResponse, ContractError> {
@@ -252,8 +252,8 @@ fn generate_ibc_denom(channel: String, denom: String) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn generate_transfer_message(
-    deps: &Deps,
+pub fn generate_transfer_message<C: CustomQuery>(
+    deps: &Deps<C>,
     recipient: AndrAddr,
     message: Binary,
     funds: Coin,
@@ -308,7 +308,10 @@ pub fn hash_denom_trace(unwrapped: &str) -> String {
     format!("ibc/{}", sha256::digest(unwrapped))
 }
 
-pub fn unwrap_denom_path(deps: &Deps, denom: &str) -> Result<Vec<MultiHopDenom>, ContractError> {
+pub fn unwrap_denom_path<C: CustomQuery>(
+    deps: &Deps<C>,
+    denom: &str,
+) -> Result<Vec<MultiHopDenom>, ContractError> {
     // Check that the denom is an IBC denom
     if !denom.starts_with("ibc/") {
         return Ok(vec![MultiHopDenom {

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -11,7 +11,7 @@ use andromeda_std::{
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
     attr, ensure, instantiate2_address, to_json_binary, wasm_execute, Addr, Api, Binary,
-    CodeInfoResponse, Deps, Event, QuerierWrapper, SubMsg, WasmMsg,
+    CodeInfoResponse, CustomQuery, Deps, Event, QuerierWrapper, SubMsg, WasmMsg,
 };
 use serde::Serialize;
 
@@ -124,11 +124,11 @@ impl AppComponent {
     /// Generates an `Instantiate2` address for the component.
     ///
     /// Returns `None` for `Symlink` and `CrossChain` components.
-    pub fn get_new_addr(
+    pub fn get_new_addr<C: CustomQuery>(
         &self,
         api: &dyn Api,
         adodb_addr: &Addr,
-        querier: &QuerierWrapper,
+        querier: &QuerierWrapper<C>,
         parent_addr: Addr,
     ) -> Result<Option<Addr>, ContractError> {
         if !matches!(self.component_type, ComponentType::New(..)) {
@@ -243,9 +243,9 @@ impl AppComponent {
     /// Generates an instantiation message for the component.
     ///
     /// Returns `None` for `Symlink` and `CrossChain` components.
-    pub fn generate_instantiation_message(
+    pub fn generate_instantiation_message<C: CustomQuery>(
         &self,
-        querier: &QuerierWrapper,
+        querier: &QuerierWrapper<C>,
         adodb_addr: &Addr,
         parent_addr: &Addr,
         sender: &str,

--- a/packages/andromeda-finance/src/conditional_splitter.rs
+++ b/packages/andromeda-finance/src/conditional_splitter.rs
@@ -4,7 +4,7 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Decimal, Deps, Uint128};
+use cosmwasm_std::{ensure, CustomQuery, Decimal, Deps, Uint128};
 use std::collections::HashSet;
 
 use crate::splitter::AddressPercent;
@@ -57,7 +57,7 @@ pub struct ConditionalSplitter {
     pub lock_time: Option<MillisecondsExpiration>,
 }
 impl ConditionalSplitter {
-    pub fn validate(&self, deps: Deps) -> Result<(), ContractError> {
+    pub fn validate<C: CustomQuery>(&self, deps: Deps<C>) -> Result<(), ContractError> {
         validate_thresholds(deps, &self.thresholds)
     }
 }
@@ -106,7 +106,10 @@ pub struct GetConditionalSplitterConfigResponse {
 /// * The number of recipients for each threshold must not exceed 100
 /// * The recipient addresses must be unique for each threshold
 /// * Make sure there are no duplicate min values between the thresholds
-pub fn validate_thresholds(deps: Deps, thresholds: &Vec<Threshold>) -> Result<(), ContractError> {
+pub fn validate_thresholds<C: CustomQuery>(
+    deps: Deps<C>,
+    thresholds: &Vec<Threshold>,
+) -> Result<(), ContractError> {
     ensure!(
         !thresholds.is_empty(),
         ContractError::EmptyThresholdsList {}

--- a/packages/andromeda-finance/src/splitter.rs
+++ b/packages/andromeda-finance/src/splitter.rs
@@ -7,7 +7,7 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Decimal, Deps};
+use cosmwasm_std::{ensure, CustomQuery, Decimal, Deps};
 
 #[cw_serde]
 pub struct AddressPercent {
@@ -79,8 +79,8 @@ pub struct GetSplitterConfigResponse {
 /// * The number of recipients must not exceed 100
 /// * The combined percentage of the recipients must not exceed 100
 /// * The recipient addresses must be unique
-pub fn validate_recipient_list(
-    deps: Deps,
+pub fn validate_recipient_list<C: CustomQuery>(
+    deps: Deps<C>,
     recipients: Vec<AddressPercent>,
 ) -> Result<(), ContractError> {
     ensure!(

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{amp::AndrAddr, andr_exec, andr_instantiate, andr_query, error::ContractError};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Coin, DepsMut, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, CustomQuery, DepsMut, Timestamp, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -50,7 +50,10 @@ impl InstantiateMsg {
     }
 }
 
-pub fn is_validator(deps: &DepsMut, validator: &Addr) -> Result<bool, ContractError> {
+pub fn is_validator<C: CustomQuery>(
+    deps: &DepsMut<C>,
+    validator: &Addr,
+) -> Result<bool, ContractError> {
     let validator = deps.querier.query_validator(validator)?;
     if validator.is_none() {
         return Err(ContractError::InvalidValidator {});

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.1.1"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_base/rates.rs
+++ b/packages/std/src/ado_base/rates.rs
@@ -6,7 +6,7 @@ use crate::{
     os::{adodb::ADOVersion, aos_querier::AOSQuerier},
 };
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{ensure, has_coins, Coin, Decimal, Deps, Event, Fraction, SubMsg};
+use cosmwasm_std::{ensure, has_coins, Coin, CustomQuery, Decimal, Deps, Event, Fraction, SubMsg};
 use cw20::Cw20Coin;
 
 #[cw_serde]
@@ -112,9 +112,9 @@ pub struct LocalRate {
 type LocalRateResponse = (Vec<SubMsg>, Vec<Event>, Vec<Coin>);
 
 impl LocalRate {
-    pub fn generate_response(
+    pub fn generate_response<C: CustomQuery>(
         &self,
-        deps: Deps,
+        deps: Deps<C>,
         coin: Coin,
         is_native: bool,
     ) -> Result<LocalRateResponse, ContractError> {
@@ -168,7 +168,7 @@ pub enum Rate {
 
 impl Rate {
     // Makes sure that the contract address is that of a Rates contract verified by the ADODB and validates the local rate value
-    pub fn validate_rate(&self, deps: Deps) -> Result<(), ContractError> {
+    pub fn validate_rate<C: CustomQuery>(&self, deps: Deps<C>) -> Result<(), ContractError> {
         match self {
             Rate::Contract(address) => {
                 let raw_address = address.get_raw_address(&deps)?;

--- a/packages/std/src/ado_contract/app.rs
+++ b/packages/std/src/ado_contract/app.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{ensure, Addr, DepsMut, MessageInfo, Response, Storage};
+use cosmwasm_std::{ensure, Addr, CustomQuery, DepsMut, MessageInfo, Response, Storage};
 
 use crate::ado_contract::ADOContract;
 use crate::amp::addresses::AndrAddr;
@@ -17,9 +17,9 @@ impl<'a> ADOContract<'a> {
         Ok(self.app_contract.may_load(storage)?)
     }
 
-    pub fn execute_update_app_contract(
+    pub fn execute_update_app_contract<C: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<C>,
         info: MessageInfo,
         address: String,
         addresses: Option<Vec<AndrAddr>>,

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -19,7 +19,7 @@ use semver::Version;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-type ExecuteContextFunction<M, C: CustomQuery, E = ContractError> =
+type ExecuteContextFunction<M, C, E = ContractError> =
     fn(ExecuteContext<C>, M) -> Result<Response, E>;
 
 impl<'a> ADOContract<'a> {

--- a/packages/std/src/ado_contract/ownership.rs
+++ b/packages/std/src/ado_contract/ownership.rs
@@ -5,7 +5,7 @@ use crate::{
     ado_base::ownership::{ContractPotentialOwnerResponse, OwnershipMessage},
     ado_contract::ADOContract,
 };
-use cosmwasm_std::{attr, ensure, Addr, DepsMut, Env, MessageInfo, Response, Storage};
+use cosmwasm_std::{attr, ensure, Addr, CustomQuery, DepsMut, Env, MessageInfo, Response, Storage};
 use cw_storage_plus::Item;
 
 const POTENTIAL_OWNER: Item<Addr> = Item::new("andr_potential_owner");
@@ -13,9 +13,9 @@ const POTENTIAL_OWNER_EXPIRATION: Item<MillisecondsExpiration> =
     Item::new("andr_potential_owner_expiration");
 
 impl<'a> ADOContract<'a> {
-    pub fn execute_ownership(
+    pub fn execute_ownership<C: cosmwasm_std::CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<'a, C>,
         env: Env,
         info: MessageInfo,
         msg: OwnershipMessage,
@@ -32,9 +32,9 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Updates the current contract owner. **Only executable by the current contract owner.**
-    pub fn update_owner(
+    pub fn update_owner<C: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<C>,
         env: Env,
         info: MessageInfo,
         new_owner: Addr,
@@ -65,9 +65,9 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Revokes the ownership offer. **Only executable by the current contract owner.**
-    pub fn revoke_ownership_offer(
+    pub fn revoke_ownership_offer<C: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<C>,
         info: MessageInfo,
     ) -> Result<Response, ContractError> {
         ensure!(
@@ -80,9 +80,9 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Accepts the ownership of the contract. **Only executable by the new contract owner.**
-    pub fn accept_ownership(
+    pub fn accept_ownership<C: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<C>,
         env: Env,
         info: MessageInfo,
     ) -> Result<Response, ContractError> {
@@ -106,7 +106,11 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Disowns the contract. **Only executable by the current contract owner.**
-    pub fn disown(&self, deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
+    pub fn disown<C: CustomQuery>(
+        &self,
+        deps: DepsMut<C>,
+        info: MessageInfo,
+    ) -> Result<Response, ContractError> {
         ensure!(
             self.is_contract_owner(deps.storage, info.sender.as_str())?,
             ContractError::Unauthorized {}

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -6,7 +6,9 @@ use crate::{
     common::{context::ExecuteContext, OrderBy},
     error::ContractError,
 };
-use cosmwasm_std::{ensure, Deps, DepsMut, Env, MessageInfo, Order, Response, Storage};
+use cosmwasm_std::{
+    ensure, CustomQuery, Deps, DepsMut, Env, MessageInfo, Order, Response, Storage,
+};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, MultiIndex};
 
 use super::ADOContract;
@@ -45,9 +47,9 @@ pub fn permissions<'a>() -> IndexedMap<'a, &'a str, PermissionInfo, PermissionsI
 }
 
 impl<'a> ADOContract<'a> {
-    pub fn execute_permissioning(
+    pub fn execute_permissioning<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         msg: PermissioningMessage,
     ) -> Result<Response, ContractError> {
         match msg {
@@ -70,9 +72,9 @@ impl<'a> ADOContract<'a> {
     /// Determines if the provided actor is authorised to perform the given action
     ///
     /// Returns an error if the given action is not permissioned for the given actor
-    pub fn is_permissioned(
+    pub fn is_permissioned<C: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<C>,
         env: Env,
         action: impl Into<String>,
         actor: impl Into<String>,
@@ -143,9 +145,9 @@ impl<'a> ADOContract<'a> {
     /// **Ignores the `PERMISSIONED_ACTIONS` map**
     ///
     /// Returns an error if the permission has expired or if no permission exists for a restricted ADO
-    pub fn is_permissioned_strict(
+    pub fn is_permissioned_strict<C: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<C>,
         env: Env,
         action: impl Into<String>,
         actor: impl Into<String>,
@@ -254,9 +256,9 @@ impl<'a> ADOContract<'a> {
     ///
     /// **Whitelisted/Limited permissions will only work for permissioned actions**
     ///
-    pub fn execute_set_permission(
+    pub fn execute_set_permission<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         actor: AndrAddr,
         action: impl Into<String>,
         permission: Permission,
@@ -283,9 +285,9 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Execute handler for setting permission
-    pub fn execute_remove_permission(
+    pub fn execute_remove_permission<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         actor: AndrAddr,
         action: impl Into<String>,
     ) -> Result<Response, ContractError> {
@@ -320,9 +322,9 @@ impl<'a> ADOContract<'a> {
         self.permissioned_actions.remove(store, action.into());
     }
 
-    pub fn execute_permission_action(
+    pub fn execute_permission_action<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         action: impl Into<String>,
     ) -> Result<Response, ContractError> {
         let action_string: String = action.into();
@@ -337,9 +339,9 @@ impl<'a> ADOContract<'a> {
         ]))
     }
 
-    pub fn execute_disable_action_permission(
+    pub fn execute_disable_action_permission<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         action: impl Into<String>,
     ) -> Result<Response, ContractError> {
         let action_string: String = action.into();
@@ -427,8 +429,8 @@ impl<'a> ADOContract<'a> {
 /// Two scenarios exist:
 /// - The context does not contain any AMP context and the **sender** is the actor
 /// - The context contains AMP context and the **previous sender** or **origin** are considered the actor
-pub fn is_context_permissioned(
-    deps: &mut DepsMut,
+pub fn is_context_permissioned<C: CustomQuery>(
+    deps: &mut DepsMut<C>,
     info: &MessageInfo,
     env: &Env,
     ctx: &Option<AMPPkt>,
@@ -464,8 +466,8 @@ pub fn is_context_permissioned(
 /// Two scenarios exist:
 /// - The context does not contain any AMP context and the **sender** is the actor
 /// - The context contains AMP context and the **previous sender** or **origin** are considered the actor
-pub fn is_context_permissioned_strict(
-    mut deps: DepsMut,
+pub fn is_context_permissioned_strict<C: CustomQuery>(
+    mut deps: DepsMut<C>,
     info: &MessageInfo,
     env: &Env,
     ctx: &Option<AMPPkt>,

--- a/packages/std/src/ado_contract/rates.rs
+++ b/packages/std/src/ado_contract/rates.rs
@@ -3,7 +3,7 @@ use crate::amp::Recipient;
 use crate::common::{context::ExecuteContext, Funds};
 use crate::error::ContractError;
 use crate::os::aos_querier::AOSQuerier;
-use cosmwasm_std::{coin as create_coin, ensure, Coin, Deps, Response, Storage};
+use cosmwasm_std::{coin as create_coin, ensure, Coin, CustomQuery, Deps, Response, Storage};
 use cw20::Cw20Coin;
 use cw_storage_plus::Map;
 
@@ -25,9 +25,9 @@ impl<'a> ADOContract<'a> {
         self.rates.save(store, &action, &rate)?;
         Ok(())
     }
-    pub fn execute_rates(
+    pub fn execute_rates<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         rates_message: RatesMessage,
     ) -> Result<Response, ContractError> {
         match rates_message {
@@ -35,9 +35,9 @@ impl<'a> ADOContract<'a> {
             RatesMessage::RemoveRate { action } => self.execute_remove_rates(ctx, action),
         }
     }
-    pub fn execute_set_rates(
+    pub fn execute_set_rates<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         action: impl Into<String>,
         mut rate: Rate,
     ) -> Result<Response, ContractError> {
@@ -73,9 +73,9 @@ impl<'a> ADOContract<'a> {
         self.rates.remove(store, &action);
         Ok(())
     }
-    pub fn execute_remove_rates(
+    pub fn execute_remove_rates<C: CustomQuery>(
         &self,
-        ctx: ExecuteContext,
+        ctx: ExecuteContext<C>,
         action: impl Into<String>,
     ) -> Result<Response, ContractError> {
         ensure!(
@@ -116,9 +116,9 @@ impl<'a> ADOContract<'a> {
         Ok(AllRatesResponse { all_rates })
     }
 
-    pub fn query_deducted_funds(
+    pub fn query_deducted_funds<C: CustomQuery>(
         self,
-        deps: Deps,
+        deps: Deps<C>,
         action: impl Into<String>,
         funds: Funds,
     ) -> Result<Option<RatesResponse>, ContractError> {

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -4,7 +4,7 @@ use crate::error::ContractError;
 use crate::os::vfs::{vfs_resolve_symlink, PATH_REGEX, PROTOCOL_PATH_REGEX};
 use crate::{ado_contract::ADOContract, os::vfs::vfs_resolve_path};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Api, Deps, QuerierWrapper, Storage};
+use cosmwasm_std::{Addr, Api, CustomQuery, Deps, QuerierWrapper, Storage};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -78,7 +78,7 @@ impl AndrAddr {
     /// If the address is a valid human readable address then that is returned, otherwise it is assumed to be a Andromeda VFS path and is resolved accordingly.
     ///
     /// If the address is assumed to be a VFS path and no VFS contract address is provided then an appropriate error is returned.
-    pub fn get_raw_address(&self, deps: &Deps) -> Result<Addr, ContractError> {
+    pub fn get_raw_address<C: CustomQuery>(&self, deps: &Deps<C>) -> Result<Addr, ContractError> {
         if !self.is_vfs_path() {
             return Ok(deps.api.addr_validate(&self.0)?);
         }
@@ -93,9 +93,9 @@ impl AndrAddr {
     /// If the address is a valid human readable address then that is returned, otherwise it is assumed to be a Andromeda VFS path and is resolved accordingly.
     ///
     /// If the address is assumed to be a VFS path and no VFS contract address is provided then an appropriate error is returned.
-    pub fn get_raw_address_from_vfs(
+    pub fn get_raw_address_from_vfs<C: CustomQuery>(
         &self,
-        deps: &Deps,
+        deps: &Deps<C>,
         vfs_contract: impl Into<String>,
     ) -> Result<Addr, ContractError> {
         match self.is_vfs_path() {
@@ -119,10 +119,10 @@ impl AndrAddr {
     }
 
     /// Converts a local path to a valid VFS path by replacing `./` with the app contract address
-    pub fn local_path_to_vfs_path(
+    pub fn local_path_to_vfs_path<C: CustomQuery>(
         &self,
         storage: &dyn Storage,
-        querier: &QuerierWrapper,
+        querier: &QuerierWrapper<C>,
         vfs_contract: impl Into<String>,
     ) -> Result<AndrAddr, ContractError> {
         match self.is_local_path() {

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -5,8 +5,8 @@ use crate::os::aos_querier::AOSQuerier;
 use crate::os::{kernel::ExecuteMsg as KernelExecuteMsg, kernel::QueryMsg as KernelQueryMsg};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_json_binary, wasm_execute, Addr, Binary, Coin, ContractInfoResponse, CosmosMsg, Deps, Empty,
-    MessageInfo, QueryRequest, ReplyOn, SubMsg, WasmMsg, WasmQuery,
+    to_json_binary, wasm_execute, Addr, Binary, Coin, ContractInfoResponse, CosmosMsg, CustomQuery,
+    Deps, Empty, MessageInfo, QueryRequest, ReplyOn, SubMsg, WasmMsg, WasmQuery,
 };
 
 use super::addresses::AndrAddr;
@@ -301,7 +301,11 @@ impl AMPPkt {
     /// 3. The sender has a code ID stored within the ADODB (and as such is a valid ADO)
     ///
     /// If the sender is not valid, an error is returned
-    pub fn verify_origin(&self, info: &MessageInfo, deps: &Deps) -> Result<(), ContractError> {
+    pub fn verify_origin<C: CustomQuery>(
+        &self,
+        info: &MessageInfo,
+        deps: &Deps<C>,
+    ) -> Result<(), ContractError> {
         let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
         if info.sender == self.ctx.origin || info.sender == kernel_address {
             Ok(())

--- a/packages/std/src/amp/recipient.rs
+++ b/packages/std/src/amp/recipient.rs
@@ -1,7 +1,9 @@
 use super::{addresses::AndrAddr, messages::AMPMsg};
 use crate::{ado_contract::ADOContract, common::encode_binary, error::ContractError};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, SubMsg, WasmMsg};
+use cosmwasm_std::{
+    to_json_binary, BankMsg, Binary, Coin, CosmosMsg, CustomQuery, Deps, SubMsg, WasmMsg,
+};
 use cw20::{Cw20Coin, Cw20ExecuteMsg};
 use serde::Serialize;
 
@@ -28,7 +30,7 @@ impl Recipient {
     }
 
     /// Validates a recipient by validating its address and recovery address (if it is provided)
-    pub fn validate(&self, deps: &Deps) -> Result<(), ContractError> {
+    pub fn validate<C: CustomQuery>(&self, deps: &Deps<C>) -> Result<(), ContractError> {
         self.address.validate(deps.api)?;
         self.address.get_raw_address(deps)?;
 
@@ -59,9 +61,9 @@ impl Recipient {
     }
 
     /// Generates a direct sub message for the given recipient.
-    pub fn generate_direct_msg(
+    pub fn generate_direct_msg<C: CustomQuery>(
         &self,
-        deps: &Deps,
+        deps: &Deps<C>,
         funds: Vec<Coin>,
     ) -> Result<SubMsg, ContractError> {
         let resolved_addr = self.address.get_raw_address(deps)?;
@@ -82,9 +84,9 @@ impl Recipient {
     /// Generates a message to send a CW20 token to the recipient with the attached message.
     ///
     /// **Assumes the attached message is a valid CW20 Hook message for the receiving address**.
-    pub fn generate_msg_cw20(
+    pub fn generate_msg_cw20<C: CustomQuery>(
         &self,
-        deps: &Deps,
+        deps: &Deps<C>,
         cw20_coin: Cw20Coin,
     ) -> Result<SubMsg, ContractError> {
         let resolved_addr = self.address.get_raw_address(deps)?;
@@ -112,9 +114,9 @@ impl Recipient {
     /// Generates an AMP message from the given Recipient.
     ///
     /// This can be attached to an AMP Packet for execution via the aOS.
-    pub fn generate_amp_msg(
+    pub fn generate_amp_msg<C: CustomQuery>(
         &self,
-        deps: &Deps,
+        deps: &Deps<C>,
         funds: Option<Vec<Coin>>,
     ) -> Result<AMPMsg, ContractError> {
         let mut address = self.address.clone();

--- a/packages/std/src/common/actions.rs
+++ b/packages/std/src/common/actions.rs
@@ -3,10 +3,10 @@ use crate::{
     amp::messages::AMPPkt,
     error::ContractError,
 };
-use cosmwasm_std::{ensure, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{ensure, CustomQuery, DepsMut, Env, MessageInfo, Response};
 
-pub fn call_action(
-    deps: &mut DepsMut,
+pub fn call_action<C: CustomQuery>(
+    deps: &mut DepsMut<C>,
     info: &MessageInfo,
     env: &Env,
     amp_ctx: &Option<AMPPkt>,

--- a/packages/std/src/common/context.rs
+++ b/packages/std/src/common/context.rs
@@ -1,16 +1,16 @@
 use crate::amp::messages::AMPPkt;
-use cosmwasm_std::{DepsMut, Env, MessageInfo};
+use cosmwasm_std::{CustomQuery, DepsMut, Env, MessageInfo};
 
-pub struct ExecuteContext<'a> {
-    pub deps: DepsMut<'a>,
+pub struct ExecuteContext<'a, C: CustomQuery> {
+    pub deps: DepsMut<'a, C>,
     pub info: MessageInfo,
     pub env: Env,
     pub amp_ctx: Option<AMPPkt>,
 }
 
-impl<'a> ExecuteContext<'a> {
+impl<'a, C: CustomQuery> ExecuteContext<'a, C> {
     #[inline]
-    pub fn new(deps: DepsMut, info: MessageInfo, env: Env) -> ExecuteContext {
+    pub fn new(deps: DepsMut<C>, info: MessageInfo, env: Env) -> ExecuteContext<C> {
         ExecuteContext {
             deps,
             info,

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -2,7 +2,7 @@ use crate::ado_base::permissioning::LocalPermission;
 use crate::amp::{ADO_DB_KEY, VFS_KEY};
 use crate::error::ContractError;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{from_json, Addr, QuerierWrapper};
+use cosmwasm_std::{from_json, Addr, CustomQuery, QuerierWrapper};
 use cw_storage_plus::Path;
 use lazy_static::__Deref;
 use serde::de::DeserializeOwned;
@@ -34,8 +34,8 @@ impl AOSQuerier {
     // To find the key value in storage, we need to construct a path to the key
     // For Map storage this key is generated with get_map_storage_key
     // For Item storage this key is the namespace value
-    pub fn query_storage<T>(
-        querier: &QuerierWrapper,
+    pub fn query_storage<T, C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         addr: &Addr,
         key: &str,
     ) -> Result<Option<T>, ContractError>
@@ -53,8 +53,8 @@ impl AOSQuerier {
         }
     }
 
-    pub fn ado_type_getter(
-        querier: &QuerierWrapper,
+    pub fn ado_type_getter<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         adodb_addr: &Addr,
         code_id: u64,
     ) -> Result<Option<String>, ContractError> {
@@ -63,8 +63,8 @@ impl AOSQuerier {
         Ok(ado_type.map(|v| v.get_type()))
     }
 
-    pub fn ado_type_getter_smart(
-        querier: &QuerierWrapper,
+    pub fn ado_type_getter_smart<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         adodb_addr: &Addr,
         code_id: u64,
     ) -> Result<Option<String>, ContractError> {
@@ -88,8 +88,8 @@ impl AOSQuerier {
     }
 
     /// Checks if the code id exists in the ADODB by querying its raw storage for the code id's ado type
-    pub fn verify_code_id(
-        querier: &QuerierWrapper,
+    pub fn verify_code_id<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         adodb_addr: &Addr,
         code_id: u64,
     ) -> Result<(), ContractError> {
@@ -117,8 +117,8 @@ impl AOSQuerier {
         }
     }
 
-    pub fn code_id_getter(
-        querier: &QuerierWrapper,
+    pub fn code_id_getter<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         adodb_addr: &Addr,
         ado_type: &str,
     ) -> Result<u64, ContractError> {
@@ -130,24 +130,24 @@ impl AOSQuerier {
     }
 
     /// Queries the kernel's raw storage for the VFS's address
-    pub fn vfs_address_getter(
-        querier: &QuerierWrapper,
+    pub fn vfs_address_getter<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         kernel_addr: &Addr,
     ) -> Result<Addr, ContractError> {
         AOSQuerier::kernel_address_getter(querier, kernel_addr, VFS_KEY)
     }
 
     /// Queries the kernel's raw storage for the ADODB's address
-    pub fn adodb_address_getter(
-        querier: &QuerierWrapper,
+    pub fn adodb_address_getter<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         kernel_addr: &Addr,
     ) -> Result<Addr, ContractError> {
         AOSQuerier::kernel_address_getter(querier, kernel_addr, ADO_DB_KEY)
     }
 
     /// Queries the kernel's raw storage for the VFS's address
-    pub fn kernel_address_getter(
-        querier: &QuerierWrapper,
+    pub fn kernel_address_getter<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         kernel_addr: &Addr,
         key: &str,
     ) -> Result<Addr, ContractError> {
@@ -175,8 +175,8 @@ impl AOSQuerier {
     }
 
     /// Queries the kernel's raw storage for the VFS's address
-    pub fn ado_owner_getter(
-        querier: &QuerierWrapper,
+    pub fn ado_owner_getter<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         ado_addr: &Addr,
     ) -> Result<Addr, ContractError> {
         let verify: Option<Addr> = AOSQuerier::query_storage(querier, ado_addr, "owner")?;
@@ -214,8 +214,8 @@ impl AOSQuerier {
         }
     }
     /// Queries an actor's permission from the address list contract
-    pub fn get_permission(
-        querier: &QuerierWrapper,
+    pub fn get_permission<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         contract_addr: &Addr,
         actor: &str,
     ) -> Result<LocalPermission, ContractError> {
@@ -230,8 +230,8 @@ impl AOSQuerier {
 
     #[cfg(feature = "rates")]
     /// Queries the rates contract
-    pub fn get_rate(
-        querier: &QuerierWrapper,
+    pub fn get_rate<C: CustomQuery>(
+        querier: &QuerierWrapper<C>,
         addr: &Addr,
         action: &str,
     ) -> Result<LocalRate, ContractError> {

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -1,6 +1,6 @@
 use crate::{ado_base::ownership::OwnershipMessage, amp::AndrAddr, error::ContractError};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Addr, Api, QuerierWrapper};
+use cosmwasm_std::{ensure, Addr, Api, CustomQuery, QuerierWrapper};
 use regex::Regex;
 
 pub const COMPONENT_NAME_REGEX: &str = r"^[A-Za-z0-9.\-_]{2,80}$";
@@ -229,10 +229,10 @@ pub enum QueryMsg {
 }
 
 /// Queries the provided VFS contract address to resolve the given path
-pub fn vfs_resolve_path(
+pub fn vfs_resolve_path<C: CustomQuery>(
     path: impl Into<String>,
     vfs_contract: impl Into<String>,
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<C>,
 ) -> Result<Addr, ContractError> {
     let query = QueryMsg::ResolvePath {
         path: AndrAddr::from_string(path.into()),
@@ -245,10 +245,10 @@ pub fn vfs_resolve_path(
 }
 
 /// Queries the provided VFS contract address to resolve the given path
-pub fn vfs_resolve_symlink(
+pub fn vfs_resolve_symlink<C: CustomQuery>(
     path: impl Into<String>,
     vfs_contract: impl Into<String>,
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<C>,
 ) -> Result<AndrAddr, ContractError> {
     let query = QueryMsg::ResolveSymlink {
         path: AndrAddr::from_string(path.into()),


### PR DESCRIPTION
# Motivation
Closes #536 

# Implementation
Adjusted `ExecuteContext` to the following:
```rust
pub struct ExecuteContext<'a, C: CustomQuery> {
    pub deps: DepsMut<'a, C>,
    pub info: MessageInfo,
    pub env: Env,
    pub amp_ctx: Option<AMPPkt>,
}
```
and applied all the necessary adjustments to accommodate the above change

# Testing
No tests were affected nor created

# Version Changes
`std` from 1.1.1 to 1.2.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- end of auto-generated comment: release notes by coderabbit.ai -->