### PR TITLE
ref: Mint and Batch mint now use standard action names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
 - Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
+- Make Action Names in CW721 Conform to Standard  [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c999a12f8cd8736f6f86e9a4ede5905530cb23cfdef946b9da1c506ad1b70799"
+checksum = "64e2cf17accdcafe71859a683b6ed3f18311634a769550aacf4829b50151b221"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cw20 = "1.1.2"
 cw20-base = "1.1.2"
 cw721 = "0.18.0"
 cw721-base = { version = "0.18.0", features = ["library"] }
-cw-asset = "3.0.0"
+cw-asset = "=3.0.0"
 cosmwasm-schema = "1.5.2"
 semver = "1.0.0"
 enum-repr = "0.2.6"

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
 };
 
 use crate::state::{
-    is_archived, ANDR_MINTER, ARCHIVED, BATCH_MINT_ACTION, MINT_ACTION, TRANSFER_AGREEMENTS,
+    is_archived, ANDR_MINTER, ARCHIVED, TRANSFER_AGREEMENTS,
 };
 use andromeda_non_fungible_tokens::cw721::{
     ExecuteMsg, InstantiateMsg, MintMsg, QueryMsg, TokenExtension, TransferAgreement,
@@ -113,8 +113,8 @@ fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
             token_uri,
             owner,
             extension,
-        } => execute_mint(ctx, token_id, token_uri, owner, extension),
-        ExecuteMsg::BatchMint { tokens } => execute_batch_mint(ctx, tokens),
+        } => execute_mint(ctx, token_id, token_uri, owner, extension, action),
+        ExecuteMsg::BatchMint { tokens } => execute_batch_mint(ctx, tokens, action),
         ExecuteMsg::TransferNft {
             recipient,
             token_id,
@@ -159,6 +159,7 @@ fn execute_mint(
     token_uri: Option<String>,
     owner: String,
     extension: TokenExtension,
+    action: String
 ) -> Result<Response, ContractError> {
     let minter = ANDR_MINTER
         .load(ctx.deps.storage)?
@@ -170,7 +171,7 @@ fn execute_mint(
                 &ctx.info,
                 &ctx.env,
                 &ctx.amp_ctx,
-                MINT_ACTION
+                action
             )?,
         ContractError::Unauthorized {}
     );
@@ -211,6 +212,7 @@ fn mint(
 fn execute_batch_mint(
     mut ctx: ExecuteContext,
     tokens_to_mint: Vec<MintMsg>,
+    action: String
 ) -> Result<Response, ContractError> {
     let mut resp = Response::default();
     let minter = ANDR_MINTER
@@ -223,7 +225,7 @@ fn execute_batch_mint(
                 &ctx.info,
                 &ctx.env,
                 &ctx.amp_ctx,
-                BATCH_MINT_ACTION
+                action
             )?,
         ContractError::Unauthorized {}
     );

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/contract.rs
@@ -5,9 +5,7 @@ use cosmwasm_std::{
     CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, QuerierWrapper, Response, SubMsg, Uint128,
 };
 
-use crate::state::{
-    is_archived, ANDR_MINTER, ARCHIVED, TRANSFER_AGREEMENTS,
-};
+use crate::state::{is_archived, ANDR_MINTER, ARCHIVED, TRANSFER_AGREEMENTS};
 use andromeda_non_fungible_tokens::cw721::{
     ExecuteMsg, InstantiateMsg, MintMsg, QueryMsg, TokenExtension, TransferAgreement,
 };
@@ -159,7 +157,7 @@ fn execute_mint(
     token_uri: Option<String>,
     owner: String,
     extension: TokenExtension,
-    action: String
+    action: String,
 ) -> Result<Response, ContractError> {
     let minter = ANDR_MINTER
         .load(ctx.deps.storage)?
@@ -212,7 +210,7 @@ fn mint(
 fn execute_batch_mint(
     mut ctx: ExecuteContext,
     tokens_to_mint: Vec<MintMsg>,
-    action: String
+    action: String,
 ) -> Result<Response, ContractError> {
     let mut resp = Response::default();
     let minter = ANDR_MINTER

--- a/contracts/non-fungible-tokens/andromeda-cw721/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-cw721/src/state.rs
@@ -7,9 +7,6 @@ pub const ANDR_MINTER: Item<AndrAddr> = Item::new("minter");
 pub const TRANSFER_AGREEMENTS: Map<&str, TransferAgreement> = Map::new("transfer_agreements");
 pub const ARCHIVED: Map<&str, bool> = Map::new("archived_tokens");
 
-pub const MINT_ACTION: &str = "can_mint";
-pub const BATCH_MINT_ACTION: &str = "can_batch_mint";
-
 pub fn is_archived(
     storage: &dyn Storage,
     token_id: &str,


### PR DESCRIPTION
# Motivation
Closes #543 

# Implementation
Use action name as `msg.as_ref().to_string();` instead of constants. 

# Testing
No tests were made nor affected

# Version Changes
Bumped cw721 from `2.0.1` to `2.0.2`