### PR TITLE
ref: replace MillisecondsExpiration with Expiry in TimeLock ADO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
 - Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
+- Timelock ADO: Replace MillisecondsExpiration with Expiry [(#550)](https://github.com/andromedaprotocol/andromeda-core/pull/550)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c999a12f8cd8736f6f86e9a4ede5905530cb23cfdef946b9da1c506ad1b70799"
+checksum = "64e2cf17accdcafe71859a683b6ed3f18311634a769550aacf4829b50151b221"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 


### PR DESCRIPTION
# Motivation
Closes #546 

# Implementation
Replaced `Expiration(MillisecondsExpiration)` in `EscrowCondition` with `Expiration(Expiry)`

# Testing
Modified some tests to accommodate the change. 

# Version Changes
Bumped timelock from 2.0.0 to 2.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the escrow expiration handling to use a new `Expiry` enum, improving clarity and flexibility in defining expiration conditions.

- **Bug Fixes**
	- Minor version update to the "andromeda-timelock" package, indicating enhancements and bug fixes.

- **Refactor**
	- Simplified the test suite by removing outdated test functions and updating remaining tests to align with the new expiration logic.
  
- **Documentation**
	- Added a new entry in the changelog to document the replacement of `MillisecondsExpiration` with `Expiry` in the Timelock ADO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->