### PR TITLE
feat: ADODB prerelease tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make Action Names in CW721 Conform to Standard [(#545)](https://github.com/andromedaprotocol/andromeda-core/pull/545)
 - Timelock ADO: Replace MillisecondsExpiration with Expiry [(#550)](https://github.com/andromedaprotocol/andromeda-core/pull/550)
 - Address List: Support for multiple actors while adding and removing permissions [(#556)](https://github.com/andromedaprotocol/andromeda-core/pull/556)
+- ADODB now supports pre-release tagging [(#560)](https://github.com/andromedaprotocol/andromeda-core/pull/560)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-adodb"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/contracts/os/andromeda-adodb/Cargo.toml
+++ b/contracts/os/andromeda-adodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-adodb"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-adodb/src/state.rs
+++ b/contracts/os/andromeda-adodb/src/state.rs
@@ -33,13 +33,17 @@ pub fn store_code_id(
     ADO_TYPE
         .save(storage, &code_id.to_string(), ado_version)
         .unwrap();
-    LATEST_VERSION
-        .save(
-            storage,
-            &ado_version.get_type(),
-            &(ado_version.get_version(), code_id),
-        )
-        .unwrap();
+    let version = semver::Version::parse(&ado_version.get_version()).unwrap();
+    let prerelease = version.pre.parse::<String>().unwrap_or_default();
+    if prerelease.is_empty() {
+        LATEST_VERSION
+            .save(
+                storage,
+                &ado_version.get_type(),
+                &(ado_version.get_version(), code_id),
+            )
+            .unwrap();
+    }
     CODE_ID
         .save(storage, ado_version.as_str(), &code_id)
         .unwrap();

--- a/contracts/os/andromeda-adodb/src/state.rs
+++ b/contracts/os/andromeda-adodb/src/state.rs
@@ -33,7 +33,9 @@ pub fn store_code_id(
     ADO_TYPE
         .save(storage, &code_id.to_string(), ado_version)
         .unwrap();
-    let version = semver::Version::parse(&ado_version.get_version()).unwrap();
+    let version = semver::Version::parse(&ado_version.get_version())
+        .ok()
+        .ok_or(ContractError::InvalidADOVersion { msg: None })?;
     let prerelease = version.pre.parse::<String>().unwrap_or_default();
     if prerelease.is_empty() {
         LATEST_VERSION

--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -152,7 +152,7 @@ fn test_publish() {
     }
 
     // Test prelease
-    let ado_version = ADOVersion::from_type("ado_type_with_beta").with_version("0.1.0-beta.1");
+    let ado_version = ADOVersion::from_type("ado_type_with_beta").with_version("0.1.0-");
     let code_id = 3;
     let msg = ExecuteMsg::Publish {
         ado_type: ado_version.get_type(),
@@ -165,7 +165,6 @@ fn test_publish() {
     let resp = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
     assert!(resp.is_ok());
 
-    // assert!(resp.is_ok());
     let publisher = PUBLISHER
         .load(deps.as_ref().storage, ado_version.as_str())
         .unwrap();

--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -152,7 +152,7 @@ fn test_publish() {
     }
 
     // Test prelease
-    let ado_version = ADOVersion::from_type("ado_type_with_beta").with_version("0.1.0-");
+    let ado_version = ADOVersion::from_type("ado_type_with_beta").with_version("0.1.0-beta.1");
     let code_id = 3;
     let msg = ExecuteMsg::Publish {
         ado_type: ado_version.get_type(),

--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -121,7 +121,7 @@ fn test_publish() {
         publisher: Some(owner.clone()),
     };
 
-    let resp = execute(deps.as_mut(), env.clone(), info, msg.clone());
+    let resp = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
 
     assert!(resp.is_ok());
     let publisher = PUBLISHER
@@ -151,9 +151,39 @@ fn test_publish() {
         assert_eq!(fee, action_fee);
     }
 
+    // Test prelease
+    let ado_version = ADOVersion::from_type("ado_type_with_beta").with_version("0.1.0-beta.1");
+    let code_id = 3;
+    let msg = ExecuteMsg::Publish {
+        ado_type: ado_version.get_type(),
+        version: ado_version.get_version(),
+        code_id,
+        action_fees: None,
+        publisher: None,
+    };
+
+    let resp = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
+    assert!(resp.is_ok());
+
+    // assert!(resp.is_ok());
+    let publisher = PUBLISHER
+        .load(deps.as_ref().storage, ado_version.as_str())
+        .unwrap();
+    assert_eq!(publisher, owner);
+
+    let code_id = CODE_ID
+        .load(deps.as_ref().storage, ado_version.as_str())
+        .unwrap();
+    assert_eq!(code_id, 3u64);
+
+    let vers_code_id = LATEST_VERSION
+        .may_load(deps.as_ref().storage, &ado_version.get_type())
+        .unwrap();
+    assert!(vers_code_id.is_none());
+
     // Test unauthorised
     let unauth_info = mock_info("not_owner", &[]);
-    let resp = execute(deps.as_mut(), env, unauth_info, msg);
+    let resp = execute(deps.as_mut(), env.clone(), unauth_info, msg);
     assert!(resp.is_err());
 }
 


### PR DESCRIPTION
# Motivation
These changes add the ability to publish a prerelease tagged ADO version without having it set as the "latest" version.

# Implementation
Added a check for `LATEST_VERSION` that no pre-release tag is set.

# Testing

An appropriate test was added for publishing.

# Version Changes

`adodb`: `1.1.1` -> `1.1.2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the package version for Andromeda ADODB to 1.1.2, indicating potential new features or improvements.
	- Added support for pre-release tagging in the ADODB, allowing better version management.

- **Bug Fixes**
	- Improved logic in version storage to ensure that the latest version is only saved when it lacks a pre-release tag, enhancing version handling reliability.
	- Enhanced test coverage for the publishing functionality, including validation for beta version publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->