### PR TITLE
fix: fixed previous sender validation in verify origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,22 +27,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merkle Root: stage expiration now uses `Milliseconds`[(#417)](https://github.com/andromedaprotocol/andromeda-core/pull/417)
 - Module Redesign [(#452)](https://github.com/andromedaprotocol/andromeda-core/pull/452)
 - Primitive Improvements [(#476)](https://github.com/andromedaprotocol/andromeda-core/pull/476)
-- Crowdfund Restructure  [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
+- Crowdfund Restructure [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
 - Conditional Splitter Internal Audit [(#479)](https://github.com/andromedaprotocol/andromeda-core/pull/479)
 - Merkle Root: Andromeda Asset is used now as a `asset_info`[(#480)](https://github.com/andromedaprotocol/andromeda-core/pull/480)
-- Reference Address List contract for Permission  [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
+- Reference Address List contract for Permission [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
 - Crowdfund Internal Audit [(#485)](https://github.com/andromedaprotocol/andromeda-core/pull/485)
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
 - Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
 - Permissioning: Allow multiple actors to be set and removed at once [(#548)](https://github.com/andromedaprotocol/andromeda-core/pull/548)
-- Make Action Names in CW721 Conform to Standard  [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
+- Make Action Names in CW721 Conform to Standard [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
 - Timelock ADO: Replace MillisecondsExpiration with Expiry [(#550)](https://github.com/andromedaprotocol/andromeda-core/pull/550)
 
 ### Fixed
 
 - Splitter: avoid zero send messages, owner updates lock any time [(#457)](https://github.com/andromedaprotocol/andromeda-core/pull/457)
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
+- AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -2,7 +2,7 @@ use crate::ado_contract::ADOContract;
 use crate::common::encode_binary;
 use crate::error::ContractError;
 use crate::os::aos_querier::AOSQuerier;
-use crate::os::{kernel::ExecuteMsg as KernelExecuteMsg, kernel::QueryMsg as KernelQueryMsg};
+use crate::os::kernel::ExecuteMsg as KernelExecuteMsg;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, wasm_execute, Addr, Binary, Coin, ContractInfoResponse, CosmosMsg, Deps, Empty,

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -303,16 +303,13 @@ impl AMPPkt {
     /// If the sender is not valid, an error is returned
     pub fn verify_origin(&self, info: &MessageInfo, deps: &Deps) -> Result<(), ContractError> {
         let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
-        if info.sender == self.ctx.origin || info.sender == kernel_address {
+        if (info.sender == self.ctx.origin && info.sender == self.ctx.previous_sender)
+            || info.sender == kernel_address
+        {
             Ok(())
         } else {
             let adodb_address: Addr =
-                deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: kernel_address.to_string(),
-                    msg: to_json_binary(&KernelQueryMsg::KeyAddress {
-                        key: ADO_DB_KEY.to_string(),
-                    })?,
-                }))?;
+                AOSQuerier::kernel_address_getter(&deps.querier, &kernel_address, ADO_DB_KEY)?;
 
             // Get the sender's Code ID
             let contract_info: ContractInfoResponse =
@@ -504,9 +501,15 @@ mod tests {
         let res = pkt.verify_origin(&info, &deps.as_ref());
         assert!(res.is_err());
 
-        let offchain_pkt = AMPPkt::new(INVALID_CONTRACT, INVALID_CONTRACT, vec![msg]);
-        let res = offchain_pkt.verify_origin(&info, &deps.as_ref());
+        // Previous sender and origin set correctly
+        let direct_pkt_valid = AMPPkt::new(INVALID_CONTRACT, INVALID_CONTRACT, vec![msg.clone()]);
+        let res = direct_pkt_valid.verify_origin(&info, &deps.as_ref());
         assert!(res.is_ok());
+
+        // Previous sender and origin set incorrectly
+        let direct_pkt_invalid = AMPPkt::new(INVALID_CONTRACT, "notvalid", vec![msg]);
+        let res = direct_pkt_invalid.verify_origin(&info, &deps.as_ref());
+        assert!(res.is_err());
     }
 
     #[test]


### PR DESCRIPTION
# Motivation
These changes are to fix the following audit finding https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/45

# Implementation

The change adjusts `AMPPkt::verify_origin()` to ensure that the provided origin and previous sender cannot be forged went sent directly to an ADO.

# Testing

A test case was added for the provided finding and passes.

# Version Changes
`andromeda-std`: `1.2.1` -> `1.2.2`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced optional fields in CampaignConfig for enhanced flexibility.
	- Updated permissioning to allow simultaneous setting/removal of multiple actors.
	- Enhanced the `verify_origin` method for improved security checks.

- **Bug Fixes**
	- Added a fix for AMPPkt verification origin to enhance security.

- **Documentation**
	- Updated CHANGELOG.md for clarity on recent improvements and fixes.

- **Chores**
	- Incremented version number for the "andromeda-std" package to 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->