### PR TITLE
fix: fixed get_tiers operation in crowdfund state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Splitter and Conditional Splitter: fix lock time calculation [(#547)](https://github.com/andromedaprotocol/andromeda-core/pull/547)
 - AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
 - Fix permissioning limited use consumptions and blacklist bypass scenario [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
+- Crowdfund: fixed error related to `QueryMsg::Tiers` message handler [(#563)](https://github.com/andromedaprotocol/andromeda-core/pull/563)
 
 ### Removed
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
@@ -3,7 +3,7 @@
 use crate::contract::{execute, instantiate, query, reply};
 use andromeda_non_fungible_tokens::crowdfund::{
     CampaignConfig, CampaignSummaryResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg,
-    PresaleTierOrder, QueryMsg, SimpleTierOrder, Tier, TierMetaData,
+    PresaleTierOrder, QueryMsg, SimpleTierOrder, Tier, TierMetaData, TiersResponse,
 };
 use andromeda_std::common::Milliseconds;
 use andromeda_testing::{
@@ -98,9 +98,13 @@ impl MockCrowdfund {
         let msg = QueryMsg::CampaignSummary {};
         self.query(app, msg)
     }
-    
+
     pub fn query_tiers(&self, app: &mut MockApp) -> TiersResponse {
-        let msg = QueryMsg::Tiers {start_after: None, limit: None, order_by: None};
+        let msg = QueryMsg::Tiers {
+            start_after: None,
+            limit: None,
+            order_by: None,
+        };
         self.query(app, msg)
     }
 }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
@@ -98,6 +98,11 @@ impl MockCrowdfund {
         let msg = QueryMsg::CampaignSummary {};
         self.query(app, msg)
     }
+    
+    pub fn query_tiers(&self, app: &mut MockApp) -> TiersResponse {
+        let msg = QueryMsg::Tiers {start_after: None, limit: None, order_by: None};
+        self.query(app, msg)
+    }
 }
 
 pub fn mock_andromeda_crowdfund() -> Box<dyn Contract<Empty>> {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -216,13 +216,12 @@ pub(crate) fn set_tier_orders(
         let mut sold_amount = TIER_SALES
             .load(storage, new_order.level.into())
             .unwrap_or_default();
+        sold_amount = sold_amount.checked_add(new_order.amount)?;
         if let Some(limit) = tier.limit {
-            sold_amount = sold_amount.checked_add(new_order.amount)?;
-            ensure!(limit >= sold_amount, ContractError::PurchaseLimitReached {});
-
-            update_tier(storage, &tier)?;
-            set_tier_sales(storage, new_order.level.into(), sold_amount)?;
+            ensure!(limit > sold_amount, ContractError::PurchaseLimitReached {});
         }
+        update_tier(storage, &tier)?;
+        set_tier_sales(storage, new_order.level.into(), sold_amount)?;
 
         let mut order = TIER_ORDERS
             .load(storage, (new_order.orderer.clone(), new_order.level.into()))

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -175,7 +175,7 @@ pub(crate) fn get_tiers(
         .take(limit)
         .map(|v| {
             let (level, tier) = v?;
-            let sold_amount = TIER_SALES.load(storage, level)?;
+            let sold_amount = TIER_SALES.load(storage, level).unwrap_or_default();
             Ok(TierResponseItem { tier, sold_amount })
         })
         .collect()

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -272,6 +272,9 @@ fn test_successful_crowdfund_app_native(setup: TestCase) {
     assert_eq!(summary.current_capital, 0);
     assert_eq!(summary.current_stage, CampaignStage::ONGOING.to_string());
 
+    let tiers = crowdfund.query_tiers(&mut router).tiers;
+    assert_eq!(tiers.len(), 2);
+
     // Purchase tiers
     router.set_block(BlockInfo {
         height: router.block_info().height,
@@ -327,9 +330,6 @@ fn test_successful_crowdfund_app_native(setup: TestCase) {
     let _ = crowdfund
         .execute_claim(buyer_one.clone(), &mut router)
         .unwrap();
-
-    let tiers = crowdfund.query_tiers(&mut router).unwrap().tiers;
-    assert_eq!(tiers.len(), 2);
 
     // buyer_one should own 30 tiers now (10 pre order + 20 purchased)
     let owner_resp = cw721.query_owner_of(&router, "0".to_string());
@@ -652,6 +652,9 @@ fn test_successful_crowdfund_app_cw20(#[with(false)] setup: TestCase) {
     let summary = crowdfund.query_campaign_summary(&mut router);
     assert_eq!(summary.current_capital, 0);
     assert_eq!(summary.current_stage, CampaignStage::ONGOING.to_string());
+
+    let tiers = crowdfund.query_tiers(&mut router).tiers;
+    assert_eq!(tiers.len(), 2);
 
     // Purchase tiers
     router.set_block(BlockInfo {

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -327,6 +327,10 @@ fn test_successful_crowdfund_app_native(setup: TestCase) {
     let _ = crowdfund
         .execute_claim(buyer_one.clone(), &mut router)
         .unwrap();
+
+    let tiers = crowdfund.query_tiers(&mut router).unwrap().tiers;
+    assert_eq!(tiers.len(), 2);
+
     // buyer_one should own 30 tiers now (10 pre order + 20 purchased)
     let owner_resp = cw721.query_owner_of(&router, "0".to_string());
     assert_eq!(owner_resp, buyer_one.to_string());


### PR DESCRIPTION
# Motivation

Resolves https://github.com/andromedaprotocol/andromeda-core/issues/562

# Implementation

`get_tiers` function in `state` was iterating over tiers to calculate sold amount. For unsold tiers, it was throwing error.
Updated the sold amount calculation logic to use default value in case no tier is sold.

```diff
-          let sold_amount = TIER_SALES.load(storage, level)?;
+          let sold_amount = TIER_SALES.load(storage, level).unwrap_or_default();
```

# Testing
Updated `test_successful_crowdfund_app_native` and `test_successful_crowdfund_app_cw20` to query tiers.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to query tiers in the crowdfund application, enhancing user access to tier information.
  
- **Bug Fixes**
	- Improved error handling in the tier retrieval process, ensuring that the application continues to function smoothly even if errors occur.

- **Tests**
	- Added assertions in the test suite to validate the correctness of tier queries after a claim, increasing test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->