### PR TITLE
fix: fixed claim rewards submessage handler

### DIFF
--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -4,8 +4,7 @@ use crate::{
 };
 use cosmwasm_std::{
     coin, ensure, entry_point, Addr, BankMsg, Binary, CosmosMsg, Deps, DepsMut, DistributionMsg,
-    Env, FullDelegation, MessageInfo, Reply, Response, StakingMsg, StdError, SubMsg, Timestamp,
-    Uint128,
+    Env, FullDelegation, MessageInfo, Reply, Response, StakingMsg, SubMsg, Timestamp, Uint128,
 };
 use cw2::set_contract_version;
 
@@ -82,10 +81,7 @@ pub fn handle_execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, 
     match msg {
         ExecuteMsg::Stake { validator } => execute_stake(ctx, validator),
         ExecuteMsg::Unstake { validator, amount } => execute_unstake(ctx, validator, amount),
-        ExecuteMsg::Claim {
-            validator,
-            recipient,
-        } => execute_claim(ctx, validator, recipient),
+        ExecuteMsg::Claim { validator } => execute_claim(ctx, validator),
         ExecuteMsg::WithdrawFunds { denom, recipient } => {
             execute_withdraw_fund(ctx, denom, recipient)
         }
@@ -213,11 +209,7 @@ fn execute_unstake(
     Ok(res)
 }
 
-fn execute_claim(
-    ctx: ExecuteContext,
-    validator: Option<Addr>,
-    recipient: Option<AndrAddr>,
-) -> Result<Response, ContractError> {
+fn execute_claim(ctx: ExecuteContext, validator: Option<Addr>) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
@@ -228,15 +220,9 @@ fn execute_claim(
     // Check if the validator is valid before unstaking
     is_validator(&deps, &validator)?;
 
-    let recipient_address = if let Some(ref recipient) = recipient {
-        recipient.get_raw_address(&deps.as_ref())?
-    } else {
-        info.sender
-    };
-
-    // Ensure recipient is the contract owner
+    // Ensure msg sender is the contract owner
     ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, recipient_address.as_str())?,
+        ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {}
     );
 
@@ -257,20 +243,11 @@ fn execute_claim(
         ContractError::InvalidClaim {}
     );
 
-    let set_withdraw_addr_msg = SubMsg::reply_on_error(
-        DistributionMsg::SetWithdrawAddress {
-            address: recipient_address.to_string(),
-        },
-        ReplyId::SetWithdrawAddress.repr(),
-    );
-
     let res = Response::new()
-        .add_submessage(set_withdraw_addr_msg)
         .add_message(DistributionMsg::WithdrawDelegatorReward {
             validator: validator.to_string(),
         })
         .add_attribute("action", "validator-claim-reward")
-        .add_attribute("recipient", recipient_address)
         .add_attribute("validator", validator.to_string());
 
     Ok(res)
@@ -353,14 +330,6 @@ fn query_unstaked_tokens(deps: Deps) -> Result<Vec<UnstakingTokens>, ContractErr
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
-    if msg.result.is_err() {
-        return match ReplyId::from_repr(msg.id) {
-            Some(ReplyId::SetWithdrawAddress) => Ok(Response::default()),
-            _ => Err(ContractError::Std(StdError::generic_err(
-                msg.result.unwrap_err(),
-            ))),
-        };
-    }
     match ReplyId::from_repr(msg.id) {
         Some(ReplyId::ValidatorUnstake) => on_validator_unstake(deps, msg),
         _ => Ok(Response::default()),

--- a/contracts/finance/andromeda-validator-staking/src/mock.rs
+++ b/contracts/finance/andromeda-validator-staking/src/mock.rs
@@ -42,9 +42,8 @@ impl MockValidatorStaking {
         app: &mut MockApp,
         sender: Addr,
         validator: Option<Addr>,
-        recipient: Option<AndrAddr>,
     ) -> ExecuteResult {
-        let msg = mock_execute_claim_reward(validator, recipient);
+        let msg = mock_execute_claim_reward(validator);
         self.execute(app, &msg, sender, &[])
     }
 
@@ -99,14 +98,8 @@ pub fn mock_execute_unstake(validator: Option<Addr>, amount: Option<Uint128>) ->
     ExecuteMsg::Unstake { validator, amount }
 }
 
-pub fn mock_execute_claim_reward(
-    validator: Option<Addr>,
-    recipient: Option<AndrAddr>,
-) -> ExecuteMsg {
-    ExecuteMsg::Claim {
-        validator,
-        recipient,
-    }
+pub fn mock_execute_claim_reward(validator: Option<Addr>) -> ExecuteMsg {
+    ExecuteMsg::Claim { validator }
 }
 
 pub fn mock_execute_withdraw_fund(

--- a/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
@@ -3,9 +3,7 @@ use crate::{
     testing::mock_querier::{mock_dependencies_custom, DEFAULT_VALIDATOR, VALID_VALIDATOR},
 };
 
-use andromeda_std::{
-    amp::AndrAddr, error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT,
-};
+use andromeda_std::{error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT};
 use cosmwasm_std::{
     coin,
     testing::{mock_env, mock_info},
@@ -15,6 +13,7 @@ use cosmwasm_std::{
 use andromeda_finance::validator_staking::{ExecuteMsg, InstantiateMsg};
 
 const OWNER: &str = "owner";
+const ANYONE: &str = "anyone";
 
 fn init(deps: DepsMut, default_validator: Addr) -> Result<Response, ContractError> {
     let msg = InstantiateMsg {
@@ -168,10 +167,9 @@ fn test_unauthorized_claim() {
 
     let msg = ExecuteMsg::Claim {
         validator: Some(valid_validator.clone()),
-        recipient: Some(AndrAddr::from_string("other")),
     };
 
-    let info = mock_info(OWNER, &[coin(100, "uandr")]);
+    let info = mock_info(ANYONE, &[coin(100, "uandr")]);
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
     assert_eq!(res, ContractError::Unauthorized {});
 }

--- a/ibc-tests/tests/validator_staking.rs
+++ b/ibc-tests/tests/validator_staking.rs
@@ -91,7 +91,6 @@ fn test_validator_staking() {
 
     let claim_msg = validator_staking::ExecuteMsg::Claim {
         validator: Some(Addr::unchecked(default_validator.address.to_string())),
-        recipient: None,
     };
     validator_staking_contract
         .execute(&claim_msg, None)
@@ -177,7 +176,6 @@ fn test_kicked_validator() {
 
     let claim_msg = validator_staking::ExecuteMsg::Claim {
         validator: Some(Addr::unchecked(kicked_validator.address.to_string())),
-        recipient: None,
     };
     validator_staking_contract
         .execute(&claim_msg, None)

--- a/ibc-tests/tests/validator_staking.rs
+++ b/ibc-tests/tests/validator_staking.rs
@@ -61,7 +61,7 @@ fn test_validator_staking() {
 
     let validator_staking_contract = ValidatorStakingContract::new(daemon.clone());
     validator_staking_contract.set_address(&Addr::unchecked(
-        "terra1vk603ncakghk33t8lklvpdq4aff03hwu2rak73f5zdayruead20qcwp0rf",
+        "terra18cv7jca4dnsu8vuhu2t7fkwl23dxres8kpnhggdarf7f0dh4j4ysv3qhd7",
     ));
 
     let staking_querier = Staking::new(&daemon);
@@ -89,15 +89,6 @@ fn test_validator_staking() {
         .query(&staking_query_msg)
         .unwrap();
 
-    let contract_balance = daemon
-        .balance(
-            validator_staking_contract.addr_str().unwrap(),
-            Some(denom.to_string()),
-        )
-        .unwrap()[0]
-        .amount;
-    assert_eq!(contract_balance, Uint128::zero());
-
     let claim_msg = validator_staking::ExecuteMsg::Claim {
         validator: Some(Addr::unchecked(default_validator.address.to_string())),
         recipient: None,
@@ -113,14 +104,6 @@ fn test_validator_staking() {
     validator_staking_contract
         .execute(&unstake_msg, None)
         .unwrap();
-    let contract_balance = daemon
-        .balance(
-            validator_staking_contract.addr_str().unwrap(),
-            Some(denom.to_string()),
-        )
-        .unwrap()[0]
-        .amount;
-    assert_eq!(contract_balance, Uint128::zero());
 
     daemon.wait_seconds(61).unwrap();
 
@@ -154,7 +137,7 @@ fn test_kicked_validator() {
 
     let validator_staking_contract = ValidatorStakingContract::new(daemon.clone());
     validator_staking_contract.set_address(&Addr::unchecked(
-        "terra1cvcm3yztqxdvnx26dyk2dk856nn4paggh84x7dkccy2hy0a0xnysd3pct0",
+        "terra18cv7jca4dnsu8vuhu2t7fkwl23dxres8kpnhggdarf7f0dh4j4ysv3qhd7",
     ));
 
     let staking_querier = Staking::new(&daemon);
@@ -207,14 +190,6 @@ fn test_kicked_validator() {
     validator_staking_contract
         .execute(&unstake_msg, None)
         .unwrap();
-    let contract_balance = daemon
-        .balance(
-            validator_staking_contract.addr_str().unwrap(),
-            Some(denom.to_string()),
-        )
-        .unwrap()[0]
-        .amount;
-    assert_eq!(contract_balance, Uint128::zero());
 
     daemon.wait_seconds(61).unwrap();
 

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -22,7 +22,6 @@ pub enum ExecuteMsg {
     },
     Claim {
         validator: Option<Addr>,
-        recipient: Option<AndrAddr>,
     },
     WithdrawFunds {
         denom: Option<String>,

--- a/tests-integration/tests/validator_staking.rs
+++ b/tests-integration/tests/validator_staking.rs
@@ -3,7 +3,6 @@
 use andromeda_app::app::AppComponent;
 use andromeda_app_contract::mock::{mock_andromeda_app, MockAppContract};
 
-use andromeda_std::amp::AndrAddr;
 use andromeda_testing::mock::mock_app;
 use andromeda_testing::mock_builder::MockAndromedaBuilder;
 use andromeda_validator_staking::mock::{
@@ -28,7 +27,6 @@ fn test_validator_stake() {
         ])
         .build(&mut router);
     let owner = andr.get_wallet("owner");
-    let recipient = AndrAddr::from_string(owner.to_string());
     let validator_1 = router.api().addr_make("validator1");
 
     let validator_staking_init_msg = mock_validator_staking_instantiate_msg(
@@ -75,7 +73,6 @@ fn test_validator_stake() {
             &mut router,
             owner.clone(),
             Some(validator_1.clone()),
-            Some(recipient.clone()),
         )
         .unwrap_err();
     // assert_eq!(may_err.unwrap(), &expected_err);
@@ -96,7 +93,6 @@ fn test_validator_stake() {
             &mut router,
             owner.clone(),
             Some(validator_1.clone()),
-            Some(AndrAddr::from_string("some_address")),
         )
         .unwrap_err();
     // let _err = err.root_cause().downcast_ref::<ContractError>().unwrap();
@@ -108,7 +104,6 @@ fn test_validator_stake() {
             &mut router,
             owner.clone(),
             Some(validator_1),
-            Some(recipient),
         )
         .unwrap();
 
@@ -206,7 +201,6 @@ fn test_validator_stake_and_unstake_specific_amount() {
         ])
         .build(&mut router);
     let owner = andr.get_wallet("owner");
-    let recipient = AndrAddr::from_string(owner.to_string());
     let validator_1 = router.api().addr_make("validator1");
 
     let validator_staking_init_msg = mock_validator_staking_instantiate_msg(
@@ -252,7 +246,6 @@ fn test_validator_stake_and_unstake_specific_amount() {
             &mut router,
             owner.clone(),
             Some(validator_1.clone()),
-            Some(recipient.clone()),
         )
         .unwrap_err();
     // assert_eq!(may_err.unwrap(), &expected_err);
@@ -273,7 +266,6 @@ fn test_validator_stake_and_unstake_specific_amount() {
             &mut router,
             owner.clone(),
             Some(validator_1.clone()),
-            Some(AndrAddr::from_string("some_address")),
         )
         .unwrap_err();
 
@@ -282,7 +274,6 @@ fn test_validator_stake_and_unstake_specific_amount() {
             &mut router,
             owner.clone(),
             Some(validator_1),
-            Some(recipient),
         )
         .unwrap();
 

--- a/tests-integration/tests/validator_staking.rs
+++ b/tests-integration/tests/validator_staking.rs
@@ -69,11 +69,7 @@ fn test_validator_stake() {
     // Testing when there is no reward to claim
     // TODO: These errors cant be downcast anymore?
     let _err = validator_staking
-        .execute_claim_reward(
-            &mut router,
-            owner.clone(),
-            Some(validator_1.clone()),
-        )
+        .execute_claim_reward(&mut router, owner.clone(), Some(validator_1.clone()))
         .unwrap_err();
     // assert_eq!(may_err.unwrap(), &expected_err);
 
@@ -88,16 +84,15 @@ fn test_validator_stake() {
     });
 
     validator_staking
-        .execute_claim_reward(
-            &mut router,
-            owner.clone(),
-            Some(validator_1),
-        )
+        .execute_claim_reward(&mut router, owner.clone(), Some(validator_1))
         .unwrap();
 
     // Default APR 10% by cw-multi-test -> StakingInfo
     // should now have 1000 * 10% / 2 - 0% commission = 50 tokens reward
-    let contract_balance = router.wrap().query_balance(validator_staking.addr(), "TOKEN").unwrap();
+    let contract_balance = router
+        .wrap()
+        .query_balance(validator_staking.addr(), "TOKEN")
+        .unwrap();
     assert_eq!(contract_balance, coin(50, "TOKEN"));
 
     // Test unstake with invalid validator
@@ -142,7 +137,6 @@ fn test_validator_stake() {
             msg: "Querier contract error: InvalidDelegation".to_string()
         })
     );
-
 
     let unstaked_tokens = validator_staking.query_unstaked_tokens(&router).unwrap();
     let unbonding_period =
@@ -221,11 +215,7 @@ fn test_validator_stake_and_unstake_specific_amount() {
 
     // Testing when there is no reward to claim
     let _err = validator_staking
-        .execute_claim_reward(
-            &mut router,
-            owner.clone(),
-            Some(validator_1.clone()),
-        )
+        .execute_claim_reward(&mut router, owner.clone(), Some(validator_1.clone()))
         .unwrap_err();
     // assert_eq!(may_err.unwrap(), &expected_err);
 
@@ -240,16 +230,15 @@ fn test_validator_stake_and_unstake_specific_amount() {
     });
 
     validator_staking
-        .execute_claim_reward(
-            &mut router,
-            owner.clone(),
-            Some(validator_1),
-        )
+        .execute_claim_reward(&mut router, owner.clone(), Some(validator_1))
         .unwrap();
 
     // Default APR 10% by cw-multi-test -> StakingInfo
     // should now have 1000 * 10% / 2 - 0% commission = 50 tokens reward
-    let contract_balance = router.wrap().query_balance(validator_staking.addr(), "TOKEN").unwrap();
+    let contract_balance = router
+        .wrap()
+        .query_balance(validator_staking.addr(), "TOKEN")
+        .unwrap();
     assert_eq!(contract_balance, coin(50, "TOKEN"));
 
     // Test unstake with invalid validator

--- a/tests-integration/tests/validator_staking.rs
+++ b/tests-integration/tests/validator_staking.rs
@@ -87,18 +87,6 @@ fn test_validator_stake() {
         chain_id: router.block_info().chain_id,
     });
 
-    // only owner can become a recipient
-    let _err = validator_staking
-        .execute_claim_reward(
-            &mut router,
-            owner.clone(),
-            Some(validator_1.clone()),
-        )
-        .unwrap_err();
-    // let _err = err.root_cause().downcast_ref::<ContractError>().unwrap();
-    // let expected_err = ContractError::Unauthorized {};
-    // assert_eq!(err, &expected_err);
-
     validator_staking
         .execute_claim_reward(
             &mut router,
@@ -109,8 +97,8 @@ fn test_validator_stake() {
 
     // Default APR 10% by cw-multi-test -> StakingInfo
     // should now have 1000 * 10% / 2 - 0% commission = 50 tokens reward
-    let owner_balance = router.wrap().query_balance(owner.clone(), "TOKEN").unwrap();
-    assert_eq!(owner_balance, coin(50, "TOKEN"));
+    let contract_balance = router.wrap().query_balance(validator_staking.addr(), "TOKEN").unwrap();
+    assert_eq!(contract_balance, coin(50, "TOKEN"));
 
     // Test unstake with invalid validator
     let _err = validator_staking
@@ -155,15 +143,6 @@ fn test_validator_stake() {
         })
     );
 
-    // Test withdraw before payout period
-    let _err = validator_staking
-        .execute_withdraw_fund(&mut router, owner.clone())
-        .unwrap_err();
-    // let _err = err.root_cause().downcast_ref::<ContractError>().unwrap();
-    // let expected_err = ContractError::InvalidWithdrawal {
-    //     msg: Some("No unstaked funds to withdraw".to_string()),
-    // };
-    // assert_eq!(err, &expected_err);
 
     let unstaked_tokens = validator_staking.query_unstaked_tokens(&router).unwrap();
     let unbonding_period =
@@ -260,15 +239,6 @@ fn test_validator_stake_and_unstake_specific_amount() {
         chain_id: router.block_info().chain_id,
     });
 
-    // only owner can become a recipient
-    let _err = validator_staking
-        .execute_claim_reward(
-            &mut router,
-            owner.clone(),
-            Some(validator_1.clone()),
-        )
-        .unwrap_err();
-
     validator_staking
         .execute_claim_reward(
             &mut router,
@@ -279,8 +249,8 @@ fn test_validator_stake_and_unstake_specific_amount() {
 
     // Default APR 10% by cw-multi-test -> StakingInfo
     // should now have 1000 * 10% / 2 - 0% commission = 50 tokens reward
-    let owner_balance = router.wrap().query_balance(owner.clone(), "TOKEN").unwrap();
-    assert_eq!(owner_balance, coin(50, "TOKEN"));
+    let contract_balance = router.wrap().query_balance(validator_staking.addr(), "TOKEN").unwrap();
+    assert_eq!(contract_balance, coin(50, "TOKEN"));
 
     // Test unstake with invalid validator
     let _err = validator_staking
@@ -332,14 +302,10 @@ fn test_validator_stake_and_unstake_specific_amount() {
         }
     );
 
-    // Test withdraw before payout period
-    let _err = validator_staking
-        .execute_withdraw_fund(&mut router, owner.clone())
-        .unwrap_err();
-
     let unstaked_tokens = validator_staking.query_unstaked_tokens(&router).unwrap();
     let unbonding_period =
         unstaked_tokens[0].payout_at.seconds() - router.block_info().time.seconds();
+
     // Update block to payout period
     router.set_block(BlockInfo {
         height: router.block_info().height,


### PR DESCRIPTION
# Motivation

Resolves https://github.com/sherlock-audit/2024-05-andromeda-ado-judging/issues/43

# Implementation
- Updated `execute_claim`  function to use `DistributionMsg::SetWithdrawAddress` as a submessage (originally using message)
- Updated `reply` function to ignore error related to `SetWithdrawAddress` reply.

# Testing
- Updated e2e test to assert contract balance has no frozen fund after withdrawing fund.