### PR TITLE
feat: Multiple Actors in Address List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Permissioning: Allow multiple actors to be set and removed at once [(#548)](https://github.com/andromedaprotocol/andromeda-core/pull/548)
 - Make Action Names in CW721 Conform to Standard [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
 - Timelock ADO: Replace MillisecondsExpiration with Expiry [(#550)](https://github.com/andromedaprotocol/andromeda-core/pull/550)
+- Address List: Support for multiple actors while adding and removing permissions [(#556)](https://github.com/andromedaprotocol/andromeda-core/pull/556)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -81,10 +81,10 @@ pub fn execute(
 
 pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::AddActorPermission { actors, permission } => {
+        ExecuteMsg::PermissionActors { actors, permission } => {
             execute_add_actor_permission(ctx, actors, permission)
         }
-        ExecuteMsg::RemoveActorPermission { actors } => {
+        ExecuteMsg::RemovePermissions { actors } => {
             execute_remove_actor_permission(ctx, actors)
         }
         _ => ADOContract::default().execute(ctx, msg),

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -82,16 +82,16 @@ pub fn execute(
 pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::PermissionActors { actors, permission } => {
-            execute_add_actor_permission(ctx, actors, permission)
+            execute_permission_actors(ctx, actors, permission)
         }
         ExecuteMsg::RemovePermissions { actors } => {
-            execute_remove_actor_permission(ctx, actors)
+            execute_remove_permissions(ctx, actors)
         }
         _ => ADOContract::default().execute(ctx, msg),
     }
 }
 
-fn execute_add_actor_permission(
+fn execute_permission_actors(
     ctx: ExecuteContext,
     actors: Vec<AndrAddr>,
     permission: LocalPermission,
@@ -124,7 +124,7 @@ fn execute_add_actor_permission(
     ]))
 }
 
-fn execute_remove_actor_permission(
+fn execute_remove_permissions(
     ctx: ExecuteContext,
     actors: Vec<AndrAddr>,
 ) -> Result<Response, ContractError> {

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -84,9 +84,7 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
         ExecuteMsg::PermissionActors { actors, permission } => {
             execute_permission_actors(ctx, actors, permission)
         }
-        ExecuteMsg::RemovePermissions { actors } => {
-            execute_remove_permissions(ctx, actors)
-        }
+        ExecuteMsg::RemovePermissions { actors } => execute_remove_permissions(ctx, actors),
         _ => ADOContract::default().execute(ctx, msg),
     }
 }

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use andromeda_modules::address_list::{ActorPermissionResponse, IncludesActorResponse};
 #[cfg(not(feature = "library"))]
 use andromeda_modules::address_list::{ExecuteMsg, InstantiateMsg, QueryMsg};

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -38,7 +38,7 @@ pub fn instantiate(
             ContractError::NoActorsProvided {}
         );
         for actor in actor_permission.actors {
-            let verified_address: Addr = deps.api.addr_validate(&actor.into_string().as_str())?;
+            let verified_address: Addr = deps.api.addr_validate(actor.as_str())?;
             add_actors_permission(
                 deps.storage,
                 vec![verified_address],

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -41,15 +41,8 @@ pub fn instantiate(
             ContractError::NoActorsProvided {}
         );
 
-        let verified_actors: Vec<Addr> = actor_permission
-            .actors
-            .into_iter()
-            .map(|actor| actor.get_raw_address(&deps.as_ref()))
-            .collect::<Result<HashSet<_>, _>>()?
-            .into_iter()
-            .collect();
-
-        for verified_actor in verified_actors {
+        for actor in actor_permission.actors {
+            let verified_actor = actor.get_raw_address(&deps.as_ref())?;
             add_actors_permission(deps.storage, verified_actor, &actor_permission.permission)?;
         }
     }
@@ -159,7 +152,7 @@ fn execute_remove_actor_permission(
         .map(|actor| actor.to_string())
         .collect::<Vec<String>>()
         .join(", ");
-    
+
     Ok(Response::new().add_attributes(vec![
         attr("action", "remove_actor_permission"),
         attr("actor", actors_str),

--- a/contracts/modules/andromeda-address-list/src/mock.rs
+++ b/contracts/modules/andromeda-address-list/src/mock.rs
@@ -72,5 +72,5 @@ pub fn mock_add_actor_permission_msg(
     actors: Vec<AndrAddr>,
     permission: LocalPermission,
 ) -> ExecuteMsg {
-    ExecuteMsg::AddActorPermission { actors, permission }
+    ExecuteMsg::PermissionActors { actors, permission }
 }

--- a/contracts/modules/andromeda-address-list/src/mock.rs
+++ b/contracts/modules/andromeda-address-list/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_modules::address_list::{ActorPermission, ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_std::ado_base::permissioning::LocalPermission;
+use andromeda_std::{ado_base::permissioning::LocalPermission, amp::AndrAddr};
 use andromeda_testing::{
     mock::MockApp, mock_ado, mock_contract::ExecuteResult, MockADO, MockContract,
 };
@@ -39,7 +39,7 @@ impl MockAddressList {
         &self,
         app: &mut MockApp,
         sender: Addr,
-        actors: Vec<Addr>,
+        actors: Vec<AndrAddr>,
         permission: LocalPermission,
     ) -> ExecuteResult {
         self.execute(
@@ -68,6 +68,9 @@ pub fn mock_address_list_instantiate_msg(
     }
 }
 
-pub fn mock_add_actor_permission_msg(actors: Vec<Addr>, permission: LocalPermission) -> ExecuteMsg {
+pub fn mock_add_actor_permission_msg(
+    actors: Vec<AndrAddr>,
+    permission: LocalPermission,
+) -> ExecuteMsg {
     ExecuteMsg::AddActorPermission { actors, permission }
 }

--- a/contracts/modules/andromeda-address-list/src/mock.rs
+++ b/contracts/modules/andromeda-address-list/src/mock.rs
@@ -39,12 +39,12 @@ impl MockAddressList {
         &self,
         app: &mut MockApp,
         sender: Addr,
-        actor: Addr,
+        actors: Vec<Addr>,
         permission: LocalPermission,
     ) -> ExecuteResult {
         self.execute(
             app,
-            &mock_add_actor_permission_msg(actor, permission),
+            &mock_add_actor_permission_msg(actors, permission),
             sender,
             &[],
         )
@@ -68,6 +68,6 @@ pub fn mock_address_list_instantiate_msg(
     }
 }
 
-pub fn mock_add_actor_permission_msg(actor: Addr, permission: LocalPermission) -> ExecuteMsg {
-    ExecuteMsg::AddActorPermission { actor, permission }
+pub fn mock_add_actor_permission_msg(actors: Vec<Addr>, permission: LocalPermission) -> ExecuteMsg {
+    ExecuteMsg::AddActorPermission { actors, permission }
 }

--- a/contracts/modules/andromeda-address-list/src/state.rs
+++ b/contracts/modules/andromeda-address-list/src/state.rs
@@ -11,10 +11,13 @@ pub fn includes_actor(storage: &dyn Storage, actor: &Addr) -> StdResult<bool> {
 }
 
 /// Add or update an actor's permission
-pub fn add_actor_permission(
+pub fn add_actors_permission(
     storage: &mut dyn Storage,
-    actor: &Addr,
+    actors: Vec<Addr>,
     permission: &LocalPermission,
 ) -> StdResult<()> {
-    PERMISSIONS.save(storage, actor, permission)
+    for actor in actors {
+        PERMISSIONS.save(storage, &actor, permission)?;
+    }
+    Ok(())
 }

--- a/contracts/modules/andromeda-address-list/src/state.rs
+++ b/contracts/modules/andromeda-address-list/src/state.rs
@@ -13,11 +13,9 @@ pub fn includes_actor(storage: &dyn Storage, actor: &Addr) -> StdResult<bool> {
 /// Add or update an actor's permission
 pub fn add_actors_permission(
     storage: &mut dyn Storage,
-    actors: Vec<Addr>,
+    actor: Addr,
     permission: &LocalPermission,
 ) -> StdResult<()> {
-    for actor in actors {
-        PERMISSIONS.save(storage, &actor, permission)?;
-    }
+    PERMISSIONS.save(storage, &actor, permission)?;
     Ok(())
 }

--- a/contracts/modules/andromeda-address-list/src/testing/tests.rs
+++ b/contracts/modules/andromeda-address-list/src/testing/tests.rs
@@ -81,7 +81,7 @@ fn test_add_remove_actor() {
 
     init(deps.as_mut(), info.clone());
 
-    let msg = ExecuteMsg::AddActorPermission {
+    let msg = ExecuteMsg::PermissionActors {
         actors: vec![AndrAddr::from_string(actor.clone())],
         permission: permission.clone(),
     };
@@ -105,7 +105,7 @@ fn test_add_remove_actor() {
 
     // // Contract permissions aren't allowed to be saved in the address list contract
     // let contract_permission = Permission::Whitelisted(None);
-    // let msg = ExecuteMsg::AddActorPermission {
+    // let msg = ExecuteMsg::PermissionActors {
     //     actor: Addr::unchecked(MOCK_KERNEL_CONTRACT),
     //     permission: contract_permission,
     // };
@@ -118,7 +118,7 @@ fn test_add_remove_actor() {
     // );
 
     // Test remove actor
-    let msg = ExecuteMsg::RemoveActorPermission {
+    let msg = ExecuteMsg::RemovePermissions {
         actors: vec![AndrAddr::from_string(actor.clone())],
     };
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
@@ -132,7 +132,7 @@ fn test_add_remove_actor() {
 
     // Try removing an actor that isn't included in permissions
     let random_actor = Addr::unchecked("random_actor");
-    let msg = ExecuteMsg::RemoveActorPermission {
+    let msg = ExecuteMsg::RemovePermissions {
         actors: vec![AndrAddr::from_string(random_actor)],
     };
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
@@ -155,7 +155,7 @@ fn test_add_remove_multiple_actors() {
 
     init(deps.as_mut(), info.clone());
 
-    let msg = ExecuteMsg::AddActorPermission {
+    let msg = ExecuteMsg::PermissionActors {
         actors: actors.clone(),
         permission: permission.clone(),
     };
@@ -191,7 +191,7 @@ fn test_add_remove_multiple_actors() {
 
     // // Contract permissions aren't allowed to be saved in the address list contract
     // let contract_permission = Permission::Whitelisted(None);
-    // let msg = ExecuteMsg::AddActorPermission {
+    // let msg = ExecuteMsg::PermissionActors {
     //     actor: Addr::unchecked(MOCK_KERNEL_CONTRACT),
     //     permission: contract_permission,
     // };
@@ -204,7 +204,7 @@ fn test_add_remove_multiple_actors() {
     // );
 
     // Test remove actor
-    let msg = ExecuteMsg::RemoveActorPermission {
+    let msg = ExecuteMsg::RemovePermissions {
         actors: actors.clone(),
     };
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
@@ -230,7 +230,7 @@ fn test_add_remove_multiple_actors() {
 
     // Try removing an actor that isn't included in permissions
     let random_actor = Addr::unchecked("random_actor");
-    let msg = ExecuteMsg::RemoveActorPermission {
+    let msg = ExecuteMsg::RemovePermissions {
         actors: vec![AndrAddr::from_string(random_actor)],
     };
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();

--- a/packages/andromeda-modules/README.md
+++ b/packages/andromeda-modules/README.md
@@ -19,7 +19,7 @@ pub const PERMISSIONS: Map<&Addr, Permission> = Map::new("permissioning")
 ```
 Note that `Permission` of type `Contract` isn't allowed in the address-list contract.
 
-Apply `ExecuteMsg::AddActorPermission { actor, permission }` to the ADO you want. 
+Apply `ExecuteMsg::PermissionActors { actor, permission }` to the ADO you want. 
 To involve the address-list contract, set the Permission to be of type Contract, and input the address-list's contract address. `Permission::Contract(address_list_address)`.
 Make sure that the `actor` is the same as the one set in the address-list contract.
 

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -21,12 +21,12 @@ pub struct ActorPermission {
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Adds an actor key and a permission value
-    AddActorPermission {
+    PermissionActors {
         actors: Vec<AndrAddr>,
         permission: LocalPermission,
     },
     /// Removes actor alongisde his permission
-    RemoveActorPermission { actors: Vec<AndrAddr> },
+    RemovePermissions { actors: Vec<AndrAddr> },
 }
 
 #[andr_query]

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -1,5 +1,6 @@
 use andromeda_std::{
-    ado_base::permissioning::LocalPermission, andr_exec, andr_instantiate, andr_query,
+    ado_base::permissioning::LocalPermission, amp::AndrAddr, andr_exec, andr_instantiate,
+    andr_query,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
@@ -12,7 +13,7 @@ pub struct InstantiateMsg {
 // Struct used to bundle actor and permission
 #[cw_serde]
 pub struct ActorPermission {
-    pub actors: Vec<Addr>,
+    pub actors: Vec<AndrAddr>,
     pub permission: LocalPermission,
 }
 
@@ -21,11 +22,11 @@ pub struct ActorPermission {
 pub enum ExecuteMsg {
     /// Adds an actor key and a permission value
     AddActorPermission {
-        actors: Vec<Addr>,
+        actors: Vec<AndrAddr>,
         permission: LocalPermission,
     },
     /// Removes actor alongisde his permission
-    RemoveActorPermission { actors: Vec<Addr> },
+    RemoveActorPermission { actors: Vec<AndrAddr> },
 }
 
 #[andr_query]

--- a/packages/andromeda-modules/src/address_list.rs
+++ b/packages/andromeda-modules/src/address_list.rs
@@ -12,7 +12,7 @@ pub struct InstantiateMsg {
 // Struct used to bundle actor and permission
 #[cw_serde]
 pub struct ActorPermission {
-    pub actor: Addr,
+    pub actors: Vec<Addr>,
     pub permission: LocalPermission,
 }
 
@@ -21,11 +21,11 @@ pub struct ActorPermission {
 pub enum ExecuteMsg {
     /// Adds an actor key and a permission value
     AddActorPermission {
-        actor: Addr,
+        actors: Vec<Addr>,
         permission: LocalPermission,
     },
     /// Removes actor alongisde his permission
-    RemoveActorPermission { actor: Addr },
+    RemoveActorPermission { actors: Vec<Addr> },
 }
 
 #[andr_query]


### PR DESCRIPTION
# Motivation
This brings the address list up to date with the following [PR](https://github.com/andromedaprotocol/andromeda-core/pull/548)

# Implementation
Users can now provide a vector of actors for an action, making permissioning more convenient. 
We loop through the actors, ensuring beforehand that the vector isn't empty.
The user provides `AndrAddr` for additional flexibility. 
Renamed `AddActorPermission ` to `PermissionActors `.
Renamed `RemoveActorPermission ` to `RemovePermissions `

# Testing
`test_add_remove_multiple_actors ` in address list's `tests` file. 

# Version Changes
`andromeda-address-list`: `2.0.1` -> `2.0.2`