### PR TITLE
add readme to ADOs

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-commit_message="$1"
-# exit with a non zero exit code incase of an invalid commit message
-
-# use git-conventional-commits, see https://github.com/qoomon/git-conventional-commits
-npx git-conventional-commits commit-msg-hook "$commit_message"

--- a/contracts/app/andromeda-app-contract/README.md
+++ b/contracts/app/andromeda-app-contract/README.md
@@ -1,0 +1,6 @@
+# Overview
+
+The App ADO is a smart contract that is used to bundle up ADOs that will be interacting with each other into  what we call an  "App". It also offers a naming system that allows the contracts to reference each other by their assigned names rather than contract addresses. 
+An ADO in the App is called an AppComponent. Every App would be composed of many of these components (up to 50). Each component is assigned a name which can be used by other components to reference each other. The App ADO allows us to instantiate all of these components in one go. 
+
+[App Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/app)

--- a/contracts/data-storage/andromeda-primitive/README.md
+++ b/contracts/data-storage/andromeda-primitive/README.md
@@ -1,0 +1,21 @@
+# Overview
+
+The Primitive ADO is a smart contract that is used to store data. It is a simple contract that allows us to store key/value pairs acting like a database. It supports storage of the following data types:
+
+```rust
+pub enum Primitive {
+    Uint128(Uint128),
+    Decimal(Decimal),
+    Coin(Coin),
+    Addr(Addr),
+    String(String),
+    Bool(bool),
+    Binary(Binary),
+}
+```
+The Primitive ADO can be set to one of the following:
+- Private: Only accessible by the contract owner of the ADO.
+- Public: Accessible by anyone.
+- Restricted: Only accessible to the key owner.
+
+**Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.

--- a/contracts/ecosystem/andromeda-vault/README.md
+++ b/contracts/ecosystem/andromeda-vault/README.md
@@ -1,0 +1,2 @@
+# Note
+This ADO is depricated. 

--- a/contracts/finance/andromeda-conditional-splitter/README.md
+++ b/contracts/finance/andromeda-conditional-splitter/README.md
@@ -1,0 +1,7 @@
+# Overview
+
+The Conditional Splitter ADO is a smart contract used to split funds to specified recipients based on the amount that is sent. At instantiation, the owner specifies the recipient sets along with the minimum amount of funds needed for each set. 
+The ADO can be locked by the owner meaning that the recipient lists cannot be changed for the duration of the lock.
+
+**Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.
+

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/README.md
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+The Rate Limiting Withdrawals ADO acts as a bank account that limits the frequency and size of an account holder's withdrawals. Only one type of coin can be used. A user can deposit funds for themselves or another user and these funds can be withdrawn according the the specified limits.
+
+[Rate Limiting Withdrawals Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/rate-limiting-withdrawals)

--- a/contracts/finance/andromeda-splitter/README.md
+++ b/contracts/finance/andromeda-splitter/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+The Splitter ADO is a smart contract used to split funds to a preset number of addresses. Each of the addresses has a specific percentage assigned by the contract owner. The splitter can be locked for a specified time as a kind of insurance for recipients that their percentages will not be changed for a certain period of time. Whenever funds are sent to the splitter using the `Send` execute message, they are automatically distributed to the recipient set.
+
+[Splitter Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/splitter)

--- a/contracts/finance/andromeda-timelock/README.md
+++ b/contracts/finance/andromeda-timelock/README.md
@@ -1,0 +1,11 @@
+# Overview
+
+The Timelock ADO or Escrow ADO is a smart contract built to hold funds (Native coins) for a period of time until the set condition is satisfied. 
+There are two main conditions that can be used by the contract:
+- **Expiration:** A time expiration to when the funds can be released.
+- **MinimumFunds:** A minimum amount of funds to be deposited before they can be released.
+
+Once a condition is satisfied, the funds can be released.
+
+[Timelock Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/timelock)
+

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/README.md
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/README.md
@@ -1,0 +1,12 @@
+# Overview
+
+The CW20 Exchange ADO is used to sell CW20 tokens for other assets. The CW20 token to be sold is specified at instantiation, and then sales can be started on the token by the contract owner by sending them to this ADO. Each sale has an "asset" to purchase the tokens with. This asset can be:
+
+- CW20 
+- Native
+
+Users can then purchase the CW20 token being sold by sending the required asset to the contract.
+
+[CW20 Exchange Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw20-exchange)
+
+

