### PR TITLE
fix: unintended permissioning underflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,22 +27,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merkle Root: stage expiration now uses `Milliseconds`[(#417)](https://github.com/andromedaprotocol/andromeda-core/pull/417)
 - Module Redesign [(#452)](https://github.com/andromedaprotocol/andromeda-core/pull/452)
 - Primitive Improvements [(#476)](https://github.com/andromedaprotocol/andromeda-core/pull/476)
-- Crowdfund Restructure  [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
+- Crowdfund Restructure [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
 - Conditional Splitter Internal Audit [(#479)](https://github.com/andromedaprotocol/andromeda-core/pull/479)
 - Merkle Root: Andromeda Asset is used now as a `asset_info`[(#480)](https://github.com/andromedaprotocol/andromeda-core/pull/480)
-- Reference Address List contract for Permission  [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
+- Reference Address List contract for Permission [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
 - Crowdfund Internal Audit [(#485)](https://github.com/andromedaprotocol/andromeda-core/pull/485)
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
 - Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
 - Permissioning: Allow multiple actors to be set and removed at once [(#548)](https://github.com/andromedaprotocol/andromeda-core/pull/548)
-- Make Action Names in CW721 Conform to Standard  [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
+- Make Action Names in CW721 Conform to Standard [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
 - Timelock ADO: Replace MillisecondsExpiration with Expiry [(#550)](https://github.com/andromedaprotocol/andromeda-core/pull/550)
 
 ### Fixed
 
 - Splitter: avoid zero send messages, owner updates lock any time [(#457)](https://github.com/andromedaprotocol/andromeda-core/pull/457)
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
+- AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Splitter: avoid zero send messages, owner updates lock any time [(#457)](https://github.com/andromedaprotocol/andromeda-core/pull/457)
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
 - AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
-- Fix permissioning unintended limited use consumption [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
+- Fix permissioning limited use consumptions and blacklist bypass scenario [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Splitter: avoid zero send messages, owner updates lock any time [(#457)](https://github.com/andromedaprotocol/andromeda-core/pull/457)
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
 - AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
+- Fix permissioning unintended limited use consumption [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-adodb"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-boolean"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-counter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cross-chain-swap"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-exchange"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-staking"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-lockdrop"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-marketplace"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-merkle-airdrop"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-primitive"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-set-amount-splitter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-shunting"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-string-storage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
- "hashbrown",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "serde",
@@ -1238,6 +1238,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ff"
@@ -1399,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1905,6 +1927,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2097,7 @@ dependencies = [
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "rstest",
+ "toml",
 ]
 
 [[package]]
@@ -2097,6 +2129,40 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2150,6 +2216,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zeroize"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Check if directory and version bump type are provided
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <directory> <version_bump>"
+  echo "version_bump should be one of: patch, minor, major"
+  exit 1
+fi
+
+DIRECTORY=$1
+VERSION_BUMP=$2
+
+# Function to bump the version in a Cargo.toml file
+bump_version() {
+  FILE=$1
+  VERSION_BUMP=$2
+
+  # Extract the current version
+  VERSION=$(grep '^version =' "$FILE" | sed -E 's/version = "(.*)"/\1/')
+  
+  if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "No valid version found in $FILE"
+    return 1
+  fi
+
+  IFS='.' read -r -a VERSION_PARTS <<< "$VERSION"
+
+  MAJOR=${VERSION_PARTS[0]}
+  MINOR=${VERSION_PARTS[1]}
+  PATCH=${VERSION_PARTS[2]}
+
+  # Bump the version based on the input
+  case $VERSION_BUMP in
+    major)
+      MAJOR=$((MAJOR + 1))
+      MINOR=0
+      PATCH=0
+      ;;
+    minor)
+      MINOR=$((MINOR + 1))
+      PATCH=0
+      ;;
+    patch)
+      PATCH=$((PATCH + 1))
+      ;;
+    *)
+      echo "Invalid version bump type. Use 'patch', 'minor', or 'major'."
+      return 1
+      ;;
+  esac
+
+  NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+  
+  # Update the version in the Cargo.toml file
+  sed -i.bak "s/version = \"$VERSION\"/version = \"$NEW_VERSION\"/" "$FILE"
+  rm "$FILE.bak"
+
+  echo "Updated $FILE to version $NEW_VERSION"
+}
+
+export -f bump_version
+
+# Find all Cargo.toml files and bump their versions
+find "$DIRECTORY" -name "Cargo.toml" -exec bash -c 'bump_version "$0" "$1"' {} "$VERSION_BUMP" \;
+

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/data-storage/andromeda-boolean/Cargo.toml
+++ b/contracts/data-storage/andromeda-boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-boolean"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-counter/Cargo.toml
+++ b/contracts/data-storage/andromeda-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-counter"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-primitive"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
   "Connor Barr <crnbarr@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/data-storage/andromeda-string-storage/Cargo.toml
+++ b/contracts/data-storage/andromeda-string-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-string-storage"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
+++ b/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cross-chain-swap"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-set-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-set-amount-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-set-amount-splitter"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-exchange"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-staking"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-lockdrop"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-merkle-airdrop"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-shunting/Cargo.toml
+++ b/contracts/modules/andromeda-shunting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-shunting"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-marketplace"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/os/andromeda-adodb/Cargo.toml
+++ b/contracts/os/andromeda-adodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-adodb"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -81,7 +81,7 @@ impl LocalPermission {
             Self::Blacklisted(expiration) => {
                 if let Some(expiration) = expiration {
                     if expiration.get_time(&env.block).is_expired(&env.block) {
-                        return true;
+                        return !strict;
                     }
                 }
                 false

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -124,15 +124,10 @@ impl LocalPermission {
 
     pub fn consume_use(&mut self) -> Result<(), ContractError> {
         if let Self::Limited { uses, .. } = self {
-            if let Some(remaining_uses) = uses.checked_sub(1) {
-                *uses = remaining_uses;
-                Ok(())
-            } else {
-                Err(ContractError::Underflow {})
-            }
-        } else {
-            Ok(())
+            *uses = uses.saturating_sub(1);
         }
+
+        Ok(())
     }
 }
 

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -105,16 +105,19 @@ impl<'a> ADOContract<'a> {
 
                         // Consume a use for a limited permission
                         if let LocalPermission::Limited { .. } = local_permission {
-                            local_permission.consume_use()?;
-                            permissions().save(
-                                deps.storage,
-                                (action_string.clone() + actor_string.as_str()).as_str(),
-                                &PermissionInfo {
-                                    action: action_string,
-                                    actor: actor_string,
-                                    permission: some_permission,
-                                },
-                            )?;
+                            // Only consume a use if the action is permissioned
+                            if permissioned_action {
+                                local_permission.consume_use()?;
+                                permissions().save(
+                                    deps.storage,
+                                    (action_string.clone() + actor_string.as_str()).as_str(),
+                                    &PermissionInfo {
+                                        action: action_string,
+                                        actor: actor_string,
+                                        permission: some_permission,
+                                    },
+                                )?;
+                            }
                         }
                     }
                     Permission::Contract(contract_address) => {

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -803,6 +803,13 @@ mod tests {
 
         env.block.time = MillisecondsExpiration::from_seconds(time + 1).into();
 
+        let res = contract.is_permissioned(deps.as_mut(), env.clone(), action, actor);
+        //Action is still permissioned so this should error
+        assert!(res.is_err());
+
+        ADOContract::default().disable_action_permission(action, deps.as_mut().storage);
+
+        // Action is no longer permissioned so this should pass
         let res = contract.is_permissioned(deps.as_mut(), env, action, actor);
         assert!(res.is_ok());
     }

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -2,7 +2,7 @@ use crate::ado_contract::ADOContract;
 use crate::common::encode_binary;
 use crate::error::ContractError;
 use crate::os::aos_querier::AOSQuerier;
-use crate::os::{kernel::ExecuteMsg as KernelExecuteMsg, kernel::QueryMsg as KernelQueryMsg};
+use crate::os::kernel::ExecuteMsg as KernelExecuteMsg;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_json_binary, wasm_execute, Addr, Binary, Coin, ContractInfoResponse, CosmosMsg, Deps, Empty,

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -303,16 +303,13 @@ impl AMPPkt {
     /// If the sender is not valid, an error is returned
     pub fn verify_origin(&self, info: &MessageInfo, deps: &Deps) -> Result<(), ContractError> {
         let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
-        if info.sender == self.ctx.origin || info.sender == kernel_address {
+        if (info.sender == self.ctx.origin && info.sender == self.ctx.previous_sender)
+            || info.sender == kernel_address
+        {
             Ok(())
         } else {
             let adodb_address: Addr =
-                deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: kernel_address.to_string(),
-                    msg: to_json_binary(&KernelQueryMsg::KeyAddress {
-                        key: ADO_DB_KEY.to_string(),
-                    })?,
-                }))?;
+                AOSQuerier::kernel_address_getter(&deps.querier, &kernel_address, ADO_DB_KEY)?;
 
             // Get the sender's Code ID
             let contract_info: ContractInfoResponse =
@@ -504,9 +501,15 @@ mod tests {
         let res = pkt.verify_origin(&info, &deps.as_ref());
         assert!(res.is_err());
 
-        let offchain_pkt = AMPPkt::new(INVALID_CONTRACT, INVALID_CONTRACT, vec![msg]);
-        let res = offchain_pkt.verify_origin(&info, &deps.as_ref());
+        // Previous sender and origin set correctly
+        let direct_pkt_valid = AMPPkt::new(INVALID_CONTRACT, INVALID_CONTRACT, vec![msg.clone()]);
+        let res = direct_pkt_valid.verify_origin(&info, &deps.as_ref());
         assert!(res.is_ok());
+
+        // Previous sender and origin set incorrectly
+        let direct_pkt_invalid = AMPPkt::new(INVALID_CONTRACT, "notvalid", vec![msg]);
+        let res = direct_pkt_invalid.verify_origin(&info, &deps.as_ref());
+        assert!(res.is_err());
     }
 
     #[test]

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -120,10 +120,7 @@ cw721-base = { workspace = true }
 cw721 = { workspace = true }
 cw20 = { workspace = true }
 cw-asset = { workspace = true }
-# cw20-base = { workspace = true }
-# cw-cii = { git = "https://github.com/public-awesome/ics721.git" }
-# cw-pause-once = { git = "https://github.com/public-awesome/ics721.git" }
-# cw721-rate-limited-proxy = { git = "https://github.com/0xekez/cw721-proxy.git" }
+toml = "0.7"
 
 andromeda-std = { workspace = true }
 


### PR DESCRIPTION
# Motivation
These changes include the following:
- Fix an unintended consumption of a limited permission for an action as stated in the following audit finding https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/46
- Fix to unintended bypassing of action permissioning https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/47
- Fix redundant limited use consumption https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/27

# Implementation
- An additional check for if the action is permissioned is performed by consuming a limited use permission
- Check the `strict` parameter when checking an expired blacklist
- Early exit for `is_context_permissioned` when origin has permission

# Testing
Test cases were added for the provided scenarios

# Version Changes

`andromeda-std`: `1.2.2` -> `1.2.3`
Bumped all ADO contract versions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced permissioning system to prevent potential exploitation of limited use consumptions.
	- Introduced a script to automate version updates across multiple project files.
	- Added a function to dynamically retrieve contract version from `Cargo.toml` for improved test accuracy.

- **Bug Fixes**
	- Minor version updates across various packages indicating bug fixes and small enhancements.

- **Documentation**
	- Updated `CHANGELOG.md` to reflect recent changes and improvements.

- **Chores**
	- Cleaned up commented-out dependencies in the integration tests configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->