### PR TITLE
feat: remove vesting contract staking feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,17 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merkle Root: stage expiration now uses `Milliseconds`[(#417)](https://github.com/andromedaprotocol/andromeda-core/pull/417)
 - Module Redesign [(#452)](https://github.com/andromedaprotocol/andromeda-core/pull/452)
 - Primitive Improvements [(#476)](https://github.com/andromedaprotocol/andromeda-core/pull/476)
-- Crowdfund Restructure  [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
+- Crowdfund Restructure [(#478)](https://github.com/andromedaprotocol/andromeda-core/pull/478)
 - Conditional Splitter Internal Audit [(#479)](https://github.com/andromedaprotocol/andromeda-core/pull/479)
 - Merkle Root: Andromeda Asset is used now as a `asset_info`[(#480)](https://github.com/andromedaprotocol/andromeda-core/pull/480)
-- Reference Address List contract for Permission  [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
+- Reference Address List contract for Permission [(#481)](https://github.com/andromedaprotocol/andromeda-core/pull/481)
 - Crowdfund Internal Audit [(#485)](https://github.com/andromedaprotocol/andromeda-core/pull/485)
 - Auction: Minimum Raise [(#486)](https://github.com/andromedaprotocol/andromeda-core/pull/486)
 - Version Bump [(#488)](https://github.com/andromedaprotocol/andromeda-core/pull/488)
 - Made Some CampaignConfig Fields Optional [(#541)](https://github.com/andromedaprotocol/andromeda-core/pull/541)
 - Permissioning: Allow multiple actors to be set and removed at once [(#548)](https://github.com/andromedaprotocol/andromeda-core/pull/548)
-- Make Action Names in CW721 Conform to Standard  [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
+- Make Action Names in CW721 Conform to Standard [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
 - Timelock ADO: Replace MillisecondsExpiration with Expiry [(#550)](https://github.com/andromedaprotocol/andromeda-core/pull/550)
+- Removed staking from vesting contract [(#554)](https://github.com/andromedaprotocol/andromeda-core/pull/554)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
 - AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
 - Fix permissioning limited use consumptions and blacklist bypass scenario [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
+- Fix precision issue with vestings claim batch method [(#555)](https://github.com/andromedaprotocol/andromeda-core/pull/555)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -6,8 +6,7 @@ use andromeda_std::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, Binary, Coin, CosmosMsg, Deps, DepsMut, DistributionMsg, Env, GovMsg, MessageInfo,
-    QuerierWrapper, Response, StakingMsg, Uint128, VoteOption,
+    ensure, Binary, Coin, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Response, Uint128,
 };
 use cw_asset::AssetInfo;
 use cw_utils::nonpayable;
@@ -37,7 +36,6 @@ pub fn instantiate(
         is_multi_batch_enabled: msg.is_multi_batch_enabled,
         recipient: msg.recipient,
         denom: msg.denom,
-        unbonding_duration: msg.unbonding_duration,
     };
 
     CONFIG.save(deps.storage, &config)?;
@@ -89,26 +87,12 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
             lockup_duration,
             release_unit,
             release_amount,
-            validator_to_delegate_to,
-        } => execute_create_batch(
-            ctx,
-            lockup_duration,
-            release_unit,
-            release_amount,
-            validator_to_delegate_to,
-        ),
+        } => execute_create_batch(ctx, lockup_duration, release_unit, release_amount),
         ExecuteMsg::Claim {
             number_of_claims,
             batch_id,
         } => execute_claim(ctx, number_of_claims, batch_id),
         ExecuteMsg::ClaimAll { limit, up_to_time } => execute_claim_all(ctx, limit, up_to_time),
-        ExecuteMsg::Delegate { amount, validator } => {
-            execute_delegate(ctx.deps, ctx.env, ctx.info, amount, validator)
-        }
-        ExecuteMsg::Redelegate { amount, from, to } => execute_redelegate(ctx, amount, from, to),
-        ExecuteMsg::Undelegate { amount, validator } => execute_undelegate(ctx, amount, validator),
-        ExecuteMsg::WithdrawRewards {} => execute_withdraw_rewards(ctx),
-        ExecuteMsg::Vote { proposal_id, vote } => execute_vote(ctx, proposal_id, vote),
 
         _ => ADOContract::default().execute(ctx, msg),
     }
@@ -119,7 +103,6 @@ fn execute_create_batch(
     lockup_duration: Option<u64>,
     release_unit: u64,
     release_amount: WithdrawalType,
-    validator_to_delegate_to: Option<String>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
@@ -196,22 +179,12 @@ fn execute_create_batch(
 
     save_new_batch(deps.storage, batch, &config)?;
 
-    let mut response = Response::new()
+    Ok(Response::new()
         .add_attribute("action", "create_batch")
         .add_attribute("amount", funds.amount)
         .add_attribute("lockup_end", lockup_end.to_string())
         .add_attribute("release_unit", release_unit.to_string())
-        .add_attribute("release_amount", release_amount_string);
-
-    if let Some(validator) = validator_to_delegate_to {
-        let delegate_response = execute_delegate(deps, env, info, Some(funds.amount), validator)?;
-        response = response
-            .add_attributes(delegate_response.attributes)
-            .add_submessages(delegate_response.messages)
-            .add_events(delegate_response.events);
-    }
-
-    Ok(response)
+        .add_attribute("release_amount", release_amount_string))
 }
 
 fn execute_claim(
@@ -321,150 +294,6 @@ fn execute_claim_all(
         .add_attribute("last_batch_id_processed", last_batch_id))
 }
 
-fn execute_delegate(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    amount: Option<Uint128>,
-    validator: String,
-) -> Result<Response, ContractError> {
-    let sender = info.sender.to_string();
-    ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
-    let config = CONFIG.load(deps.storage)?;
-    let asset = AssetInfo::native(config.denom.clone());
-    let max_amount = asset.query_balance(&deps.querier, env.contract.address)?;
-    let amount = cmp::min(max_amount, amount.unwrap_or(max_amount));
-
-    ensure!(!amount.is_zero(), ContractError::InvalidZeroAmount {});
-
-    let msg: CosmosMsg = CosmosMsg::Staking(StakingMsg::Delegate {
-        validator: validator.clone(),
-        amount: Coin {
-            denom: config.denom,
-            amount,
-        },
-    });
-
-    Ok(Response::new()
-        .add_message(get_set_withdraw_address_msg(sender))
-        .add_message(msg)
-        .add_attribute("action", "delegate")
-        .add_attribute("validator", validator)
-        .add_attribute("amount", amount))
-}
-
-fn execute_redelegate(
-    ctx: ExecuteContext,
-    amount: Option<Uint128>,
-    from: String,
-    to: String,
-) -> Result<Response, ContractError> {
-    let ExecuteContext {
-        deps, info, env, ..
-    } = ctx;
-    let sender = info.sender.to_string();
-    ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
-    let config = CONFIG.load(deps.storage)?;
-    let max_amount = get_amount_delegated(
-        &deps.querier,
-        env.contract.address.to_string(),
-        from.clone(),
-    )?;
-    let amount = cmp::min(max_amount, amount.unwrap_or(max_amount));
-
-    ensure!(!amount.is_zero(), ContractError::InvalidZeroAmount {});
-
-    let msg: CosmosMsg = CosmosMsg::Staking(StakingMsg::Redelegate {
-        src_validator: from.clone(),
-        dst_validator: to.clone(),
-        amount: Coin {
-            denom: config.denom,
-            amount,
-        },
-    });
-
-    Ok(Response::new()
-        .add_message(get_set_withdraw_address_msg(sender))
-        .add_message(msg)
-        .add_attribute("action", "redelegate")
-        .add_attribute("from", from)
-        .add_attribute("to", to)
-        .add_attribute("amount", amount))
-}
-
-fn execute_undelegate(
-    ctx: ExecuteContext,
-    amount: Option<Uint128>,
-    validator: String,
-) -> Result<Response, ContractError> {
-    let ExecuteContext {
-        deps, info, env, ..
-    } = ctx;
-    let sender = info.sender.to_string();
-    ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
-    let config = CONFIG.load(deps.storage)?;
-    let max_amount = get_amount_delegated(
-        &deps.querier,
-        env.contract.address.to_string(),
-        validator.clone(),
-    )?;
-    let amount = cmp::min(max_amount, amount.unwrap_or(max_amount));
-
-    ensure!(!amount.is_zero(), ContractError::InvalidZeroAmount {});
-
-    let msg: CosmosMsg = CosmosMsg::Staking(StakingMsg::Undelegate {
-        validator: validator.clone(),
-        amount: Coin {
-            denom: config.denom,
-            amount,
-        },
-    });
-
-    Ok(Response::new()
-        .add_message(get_set_withdraw_address_msg(sender))
-        .add_message(msg)
-        .add_attribute("action", "undelegate")
-        .add_attribute("validator", validator)
-        .add_attribute("amount", amount))
-}
-
-fn execute_withdraw_rewards(ctx: ExecuteContext) -> Result<Response, ContractError> {
-    let ExecuteContext {
-        deps, info, env, ..
-    } = ctx;
-    nonpayable(&info)?;
-
-    let sender = info.sender.to_string();
-    ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
-    let withdraw_rewards_msgs: Vec<CosmosMsg> = deps
-        .querier
-        .query_all_delegations(env.contract.address)?
-        .into_iter()
-        .map(|d| {
-            CosmosMsg::Distribution(DistributionMsg::WithdrawDelegatorReward {
-                validator: d.validator,
-            })
-        })
-        .collect();
-
-    Ok(Response::new()
-        .add_attribute("action", "withdraw_rewards")
-        .add_message(get_set_withdraw_address_msg(sender))
-        .add_messages(withdraw_rewards_msgs))
-}
-
 fn claim_batch(
     querier: &QuerierWrapper,
     env: &Env,
@@ -518,44 +347,6 @@ fn claim_batch(
     }
 
     Ok(amount_to_send)
-}
-
-fn execute_vote(
-    ctx: ExecuteContext,
-    proposal_id: u64,
-    vote: VoteOption,
-) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, info, .. } = ctx;
-    nonpayable(&info)?;
-    ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {}
-    );
-    let msg: CosmosMsg = CosmosMsg::Gov(GovMsg::Vote {
-        proposal_id,
-        vote: vote.clone(),
-    });
-    Ok(Response::new()
-        .add_message(msg)
-        .add_attribute("action", "vote")
-        .add_attribute("proposal_id", proposal_id.to_string())
-        .add_attribute("vote", format!("{vote:?}")))
-}
-
-fn get_amount_delegated(
-    querier: &QuerierWrapper,
-    delegator: String,
-    validator: String,
-) -> Result<Uint128, ContractError> {
-    let res = querier.query_delegation(delegator, validator)?;
-    match res {
-        None => Ok(Uint128::zero()),
-        Some(full_delegation) => Ok(full_delegation.amount.amount),
-    }
-}
-
-fn get_set_withdraw_address_msg(address: String) -> CosmosMsg {
-    CosmosMsg::Distribution(DistributionMsg::SetWithdrawAddress { address })
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/finance/andromeda-vesting/src/testing/tests.rs
+++ b/contracts/finance/andromeda-vesting/src/testing/tests.rs
@@ -3,10 +3,9 @@ use andromeda_std::{
     testing::mock_querier::MOCK_KERNEL_CONTRACT,
 };
 use cosmwasm_std::{
-    coin, coins, from_json,
-    testing::{mock_env, mock_info, MockQuerier, MOCK_CONTRACT_ADDR},
-    Addr, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, DistributionMsg, FullDelegation, GovMsg,
-    Response, StakingMsg, Uint128, Validator, VoteOption,
+    coins, from_json,
+    testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR},
+    BankMsg, DepsMut, Response, Uint128,
 };
 use cw_utils::Duration;
 
@@ -18,7 +17,6 @@ use crate::{
 
 use andromeda_finance::vesting::{BatchResponse, Config, ExecuteMsg, InstantiateMsg, QueryMsg};
 
-const DEFAULT_VALIDATOR: &str = "validator";
 const UNBONDING_BLOCK_DURATION: u64 = 5;
 
 fn init(deps: DepsMut) -> Response {
@@ -35,35 +33,6 @@ fn init(deps: DepsMut) -> Response {
     instantiate(deps, mock_env(), info, msg).unwrap()
 }
 
-fn sample_validator(addr: &str) -> Validator {
-    Validator {
-        address: addr.into(),
-        commission: Decimal::percent(3),
-        max_commission: Decimal::percent(10),
-        max_change_rate: Decimal::percent(1),
-    }
-}
-
-fn sample_delegation(addr: &str, amount: Coin) -> FullDelegation {
-    let can_redelegate = amount.clone();
-    let accumulated_rewards = coins(0, &amount.denom);
-    FullDelegation {
-        validator: addr.into(),
-        delegator: Addr::unchecked(MOCK_CONTRACT_ADDR),
-        amount,
-        can_redelegate,
-        accumulated_rewards,
-    }
-}
-
-fn set_delegation(querier: &mut MockQuerier, amount: u128, denom: &str) {
-    querier.update_staking(
-        "ustake",
-        &[sample_validator(DEFAULT_VALIDATOR)],
-        &[sample_delegation(DEFAULT_VALIDATOR, coin(amount, denom))],
-    )
-}
-
 fn create_batch(
     deps: DepsMut,
     lockup_duration: Option<u64>,
@@ -75,7 +44,6 @@ fn create_batch(
         lockup_duration,
         release_unit,
         release_amount,
-        validator_to_delegate_to: None,
     };
 
     let info = mock_info("owner", &coins(100, "uusd"));
@@ -102,7 +70,6 @@ fn test_instantiate() {
             recipient: Recipient::from_string("recipient"),
             is_multi_batch_enabled: true,
             denom: "uusd".to_string(),
-            unbonding_duration: Duration::Height(UNBONDING_BLOCK_DURATION)
         },
         CONFIG.load(deps.as_ref().storage).unwrap()
     );
@@ -119,7 +86,6 @@ fn test_create_batch_unauthorized() {
         lockup_duration: None,
         release_unit: 1,
         release_amount: WithdrawalType::Amount(Uint128::zero()),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -139,7 +105,6 @@ fn test_create_batch_no_funds() {
         lockup_duration: None,
         release_unit: 1,
         release_amount: WithdrawalType::Amount(Uint128::zero()),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -163,7 +128,6 @@ fn test_create_batch_invalid_denom() {
         lockup_duration: None,
         release_unit: 1,
         release_amount: WithdrawalType::Amount(Uint128::zero()),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -187,7 +151,6 @@ fn test_create_batch_valid_denom_zero_amount() {
         lockup_duration: None,
         release_unit: 1,
         release_amount: WithdrawalType::Amount(Uint128::zero()),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -206,7 +169,6 @@ fn test_create_batch_release_unit_zero() {
         lockup_duration: None,
         release_unit: 0,
         release_amount: WithdrawalType::Amount(Uint128::zero()),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -225,7 +187,6 @@ fn test_create_batch_release_amount_zero() {
         lockup_duration: None,
         release_unit: 10,
         release_amount: WithdrawalType::Amount(Uint128::zero()),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg);
@@ -244,7 +205,6 @@ fn test_create_batch() {
         lockup_duration: None,
         release_unit: 10,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -281,7 +241,6 @@ fn test_create_batch() {
         lockup_duration: Some(100),
         release_unit: 10,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -314,50 +273,6 @@ fn test_create_batch() {
 }
 
 #[test]
-fn test_create_batch_and_delegate() {
-    let mut deps = mock_dependencies_custom(&[coin(1000, "uusd")]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &coins(100, "uusd"));
-
-    deps.querier
-        .base
-        .update_balance(MOCK_CONTRACT_ADDR, coins(100, "uusd"));
-
-    let msg = ExecuteMsg::CreateBatch {
-        lockup_duration: None,
-        release_unit: 10,
-        release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: Some(DEFAULT_VALIDATOR.to_owned()),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-    let current_time = mock_env().block.time.seconds();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Delegate {
-                validator: DEFAULT_VALIDATOR.to_string(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "create_batch")
-            .add_attribute("amount", "100")
-            .add_attribute("lockup_end", current_time.to_string())
-            .add_attribute("release_unit", "10")
-            .add_attribute("release_amount", "Amount(Uint128(10))")
-            .add_attribute("action", "delegate")
-            .add_attribute("validator", DEFAULT_VALIDATOR)
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
 fn test_create_batch_multi_batch_not_supported() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
@@ -378,7 +293,6 @@ fn test_create_batch_multi_batch_not_supported() {
         lockup_duration: Some(100),
         release_unit: 10,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let res = execute(deps.as_mut(), mock_env(), info.clone(), msg.clone()).unwrap();
@@ -444,7 +358,6 @@ fn test_claim_batch_still_locked() {
         lockup_duration: Some(100),
         release_unit: 10,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -471,7 +384,6 @@ fn test_claim_batch_no_funds_available() {
         lockup_duration: None,
         release_unit: 10,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -486,109 +398,6 @@ fn test_claim_batch_no_funds_available() {
 
     // This is because, the first payment becomes available after 10 seconds.
     assert_eq!(ContractError::WithdrawalIsEmpty {}, res.unwrap_err());
-}
-
-#[test]
-fn test_claim_batch_all_funds_delegated() {
-    let mut deps = mock_dependencies_custom(&[coin(1000, "uusd")]);
-    init(deps.as_mut());
-    let info = mock_info("owner", &coins(100, "uusd"));
-
-    // Create batch.
-    let msg = ExecuteMsg::CreateBatch {
-        lockup_duration: None,
-        release_unit: 10,
-        release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
-    };
-
-    let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
-
-    deps.querier
-        .base
-        .update_balance(MOCK_CONTRACT_ADDR, coins(100, "uusd"));
-
-    // Delegate tokens
-    let msg = ExecuteMsg::Delegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_owned(),
-    };
-
-    let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
-
-    // Skip time to first release.
-    let mut env = mock_env();
-    env.block.time = env.block.time.plus_seconds(10);
-
-    // Claim batch.
-    let msg = ExecuteMsg::Claim {
-        number_of_claims: None,
-        batch_id: 1,
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    // This is because, the first payment becomes available after 10 seconds.
-    assert_eq!(ContractError::WithdrawalIsEmpty {}, res.unwrap_err());
-}
-
-#[test]
-fn test_claim_batch_some_funds_delegated() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-    let info = mock_info("owner", &coins(100, "uusd"));
-
-    // Create batch.
-    let msg = ExecuteMsg::CreateBatch {
-        lockup_duration: None,
-        release_unit: 10,
-        release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
-    };
-
-    let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
-
-    deps.querier
-        .base
-        .update_balance(MOCK_CONTRACT_ADDR, coins(100, "uusd"));
-
-    // Delegate tokens
-    let msg = ExecuteMsg::Delegate {
-        amount: Some(Uint128::new(70)),
-        validator: DEFAULT_VALIDATOR.to_owned(),
-    };
-
-    let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
-
-    // Skip time to where all funds available.
-    let mut env = mock_env();
-    env.block.time = env.block.time.plus_seconds(1000);
-
-    deps.querier
-        .base
-        .update_balance(MOCK_CONTRACT_ADDR, coins(30, "uusd"));
-
-    // Claim batch.
-    let msg = ExecuteMsg::Claim {
-        number_of_claims: None,
-        batch_id: 1,
-    };
-
-    let res = execute(deps.as_mut(), env, info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(BankMsg::Send {
-                to_address: "recipient".to_string(),
-                // Only 30 are available
-                amount: coins(30, "uusd")
-            })
-            .add_attribute("action", "claim")
-            .add_attribute("amount", "30")
-            .add_attribute("batch_id", "1")
-            .add_attribute("amount_left", "70"),
-        res
-    );
 }
 
 #[test]
@@ -604,7 +413,6 @@ fn test_claim_batch_single_claim() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -686,7 +494,6 @@ fn test_claim_batch_not_nice_numbers_single_release() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -748,7 +555,6 @@ fn test_claim_batch_not_nice_numbers_multiple_releases() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -810,7 +616,6 @@ fn test_claim_batch_middle_of_interval() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -877,7 +682,6 @@ fn test_claim_batch_multiple_claims() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -971,7 +775,6 @@ fn test_claim_batch_all_releases() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -1038,7 +841,6 @@ fn test_claim_batch_too_high_of_claim() {
         lockup_duration: None,
         release_unit,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
-        validator_to_delegate_to: None,
     };
 
     let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
@@ -1257,433 +1059,5 @@ fn test_claim_all() {
             last_claimed_release_time: lockup_end + 12,
         },
         batches().load(deps.as_ref().storage, 3u64).unwrap()
-    );
-}
-
-#[test]
-fn test_delegate_unauthorized() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("not_owner", &[]);
-
-    let msg = ExecuteMsg::Delegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
-}
-
-#[test]
-fn test_delegate_no_funds() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::Delegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::InvalidZeroAmount {}, res.unwrap_err());
-}
-
-#[test]
-fn test_delegate() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    deps.querier
-        .base
-        .update_balance(MOCK_CONTRACT_ADDR, coins(100, "uusd"));
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::Delegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Delegate {
-                validator: DEFAULT_VALIDATOR.to_string(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "delegate")
-            .add_attribute("validator", DEFAULT_VALIDATOR)
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
-fn test_delegate_more_than_balance() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    deps.querier
-        .base
-        .update_balance(MOCK_CONTRACT_ADDR, coins(100, "uusd"));
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::Delegate {
-        amount: Some(Uint128::new(200)),
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Delegate {
-                validator: DEFAULT_VALIDATOR.to_string(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "delegate")
-            .add_attribute("validator", DEFAULT_VALIDATOR)
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
-fn test_redelegate_unauthorized() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("not_owner", &[]);
-
-    let msg = ExecuteMsg::Redelegate {
-        amount: None,
-        from: DEFAULT_VALIDATOR.to_string(),
-        to: "other_validator".to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
-}
-
-#[test]
-fn test_redelegate_no_funds() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::Redelegate {
-        amount: None,
-        from: DEFAULT_VALIDATOR.to_string(),
-        to: "other_validator".to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::InvalidZeroAmount {}, res.unwrap_err());
-}
-
-#[test]
-fn test_redelegate() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    set_delegation(&mut deps.querier.base, 100, "uusd");
-
-    let msg = ExecuteMsg::Redelegate {
-        amount: None,
-        from: DEFAULT_VALIDATOR.to_string(),
-        to: "other_validator".to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Redelegate {
-                src_validator: DEFAULT_VALIDATOR.to_owned(),
-                dst_validator: "other_validator".to_string(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "redelegate")
-            .add_attribute("from", DEFAULT_VALIDATOR)
-            .add_attribute("to", "other_validator")
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
-fn test_redelegate_more_than_max() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    set_delegation(&mut deps.querier.base, 100, "uusd");
-
-    let msg = ExecuteMsg::Redelegate {
-        amount: Some(Uint128::new(200)),
-        from: DEFAULT_VALIDATOR.to_string(),
-        to: "other_validator".to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Redelegate {
-                src_validator: DEFAULT_VALIDATOR.to_owned(),
-                dst_validator: "other_validator".to_string(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "redelegate")
-            .add_attribute("from", DEFAULT_VALIDATOR)
-            .add_attribute("to", "other_validator")
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
-fn test_undelegate_unauthorized() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("not_owner", &[]);
-
-    let msg = ExecuteMsg::Undelegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
-}
-
-#[test]
-fn test_undelegate_no_funds() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::Undelegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::InvalidZeroAmount {}, res.unwrap_err());
-}
-
-#[test]
-fn test_undelegate() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    set_delegation(&mut deps.querier.base, 100, "uusd");
-
-    let msg = ExecuteMsg::Undelegate {
-        amount: None,
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Undelegate {
-                validator: DEFAULT_VALIDATOR.to_owned(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "undelegate")
-            .add_attribute("validator", DEFAULT_VALIDATOR)
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
-fn test_undelegate_more_than_max() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    set_delegation(&mut deps.querier.base, 100, "uusd");
-
-    let msg = ExecuteMsg::Undelegate {
-        amount: Some(Uint128::new(200)),
-        validator: DEFAULT_VALIDATOR.to_string(),
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Staking(StakingMsg::Undelegate {
-                validator: DEFAULT_VALIDATOR.to_owned(),
-                amount: coin(100, "uusd")
-            }))
-            .add_attribute("action", "undelegate")
-            .add_attribute("validator", DEFAULT_VALIDATOR)
-            .add_attribute("amount", "100"),
-        res
-    );
-}
-
-#[test]
-fn test_withdraw_rewards_unauthorized() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("not_owner", &[]);
-
-    let msg = ExecuteMsg::WithdrawRewards {};
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
-}
-
-#[test]
-fn test_vote_unauthorized() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("not_owner", &[]);
-
-    let msg = ExecuteMsg::Vote {
-        proposal_id: 1,
-        vote: VoteOption::Yes,
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-
-    assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
-}
-
-#[test]
-fn test_withdraw_rewards() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::WithdrawRewards {};
-
-    deps.querier.base.update_staking(
-        "ustake",
-        &[
-            sample_validator("validator1"),
-            sample_validator("validator2"),
-            sample_validator("validator3"),
-        ],
-        &[
-            sample_delegation("validator1", coin(100, "ustake")),
-            sample_delegation("validator2", coin(100, "ustake")),
-            sample_delegation("validator3", coin(100, "ustake")),
-        ],
-    );
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_attribute("action", "withdraw_rewards")
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::SetWithdrawAddress {
-                    address: "owner".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::WithdrawDelegatorReward {
-                    validator: "validator1".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::WithdrawDelegatorReward {
-                    validator: "validator2".to_string()
-                }
-            ))
-            .add_message(CosmosMsg::Distribution(
-                DistributionMsg::WithdrawDelegatorReward {
-                    validator: "validator3".to_string()
-                }
-            )),
-        res
-    );
-}
-
-#[test]
-fn test_vote() {
-    let mut deps = mock_dependencies_custom(&[]);
-    init(deps.as_mut());
-
-    let info = mock_info("owner", &[]);
-
-    let msg = ExecuteMsg::Vote {
-        proposal_id: 1,
-        vote: VoteOption::Yes,
-    };
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    assert_eq!(
-        Response::new()
-            .add_message(CosmosMsg::Gov(GovMsg::Vote {
-                proposal_id: 1,
-                vote: VoteOption::Yes
-            }))
-            .add_attribute("action", "vote")
-            .add_attribute("proposal_id", "1")
-            .add_attribute("vote", "Yes"),
-        res
     );
 }

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -2,7 +2,7 @@ use andromeda_std::{
     amp::Recipient, andr_exec, andr_instantiate, andr_query, common::withdraw::WithdrawalType,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Uint128, VoteOption};
+use cosmwasm_std::Uint128;
 use cw_utils::Duration;
 
 #[andr_instantiate]
@@ -43,30 +43,7 @@ pub enum ExecuteMsg {
         /// Specifies how much is to be released after each `release_unit`. If
         /// it is a percentage, it would be the percentage of the original amount.
         release_amount: WithdrawalType,
-        /// The validator to delegate to. If specified, funds will be delegated to it.
-        validator_to_delegate_to: Option<String>,
     },
-    /// Delegates the given amount of tokens, or all if not specified.
-    Delegate {
-        amount: Option<Uint128>,
-        validator: String,
-    },
-    /// Redelegates the given amount of tokens, or all from the `from` validator to the `to`
-    /// validator.
-    Redelegate {
-        amount: Option<Uint128>,
-        from: String,
-        to: String,
-    },
-    /// Undelegates the given amount of tokens, or all if not specified.
-    Undelegate {
-        amount: Option<Uint128>,
-        validator: String,
-    },
-    /// Withdraws rewards from all delegations to the sender.
-    WithdrawRewards {},
-    /// Votes on the specified proposal with the specified vote.
-    Vote { proposal_id: u64, vote: VoteOption },
 }
 
 #[andr_query]
@@ -95,8 +72,6 @@ pub struct Config {
     pub is_multi_batch_enabled: bool,
     /// The denom of the coin being vested.
     pub denom: String,
-    /// The unbonding duration of the native staking module.
-    pub unbonding_duration: Duration,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation
Given the recent addition of the `validator-staking` ADO and feedback from the audit for both this contract and the vesting contract we decided to remove the ability to stake vested tokens using our vesting contract temporarily. In a future iteration it is likely we will add this functionality back but using the `validator-staking` ADO instead.

This should resolve the following findings:
- https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/57
- https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/58
- https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/59

# Implementation
Removed all references to delegate/undelegate/vote in the vesting contract.

# Testing
Removed related tests

# Version Changes
`andromeda-vesting`: `2.0.0` -> `3.0.0`

# Future work
Readd this functionality using the `validator-staking` ADO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the vesting contract to remove staking functionalities, simplifying user interactions.
	- Major version increment for the `andromeda-vesting` package, indicating significant changes.

- **Bug Fixes**
	- Fixed precision issues in the vestings claim batch method, improving accuracy in withdrawal calculations.

- **Refactor**
	- Streamlined the smart contract by removing delegation-related functions and parameters, focusing on core functionalities.

- **Tests**
	- Removed tests related to delegation and voting, reflecting changes in contract capabilities and simplifying the testing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->