--- a/contracts/fungible-tokens/andromeda-cw20-staking/README.md
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+This CW20 Staking ADO allows users to stake a specified CW20 token and to receive rewards in proportion to their share. The reward token does not need to be the token they stake with. 
+
+[CW20 Staking Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw20-staking)

--- a/contracts/fungible-tokens/andromeda-cw20/README.md
+++ b/contracts/fungible-tokens/andromeda-cw20/README.md
@@ -1,0 +1,8 @@
+# Overview
+
+The CW20 ADO is a smart contract to initiate a [standard CW20 token](https://github.com/CosmWasm/cw-plus/blob/main/packages/cw20/README.md). CW20 is a specification for fungible tokens based on CosmWasm.
+
+[CW20 Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw20)
+
+
+

--- a/contracts/fungible-tokens/andromeda-lockdrop/README.md
+++ b/contracts/fungible-tokens/andromeda-lockdrop/README.md
@@ -1,5 +1,5 @@
 # Overview 
 
-The Lockdrop ADO is another part of the toolkit of allowing a user to setup their own CW20 token. The lockdrop ADO allows users to deposit a native token to be locked for a certain period of time, in exchange for a given CW20 token reward. 
+The Lockdrop ADO is another part of the toolkit of allowing a user to set up their own CW20 token. The lockdrop ADO allows users to deposit a native token to be locked for a certain period of time, in exchange for a given CW20 token reward. 
 
 [Lockdrop Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/lockdrop)

--- a/contracts/fungible-tokens/andromeda-lockdrop/README.md
+++ b/contracts/fungible-tokens/andromeda-lockdrop/README.md
@@ -1,0 +1,5 @@
+# Overview 
+
+The Lockdrop ADO is another part of the toolkit of allowing a user to setup their own CW20 token. The lockdrop ADO allows users to deposit a native token to be locked for a certain period of time, in exchange for a given CW20 token reward. 
+
+[Lockdrop Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/lockdrop)

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/README.md
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+The Merkle-Airdrop ADO is a smart contract that allows projects to launch airdrops using the Merkle-tree (hashing). Uses the same logic of the [base cw20-merkel-airdrop](https://github.com/CosmWasm/cw-tokens/tree/main/contracts/cw20-merkle-airdrop) contract. If you do not know what is a Merkle-airdrop and how it is different from a normal airdrop, please refer to the following [article](https://medium.com/smartz-blog/merkle-airdrop-the-basics-9a0857fcc930).
+
+[Merkle Airdrop Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/merkle-airdrop)

--- a/contracts/modules/andromeda-address-list/README.md
+++ b/contracts/modules/andromeda-address-list/README.md
@@ -1,0 +1,7 @@
+# Overview
+
+The address list ADO is a smart contract that facilitates setting up permissions for ADOs. Instead of setting up the permission on the ADO itself, the owner can reference this ADO instead.
+
+Permissioning allows ADO owners to give/restrict access to addresses to execute messages on their ADOs.
+
+**Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.

--- a/contracts/modules/andromeda-rates/README.md
+++ b/contracts/modules/andromeda-rates/README.md
@@ -1,5 +1,5 @@
 # Overview
 
-The Rates ADO is a smart contract that can be used to hold rates configurations for other ADOs. Instead of setting up the rate on the ADO itself, the ADO can reference this ADO to extract the rates set up and apply them on the ADO. These rates can be used to add a fee that is payed on a messages whether a tax or royalty. 
+The Rates ADO is a smart contract that can be used to hold rates configurations for other ADOs. Instead of setting up the rate on the ADO itself, the ADO can reference this ADO to extract the rates set up and apply them on the ADO. These rates can be used to add a fee that is paid on a messages whether a tax or royalty. 
 
 **Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.

--- a/contracts/modules/andromeda-rates/README.md
+++ b/contracts/modules/andromeda-rates/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+The Rates ADO is a smart contract that can be used to hold rates configurations for other ADOs. Instead of setting up the rate on the ADO itself, the ADO can reference this ADO to extract the rates set up and apply them on the ADO. These rates can be used to add a fee that is payed on a messages whether a tax or royalty. 
+
+**Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.

--- a/contracts/modules/andromeda-rates/README.md
+++ b/contracts/modules/andromeda-rates/README.md
@@ -1,5 +1,5 @@
 # Overview
 
-The Rates ADO is a smart contract that can be used to hold rates configurations for other ADOs. Instead of setting up the rate on the ADO itself, the ADO can reference this ADO to extract the rates set up and apply them on the ADO. These rates can be used to add a fee that is paid on a messages whether a tax or royalty. 
+The Rates ADO is a smart contract that can be used to hold rates configurations for other ADOs. Instead of setting up the rate on the ADO itself, the ADO can reference this ADO to extract the rates set up and apply them on the ADO. These rates can be used to add a fee that is paid on a message, whether a tax or royalty. 
 
 **Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.

--- a/contracts/non-fungible-tokens/andromeda-auction/README.md
+++ b/contracts/non-fungible-tokens/andromeda-auction/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+The Auction ADO is a smart contract that allows performing custom auctions on NFTs. NFTs can be sent to this contract with the required messages to start an auction on it. Once the auction has started, users can place bids on the token until the auction expires. The highest bid will win the auction, sending the funds to the seller and receiving the token in return. 
+
+[Auction Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/auction)

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/README.md
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/README.md
@@ -1,0 +1,6 @@
+# Overview
+
+The Crowdfund ADO is a smart contract that allows users to start a campaign and raise funds for their projects/goal by selling NFTs.
+Each campaign can contain multiple tiers for different levels of support. For example you could have a bronze, silver, and gold tier for your crowdfund each having a specified price. All NFTs of the same tier share the same metadata. 
+
+**Note**: This ADO is not released yet. Once released, a link to full documentation will be provided.

--- a/contracts/non-fungible-tokens/andromeda-cw721/README.md
+++ b/contracts/non-fungible-tokens/andromeda-cw721/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+The CW721 ADO is a smart contract to allow users to launch their own custom NFT projects. In addition to the standard CW721 messages, we have added some custom logic to further extend the utility and function of the contract. 
+
+[CW721 Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw721)

--- a/contracts/non-fungible-tokens/andromeda-marketplace/README.md
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/README.md
@@ -1,0 +1,10 @@
+# Overview
+
+The Marketplace ADO is a smart contract that allows you to sell your NFTs in a marketplace. The seller sends their NFT to the Marketplace ADO and attaches the sale options such as the price and funds used to purchase the NFT. Once the NFT is sent, the sale will start at the time specified by the seller.
+
+Purchasing the NFT can be customized to work with one of the following options:
+
+- CW20
+- Native 
+
+[Marketplace Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/marketplace)

--- a/contracts/os/andromeda-adodb/README.md
+++ b/contracts/os/andromeda-adodb/README.md
@@ -1,0 +1,5 @@
+# Overview
+The Database ADO (ADODB) is a smart contract that is primarily used to store code Ids for  Andromeda ADOs. These code Ids are used to instantiate these ADOs in Andromeda Apps. The code Ids are stored within a key value pair where the key is the ADO type and the value is the ADO code Id.
+The ADODB is also responsible for managing the economic engine of the Andromeda ecosystem, allowing ADO publishers  to set custom fees to be paid when interacting with one of their published ADOs. These fees can be set as native or a CW20 token.
+
+[ADODB Full Documentation](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/andromeda-factory)

--- a/contracts/os/andromeda-economics/README.md
+++ b/contracts/os/andromeda-economics/README.md
@@ -1,3 +1,10 @@
-# Andromeda Factory
+# Overview
 
-A repository containing the NFT contract for Andromeda Protocol on Terra. This contract's primary purpose is to initialise and register ADO collections. Registration is done by a mapping between the ADO collection's symbol and the contract address for the given ADO collection. Documentation can be found [here](https://app.gitbook.com/@andromedaprotocol/s/andromeda/contracts/andromeda-factory).
+The Economics ADO allows users to deposit funds to be used to pay fees implemented on ADO actions (Execute Messages) by the ADODB. Deposited funds can be either native funds such as "uandr" or CW20 tokens where the contract address is used. The fees are automatically called by the ADO that implements them. 
+
+Fees are charged in the following order:
+- ADO: First, the ADO requesting the fees is checked for funds and if available will use these funds to pay the fee.
+- App: The App contract of the ADO requesting the fees.
+- Payee: The address that sent the message to the ADO that is requesting the fees.
+
+[Economics Full Documentation](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/economics-engine)

--- a/contracts/os/andromeda-kernel/README.md
+++ b/contracts/os/andromeda-kernel/README.md
@@ -1,3 +1,10 @@
-# Andromeda Factory
+# Overview
+The Andromeda Kernel acts as the core of the operating system. It receives and handles packets from ADOs to be relayed to a specified recipient. The Kernel keeps track of the original sender of the message. It also verifies that the packet is sent by an Andromeda certified ADO before relaying the message. 
+The Kernel is also responsible for:
 
-A repository containing the NFT contract for Andromeda Protocol on Terra. This contract's primary purpose is to initialise and register ADO collections. Registration is done by a mapping between the ADO collection's symbol and the contract address for the given ADO collection. Documentation can be found [here](https://app.gitbook.com/@andromedaprotocol/s/andromeda/contracts/andromeda-factory).
+- Relaying any IBC messages across any two chains that have an Andromeda Kernel deployed and a channel set up.
+- Keeping track of the other AMP ADOs such as the ADODB, VFS, and Economics.
+
+All of our ADOs have an AMPReceive execute message to handle receiving packets from the Kernel.
+
+[Kernel Full Documentation](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/kernel)

--- a/contracts/os/andromeda-vfs/README.md
+++ b/contracts/os/andromeda-vfs/README.md
@@ -1,3 +1,6 @@
-# Andromeda Factory
+# Overview
 
-A repository containing the NFT contract for Andromeda Protocol on Terra. This contract's primary purpose is to initialise and register ADO collections. Registration is done by a mapping between the ADO collection's symbol and the contract address for the given ADO collection. Documentation can be found [here](https://app.gitbook.com/@andromedaprotocol/s/andromeda/contracts/andromeda-factory).
+The Virtual File System (VFS) is a part of the Andromeda Messaging System (AMP) which was heavily inspired by the linux file system. Users can register their address to a username. They can also register ADOs to paths. These paths can then be used and referenced in our ADO systems.
+When an Andromeda App is made, it will register all paths for its child components and also register itself as a child of the instantiating address. Each component under the App is registered by its name, and the App itself is registered under its assigned name.
+
+[VFS Full Documentation](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/virtual-file-system)

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -1,0 +1,29 @@
+# Andromeda STD
+
+This crate defines how a smart contract can be integrated in to the aOS and also provides several methods to aid in doing so.
+
+## Usage
+
+### ADO Base
+
+This module contains all the message and struct definitions used by the base aOS contracts and ADOs. The primary struct provided by this module are the `AndromedaMsg`, `AndromedaQuery`and `InstantiateMsg` structs.
+
+There are also several response structs to the provided queries available through this crate.
+
+### ADO Contract
+
+This module contains the base logic of an ADO, primarily provided via the `ADOContract` struct.
+
+### AMP
+
+This module contains packet and message structs used to define how the Andromeda Message Protocol can be utilised, there are three primary structs:
+
+Using these a contract can easily make use of the Andromeda Messaging protocol.
+
+### Common
+
+Contains several utility methods and structs to help with consistency across our ADOs.
+
+### OS
+
+This module contains the message definitions and a few utility methods for the core of the aOS.

--- a/packages/std/src/amp/README.md
+++ b/packages/std/src/amp/README.md
@@ -1,0 +1,77 @@
+# Andromeda Messaging Protocol
+
+The primary use of this crate is to define the Andromeda Messaging Protocol; a simple wrapper around contract communication that allows for simpler message routing and a larger context.
+
+## Usage
+
+There are two core components to the Andromeda Messaging Protocol the [`AndrAddr`](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/common-types#andraddr) struct and the `AMPPkt` struct:
+
+```rust
+// Found in addresses.rs
+pub struct AndrAddr(String);
+
+// Found in messages.rs
+pub struct AMPPkt {
+    /// Any messages associated with the packet
+    pub messages: Vec<AMPMsg>,
+    pub ctx: AMPCtx,
+}
+```
+
+### Andromeda Addresses
+
+The `AndrAddr` struct is a wrapper around a `String` to allow a user to define with a standard human readable address or a valid VFS path. This struct provides a lot of utility methods to help with validating and resolving these paths. The primary logic for validation is to assume the provided `String` is an address and validate it like so. If this fails we validate that it is a correct VFS path. An example use of this would be:
+
+```rust
+let user_andr_addr = AndrAddr::from_string("~user1/app1/component");
+let addr = user_andr_addr.get_raw_address(&deps)?;
+
+let raw_andr_addr = AndrAddr::from_string("andr1someaddress123");
+let addr = raw_andr_addr.get_raw_address(&deps)?;
+```
+
+In the first case we provide a VFS path, this will query the VFS contract that is registered with the kernel to resolve the address. The second is validated as a human readable address and returned straight away.
+
+### AMP Packet
+
+An AMP (Andromeda Messaging Protocol) Packet allows a user to specify several messages to be routed via the kernel. The benefit of this is to allow VFS routing (including IBC) and also to allow the receiving contract access to `AMPCtx`:
+
+```rust
+#[cw_serde]
+pub struct AMPCtx {
+    origin: String,
+    pub previous_sender: String,
+    pub id: u64,
+}
+```
+
+This provides the `origin` field similar to a smart contract written in Solidity. The `origin` field specifies the original sender of the message (not the current sub message). However, as this is a security risk this context struct is only provided when one of three conditions are met upon the packet reaching the kernel:
+
+1. The origin field is equivalent to the message sender
+2. The sender is a valid ADO
+3. The sender is the kernel (Only applicable when an ADO receives the packet)
+
+The other benefit to using AMP is the use of `AndrAddr` in the messages:
+
+```rust
+pub struct AMPMsg {
+    /// The message recipient, can be a contract/wallet address or a namespaced URI
+    pub recipient: AndrAddr,
+    /// The message to be sent to the recipient
+    pub message: Binary,
+    /// Any funds to be attached to the message, defaults to an empty vector
+    pub funds: Vec<Coin>,
+    /// When the message should reply, defaults to Always
+    pub config: AMPMsgConfig,
+}
+```
+
+Here the `recipient` field is using an Andromeda Address, when the kernel receives this address it is resolved and routed accordingly. The rest of the struct is extremely similar to a standard `WasmMsg` with the exception of `message`. When `Binary::default()` is provided as the message then the kernel assumes the provided message is a `BankMsg::Send` and routes accordingly.
+
+For more advanced users `AndrAddr` can be used via the kernel to route messages over IBC:
+
+```rust
+let ibc_addr = AndrAddr::from_string("ibc://terra/home/terra-user/terra-app/terra-component");
+```
+
+Our kernel will receive this address and route the message accordingly (to the Terra blockchain in this example).


### PR DESCRIPTION
# Motivation

Need to clean up our README files.

# Implementation

- Added a simple README.md for each ADO with a link to full docs.
- Took the STD README files created by Connor in another branch and added to this one. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced multiple README files providing comprehensive overviews of various ADOs, including their functionalities, access controls, and economic models.
	- Added documentation for smart contracts related to fund distribution, data storage, and non-fungible token auctions.
	- Added a README for the Rates ADO, detailing its role in managing rate configurations for other ADOs.

- **Documentation**
	- Enhanced documentation accessibility with links to full guides and details regarding specific ADOs and functionalities within the Andromeda ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->