### PR TITLE
fix: Splitter & Conditional Splitter LockTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Splitter: avoid zero send messages, owner updates lock any time [(#457)](https://github.com/andromedaprotocol/andromeda-core/pull/457)
+- Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c999a12f8cd8736f6f86e9a4ede5905530cb23cfdef946b9da1c506ad1b70799"
+checksum = "64e2cf17accdcafe71859a683b6ed3f18311634a769550aacf4829b50151b221"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cw20 = "1.1.2"
 cw20-base = "1.1.2"
 cw721 = "0.18.0"
 cw721-base = { version = "0.18.0", features = ["library"] }
-cw-asset = "3.0.0"
+cw-asset = "=3.0.0"
 cosmwasm-schema = "1.5.2"
 semver = "1.0.0"
 enum-repr = "0.2.6"

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-conditional-splitter/src/mock.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query, reply};
 use andromeda_finance::conditional_splitter::{ExecuteMsg, InstantiateMsg, QueryMsg, Threshold};
-use andromeda_std::common::Milliseconds;
+use andromeda_std::common::expiration::Expiry;
 use andromeda_testing::{
     mock::MockApp, mock_ado, mock_contract::ExecuteResult, MockADO, MockContract,
 };
@@ -19,7 +19,7 @@ impl MockConditionalSplitter {
         sender: Addr,
         thresholds: Vec<Threshold>,
         kernel_address: impl Into<String>,
-        lock_time: Option<u64>,
+        lock_time: Option<Expiry>,
         owner: Option<String>,
     ) -> Self {
         let msg =
@@ -51,12 +51,12 @@ pub fn mock_andromeda_conditional_splitter() -> Box<dyn Contract<Empty>> {
 pub fn mock_conditional_splitter_instantiate_msg(
     thresholds: Vec<Threshold>,
     kernel_address: impl Into<String>,
-    lock_time: Option<u64>,
+    lock_time: Option<Expiry>,
     owner: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         thresholds,
-        lock_time: lock_time.map(Milliseconds),
+        lock_time,
         kernel_address: kernel_address.into(),
         owner,
     }

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -34,7 +34,7 @@ fn init(deps: DepsMut) -> Response {
         owner: Some(OWNER.to_owned()),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         recipients: mock_recipient,
-        lock_time: Some(Expiry::AtTime(Milliseconds::from_seconds(100_000))),
+        lock_time: Some(Expiry::FromNow(Milliseconds(86400000))),
     };
 
     let info = mock_info("owner", &[]);
@@ -56,7 +56,8 @@ fn test_execute_update_lock() {
     let env = mock_env();
 
     let current_time = env.block.time.seconds();
-    let lock_time = 100_000;
+    // 2 days in milliseconds
+    let lock_time = 172800000;
 
     // Start off with an expiration that's behind current time (expired)
     let splitter = Splitter {

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -10,7 +10,7 @@ use andromeda_testing::economics_msg::generate_economics_message;
 use cosmwasm_std::{
     attr, from_json,
     testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR},
-    to_json_binary, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Response, SubMsg,
+    to_json_binary, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Response, SubMsg, Timestamp,
 };
 pub const OWNER: &str = "creator";
 
@@ -47,6 +47,118 @@ fn test_instantiate() {
     let res = init(deps.as_mut());
     assert_eq!(0, res.messages.len());
 }
+
+#[test]
+fn test_different_lock_times() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let mut env = mock_env();
+    // Current time
+    env.block.time = Timestamp::from_seconds(1724920577);
+    // Set a lock time that's less than 1 day in milliseconds
+    let mut lock_time = Expiry::FromNow(Milliseconds(60_000));
+
+    let msg = InstantiateMsg {
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        recipients: vec![],
+        lock_time: Some(lock_time),
+    };
+
+    let info = mock_info(OWNER, &[]);
+    let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+
+    assert_eq!(
+        err,
+        ContractError::LockTimeTooShort {}
+    );
+
+    // Set a lock time that's more than 1 year in milliseconds
+    lock_time = Expiry::FromNow(Milliseconds(31_708_800_000));
+
+    let msg = InstantiateMsg {
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        recipients: vec![],
+        lock_time: Some(lock_time),
+    };
+
+    let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+
+    assert_eq!(
+        err,
+        ContractError::LockTimeTooLong {}
+    );
+
+    // Set a lock time for 20 days in milliseconds
+    lock_time = Expiry::FromNow(Milliseconds(1728000000));
+
+    let msg = InstantiateMsg {
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        recipients: vec![AddressPercent {
+            recipient: Recipient::from_string(String::from("some_address")),
+            percent: Decimal::percent(100),
+        }],
+        lock_time: Some(lock_time),
+    };
+
+    let info = mock_info(OWNER, &[]);
+    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    assert_eq!(0, res.messages.len());
+
+    // Here we begin testing Expiry::AtTime
+    // Set a lock time that's less than 1 day from current time
+    lock_time = Expiry::AtTime(Milliseconds(1724934977000));
+
+    let msg = InstantiateMsg {
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        recipients: vec![],
+        lock_time: Some(lock_time),
+    };
+
+    let info = mock_info(OWNER, &[]);
+    let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::LockTimeTooShort {}
+    );
+
+    // Set a lock time that's more than 1 year from current time in milliseconds
+    lock_time = Expiry::AtTime(Milliseconds(1788006977000));
+
+    let msg = InstantiateMsg {
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        recipients: vec![],
+        lock_time: Some(lock_time),
+    };
+
+    let info = mock_info(OWNER, &[]);
+    let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::LockTimeTooLong {}
+    );
+
+    // Set a valid lock time
+    lock_time = Expiry::AtTime(Milliseconds(1725021377000));
+
+    let msg = InstantiateMsg {
+        owner: Some(OWNER.to_owned()),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        recipients: vec![AddressPercent {
+            recipient: Recipient::from_string(String::from("some_address")),
+            percent: Decimal::percent(100),
+        }],
+        lock_time: Some(lock_time),
+    };
+
+    let info = mock_info(OWNER, &[]);
+    let res = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    assert_eq!(0, res.messages.len());
+}   
+
 
 #[test]
 fn test_execute_update_lock() {

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -67,10 +67,7 @@ fn test_different_lock_times() {
     let info = mock_info(OWNER, &[]);
     let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
 
-    assert_eq!(
-        err,
-        ContractError::LockTimeTooShort {}
-    );
+    assert_eq!(err, ContractError::LockTimeTooShort {});
 
     // Set a lock time that's more than 1 year in milliseconds
     lock_time = Expiry::FromNow(Milliseconds(31_708_800_000));
@@ -84,10 +81,7 @@ fn test_different_lock_times() {
 
     let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
 
-    assert_eq!(
-        err,
-        ContractError::LockTimeTooLong {}
-    );
+    assert_eq!(err, ContractError::LockTimeTooLong {});
 
     // Set a lock time for 20 days in milliseconds
     lock_time = Expiry::FromNow(Milliseconds(1728000000));
@@ -119,10 +113,7 @@ fn test_different_lock_times() {
 
     let info = mock_info(OWNER, &[]);
     let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
-    assert_eq!(
-        err,
-        ContractError::LockTimeTooShort {}
-    );
+    assert_eq!(err, ContractError::LockTimeTooShort {});
 
     // Set a lock time that's more than 1 year from current time in milliseconds
     lock_time = Expiry::AtTime(Milliseconds(1788006977000));
@@ -136,10 +127,7 @@ fn test_different_lock_times() {
 
     let info = mock_info(OWNER, &[]);
     let err = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
-    assert_eq!(
-        err,
-        ContractError::LockTimeTooLong {}
-    );
+    assert_eq!(err, ContractError::LockTimeTooLong {});
 
     // Set a valid lock time
     lock_time = Expiry::AtTime(Milliseconds(1725021377000));
@@ -157,8 +145,7 @@ fn test_different_lock_times() {
     let info = mock_info(OWNER, &[]);
     let res = instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
     assert_eq!(0, res.messages.len());
-}   
-
+}
 
 #[test]
 fn test_execute_update_lock() {

--- a/packages/andromeda-finance/src/conditional_splitter.rs
+++ b/packages/andromeda-finance/src/conditional_splitter.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{
     andr_exec, andr_instantiate, andr_query,
-    common::{MillisecondsDuration, MillisecondsExpiration},
+    common::{expiration::Expiry, MillisecondsDuration, MillisecondsExpiration},
     error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
@@ -54,7 +54,7 @@ pub struct ConditionalSplitter {
     /// The vector of thresholds which assign a percentage for a certain range of received funds
     pub thresholds: Vec<Threshold>,
     /// The lock's expiration time
-    pub lock_time: Option<MillisecondsExpiration>,
+    pub lock_time: MillisecondsExpiration,
 }
 impl ConditionalSplitter {
     pub fn validate(&self, deps: Deps) -> Result<(), ContractError> {
@@ -68,7 +68,7 @@ pub struct InstantiateMsg {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is
     /// sent the amount sent will be divided amongst these recipients depending on their assigned percentage.
     pub thresholds: Vec<Threshold>,
-    pub lock_time: Option<MillisecondsDuration>,
+    pub lock_time: Option<Expiry>,
 }
 
 #[andr_exec]

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -96,6 +96,9 @@ pub enum ContractError {
     #[error("only unordered channels are supported")]
     OrderedChannel {},
 
+    #[error("Invalid Expiration Time")]
+    InvalidExpirationTime {},
+
     #[error("invalid IBC channel version - got ({actual}), expected ({expected})")]
     InvalidVersion { actual: String, expected: String },
 
@@ -676,9 +679,6 @@ pub enum ContractError {
 
     #[error("Not an assigned operator, {msg:?}")]
     NotAssignedOperator { msg: Option<String> },
-
-    #[error("Invalid Expiration Time")]
-    InvalidExpirationTime {},
 
     #[error("Invalid Parameter, {error:?}")]
     InvalidParameter { error: Option<String> },


### PR DESCRIPTION
# Motivation
Closes #544 

# Implementation
Was comparing the lock time's timestamp with a representation of one day and one year in seconds. Now it's being compared with the current time in addition to one day and one year in milliseconds. 

Made Conditional Splitter's lock the same as the one in Splitter.

# Testing
`test_different_lock_times` for both splitter contracts. Tests for too short, long and correct lock times using both `Expiry::AtTime` and `Expirty::FromNow`.

# Version Changes
Bumped splitter from 2.0.0 to 2.1.0 and conditional splitter from 1.1.0 to 1.2.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced handling of expiration times in the Conditional Splitter contract.
	- Added new test cases for various lock time scenarios.
	- Introduced a new error variant for invalid expiration times.

- **Bug Fixes**
	- Improved validation logic for lock times to ensure accuracy.
	- Fixed lock time calculation to enhance reliability.

- **Documentation**
	- Updated comments and documentation to reflect changes in time handling and contract logic.

- **Refactor**
	- Streamlined functions related to lock time management for clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->