### PR TITLE
feat: Permissioning Multiple Actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
 - Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
+- Permissioning: Allow multiple actors to be set and removed at once [(#548)](https://github.com/andromedaprotocol/andromeda-core/pull/548)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.1.1"
+version = "1.2.1"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c999a12f8cd8736f6f86e9a4ede5905530cb23cfdef946b9da1c506ad1b70799"
+checksum = "64e2cf17accdcafe71859a683b6ed3f18311634a769550aacf4829b50151b221"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cw20 = "1.1.2"
 cw20-base = "1.1.2"
 cw721 = "0.18.0"
 cw721-base = { version = "0.18.0", features = ["library"] }
-cw-asset = "3.0.0"
+cw-asset = "=3.0.0"
 cosmwasm-schema = "1.5.2"
 semver = "1.0.0"
 enum-repr = "0.2.6"

--- a/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
@@ -113,11 +113,11 @@ fn test_transfer() {
 
     // Blacklist the sender who otherwise would have been able to call the function successfully
     let permission = Permission::Local(LocalPermission::blacklisted(None));
-    let actor = AndrAddr::from_string("sender");
+    let actors = vec![AndrAddr::from_string("sender")];
     let action = "Transfer";
     let ctx = ExecuteContext::new(deps.as_mut(), mock_info("owner", &[]), mock_env());
     ADOContract::default()
-        .execute_set_permission(ctx, actor, action, permission)
+        .execute_set_permission(ctx, actors, action, permission)
         .unwrap();
     let info = mock_info("sender", &[]);
     let err = execute(deps.as_mut(), mock_env(), info.clone(), msg.clone()).unwrap_err();
@@ -126,11 +126,11 @@ fn test_transfer() {
 
     // Now whitelist the sender, that should allow him to call the function successfully
     let permission = Permission::Local(LocalPermission::whitelisted(None));
-    let actor = AndrAddr::from_string("sender");
+    let actors = vec![AndrAddr::from_string("sender")];
     let action = "Transfer";
     let ctx = ExecuteContext::new(deps.as_mut(), mock_info("owner", &[]), mock_env());
     ADOContract::default()
-        .execute_set_permission(ctx, actor, action, permission)
+        .execute_set_permission(ctx, actors, action, permission)
         .unwrap();
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -233,7 +233,11 @@ pub fn mock_set_rate_msg(action: String, rate: Rate) -> ExecuteMsg {
     ExecuteMsg::Rates(RatesMessage::SetRate { action, rate })
 }
 
-pub fn mock_set_permission(actors: Vec<AndrAddr>, action: String, permission: Permission) -> ExecuteMsg {
+pub fn mock_set_permission(
+    actors: Vec<AndrAddr>,
+    action: String,
+    permission: Permission,
+) -> ExecuteMsg {
     ExecuteMsg::Permissioning(PermissioningMessage::SetPermission {
         actors,
         action,

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -116,11 +116,11 @@ impl MockAuction {
         &self,
         app: &mut MockApp,
         sender: Addr,
-        actor: AndrAddr,
+        actors: Vec<AndrAddr>,
         action: String,
         permission: Permission,
     ) -> ExecuteResult {
-        let msg = mock_set_permission(actor, action, permission);
+        let msg = mock_set_permission(actors, action, permission);
         self.execute(app, &msg, sender, &[])
     }
 
@@ -233,9 +233,9 @@ pub fn mock_set_rate_msg(action: String, rate: Rate) -> ExecuteMsg {
     ExecuteMsg::Rates(RatesMessage::SetRate { action, rate })
 }
 
-pub fn mock_set_permission(actor: AndrAddr, action: String, permission: Permission) -> ExecuteMsg {
+pub fn mock_set_permission(actors: Vec<AndrAddr>, action: String, permission: Permission) -> ExecuteMsg {
     ExecuteMsg::Permissioning(PermissioningMessage::SetPermission {
-        actor,
+        actors,
         action,
         permission,
     })

--- a/packages/andromeda-testing/src/mock_contract.rs
+++ b/packages/andromeda-testing/src/mock_contract.rs
@@ -62,7 +62,7 @@ pub trait MockADO<E: Serialize + fmt::Debug, Q: Serialize + fmt::Debug>:
         &self,
         app: &mut MockApp,
         sender: Addr,
-        actor: AndrAddr,
+        actors: Vec<AndrAddr>,
         action: impl Into<String>,
         permission: Permission,
     ) -> ExecuteResult {
@@ -70,7 +70,7 @@ pub trait MockADO<E: Serialize + fmt::Debug, Q: Serialize + fmt::Debug>:
             sender,
             self.addr().clone(),
             &AndromedaMsg::Permissioning(PermissioningMessage::SetPermission {
-                actor,
+                actors,
                 action: action.into(),
                 permission,
             }),

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.1.1"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -12,7 +12,7 @@ use crate::{
 #[cw_serde]
 pub enum PermissioningMessage {
     SetPermission {
-        actor: AndrAddr,
+        actors: Vec<AndrAddr>,
         action: String,
         permission: Permission,
     },

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -18,7 +18,7 @@ pub enum PermissioningMessage {
     },
     RemovePermission {
         action: String,
-        actor: AndrAddr,
+        actors: Vec<AndrAddr>,
     },
     PermissionAction {
         action: String,

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -266,7 +266,7 @@ impl<'a> ADOContract<'a> {
             ContractError::Unauthorized {}
         );
         let action = action.into();
-        
+
         let mut actor_addrs = Vec::new();
 
         ensure!(!actors.is_empty(), ContractError::NoActorsProvided {});
@@ -284,7 +284,11 @@ impl<'a> ADOContract<'a> {
             )?;
         }
 
-        let actor_strs = actor_addrs.iter().map(|addr| addr.as_str()).collect::<Vec<_>>().join(", ");
+        let actor_strs = actor_addrs
+            .iter()
+            .map(|addr| addr.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
 
         Ok(Response::default().add_attributes(vec![
             ("action", "set_permission"),

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -75,6 +75,9 @@ pub enum ContractError {
     #[error("InvalidValidator")]
     InvalidValidator {},
 
+    #[error("NoActorsProvided")]
+    NoActorsProvided {},
+
     #[error("InvalidDelegation")]
     InvalidDelegation {},
 

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -616,7 +616,10 @@ fn test_auction_app_cw20_restricted() {
 
     // Place Bid One
     // Blacklist bidder now and blacklist bidder three just to test permissioning multiple actors at the same time
-    let actors = vec![AndrAddr::from_string(buyer_one.clone()), AndrAddr::from_string(buyer_three.clone())];
+    let actors = vec![
+        AndrAddr::from_string(buyer_one.clone()),
+        AndrAddr::from_string(buyer_three.clone()),
+    ];
     let action = "PlaceBid".to_string();
     let permission = Permission::Local(LocalPermission::blacklisted(None));
     auction

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -603,6 +603,17 @@ fn test_auction_app_cw20_restricted() {
     let auction_state: AuctionStateResponse = auction.query_auction_state(&mut router, *auction_id);
     assert_eq!(auction_state.coin_denom, cw20.addr().to_string());
 
+    // Try to set permission with an empty vector of actors
+    let actors = vec![];
+    let action = "PlaceBid".to_string();
+    let permission = Permission::Local(LocalPermission::blacklisted(None));
+    let err: ContractError = auction
+        .execute_set_permission(&mut router, owner.clone(), actors, action, permission)
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, ContractError::NoActorsProvided {});
+
     // Place Bid One
     // Blacklist bidder now and blacklist bidder three just to test permissioning multiple actors at the same time
     let actors = vec![AndrAddr::from_string(buyer_one.clone()), AndrAddr::from_string(buyer_three.clone())];

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -604,11 +604,11 @@ fn test_auction_app_cw20_restricted() {
 
     // Place Bid One
     // Blacklist bidder now
-    let actor = AndrAddr::from_string(buyer_one.clone());
+    let actors = vec![AndrAddr::from_string(buyer_one.clone())];
     let action = "PlaceBid".to_string();
     let permission = Permission::Local(LocalPermission::blacklisted(None));
     auction
-        .execute_set_permission(&mut router, owner.clone(), actor, action, permission)
+        .execute_set_permission(&mut router, owner.clone(), actors, action, permission)
         .unwrap();
 
     let bid_msg = mock_place_bid("0".to_string(), cw721.addr().to_string());
@@ -627,11 +627,11 @@ fn test_auction_app_cw20_restricted() {
     assert_eq!(err, ContractError::Unauthorized {});
 
     // Now whitelist bidder one
-    let actor = AndrAddr::from_string(buyer_one.clone());
+    let actors = vec![AndrAddr::from_string(buyer_one.clone())];
     let action = "PlaceBid".to_string();
     let permission = Permission::Local(LocalPermission::whitelisted(None));
     auction
-        .execute_set_permission(&mut router, owner.clone(), actor, action, permission)
+        .execute_set_permission(&mut router, owner.clone(), actors, action, permission)
         .unwrap();
 
     // Try bidding again


### PR DESCRIPTION
# Motivation
Allows users to set permissions to multiple actors at the same time. Suggested by @daniel-wehbe 

# Implementation
`SetPermission` now takes a vector of actors instead of one actor. There's a check for an empty vector, then it loops through the actors setting their permissions. 
The same method has been applied to `RemovePermission`.

# Testing
Tested empty vector of actors and two actors in the `test_auction_app_cw20_restricted` integration test.

# Version Changes
Bumped andromeda-std from 1.1.1 to 1.2.1 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced permissioning system to allow multiple actors to be set and removed simultaneously, improving efficiency in user role management.
  
- **Bug Fixes**
  - Added error handling for scenarios where no actors are provided, improving robustness and user feedback.

- **Tests**
  - Updated auction app tests to include new scenarios for managing multiple actors and handling edge cases in permissioning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->