### PR TITLE
fix: claim_batch precision issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
 - AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
 - Fix permissioning limited use consumptions and blacklist bypass scenario [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
+- Fix precision issue with vestings claim batch method [(#555)](https://github.com/andromedaprotocol/andromeda-core/pull/555)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 


### PR DESCRIPTION
# Motivation
These changes alter `claim_batch` to use a Decimal type for calculating amount to send rather than defaulting to `Uint128`. This should prevent any potential precision issues presented here:
- https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/49

# Implementation
`WithdrawalType::get_amount` now returns `Decimal` instead of `Uint128`. 

# Testing
`test_claim_batch_not_nice_numbers_multiple_releases` was altered to use the provided scenario 

# Version Changes
`andromeda-vesting`: `3.0.0` -> `3.0.1`
