### PR TITLE
ref: make title, description, banner, and url optional in CampaignConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crowdfund Internal Audit [(#485)](https://github.com/andromedaprotocol/andromeda-core/pull/485)
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
+- Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/mock_querier.rs
@@ -21,10 +21,10 @@ pub const MOCK_DEFAULT_LIMIT: u128 = 100000;
 
 pub fn mock_campaign_config(denom: Asset) -> CampaignConfig {
     CampaignConfig {
-        title: "First Crowdfund".to_string(),
-        description: "Demo campaign for testing".to_string(),
-        banner: "http://<campaign_banner>".to_string(),
-        url: "http://<campaign_url>".to_string(),
+        title: Some("First Crowdfund".to_string()),
+        description: Some("Demo campaign for testing".to_string()),
+        banner: Some("http://<campaign_banner>".to_string()),
+        url: Some("http://<campaign_url>".to_string()),
         denom,
         token_address: AndrAddr::from_string(MOCK_TIER_CONTRACT.to_owned()),
         withdrawal_recipient: Recipient::from_string(MOCK_WITHDRAWAL_ADDRESS.to_owned()),

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -54,13 +54,13 @@ pub enum Cw20HookMsg {
 #[cw_serde]
 pub struct CampaignConfig {
     /// Title of the campaign. Maximum length is 64.
-    pub title: String,
+    pub title: Option<String>,
     /// Short description about the campaign.
-    pub description: String,
+    pub description: Option<String>,
     /// URL for the banner of the campaign
-    pub banner: String,
+    pub banner: Option<String>,
     /// Official website of the campaign
-    pub url: String,
+    pub url: Option<String>,
     /// The address of the tier contract whose tokens are being distributed
     pub token_address: AndrAddr,
     /// The denom of the token that is being accepted by the campaign
@@ -87,7 +87,7 @@ impl CampaignConfig {
 
         // validate meta info
         ensure!(
-            self.title.len() <= 64,
+            self.title.clone().unwrap_or_default().len() <= 64,
             ContractError::InvalidParameter {
                 error: Some("Title length can be 64 at maximum".to_string())
             }
@@ -238,10 +238,10 @@ pub enum QueryMsg {
 #[cw_serde]
 pub struct CampaignSummaryResponse {
     // Campaign configuration
-    pub title: String,
-    pub description: String,
-    pub banner: String,
-    pub url: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub banner: Option<String>,
+    pub url: Option<String>,
     pub token_address: AndrAddr,
     pub denom: Asset,
     pub withdrawal_recipient: Recipient,

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -795,10 +795,10 @@ fn mock_campaign_config(
     soft_cap: Option<Uint128>,
 ) -> CampaignConfig {
     CampaignConfig {
-        title: "First Crowdfund".to_string(),
-        description: "Demo campaign for testing".to_string(),
-        banner: "http://<campaign_banner>".to_string(),
-        url: "http://<campaign_url>".to_string(),
+        title: Some("First Crowdfund".to_string()),
+        description: Some("Demo campaign for testing".to_string()),
+        banner: Some("http://<campaign_banner>".to_string()),
+        url: Some("http://<campaign_url>".to_string()),
         denom,
         token_address,
         withdrawal_recipient,


### PR DESCRIPTION
# Motivation
Give more flexibility during crowdfund creation. 

# Implementation
Made title, description, banner, and url optional in `CampaignConfig` and in `CampaignSummaryResponse`. 

# Testing
No tests were done or affected. 

# Version Changes
Crowdfund from 2.0.0 to 2.0.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the package version of "andromeda-crowdfund" to enhance functionality.
	- Improved flexibility in campaign configurations by allowing optional fields for the title, description, banner, and URL.

- **Bug Fixes**
	- Enhanced error handling and validation for the title field in campaign configurations to prevent potential issues with missing values.

- **Documentation**
	- Updated the CHANGELOG.md to reflect the changes in the CampaignConfig structure, highlighting the new optional fields for improved usability.
	
- **Tests**
	- Adjusted test implementations to reflect the changes in handling optional fields for campaign configurations, ensuring robustness in future scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->