### PR TITLE
fix: remove unnecessary limited permission usage in strict call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-boolean"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-counter"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cross-chain-swap"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-exchange"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-staking"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-date-time"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-lockdrop"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-marketplace"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-merkle-airdrop"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-primitive"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rates"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-set-amount-splitter"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-shunting"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-string-storage"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "async-recursion"
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.20"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1424,14 +1424,14 @@ dependencies = [
 
 [[package]]
 name = "cw-json"
-version = "0.1.1"
-source = "git+https://github.com/SlayerAnsh/cw-json.git#1a3ef8005bafdd30571dc4546ca52400e45fda8a"
+version = "0.1.0"
+source = "git+https://github.com/SlayerAnsh/cw-json.git#9c815f222f8caa43e6e9775249c76f59837c6bbf"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "serde",
  "serde-cw-value",
- "thiserror",
+ "serde-json-wasm 1.0.1",
 ]
 
 [[package]]
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3746,9 +3746,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -3791,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3813,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -4682,15 +4682,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/data-storage/andromeda-boolean/Cargo.toml
+++ b/contracts/data-storage/andromeda-boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-boolean"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-counter/Cargo.toml
+++ b/contracts/data-storage/andromeda-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-counter"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-primitive"
-version = "2.0.2"
+version = "2.0.3"
 authors = [
   "Connor Barr <crnbarr@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/data-storage/andromeda-string-storage/Cargo.toml
+++ b/contracts/data-storage/andromeda-string-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-string-storage"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
+++ b/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cross-chain-swap"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-set-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-set-amount-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-set-amount-splitter"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-exchange"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-staking"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-lockdrop"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-merkle-airdrop"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-date-time/Cargo.toml
+++ b/contracts/modules/andromeda-date-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-date-time"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rates"
-version = "2.0.1"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-shunting/Cargo.toml
+++ b/contracts/modules/andromeda-shunting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-shunting"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]

--- a/contracts/modules/andromeda-shunting/src/contract.rs
+++ b/contracts/modules/andromeda-shunting/src/contract.rs
@@ -158,12 +158,8 @@ fn parse_params(deps: Deps, params: Vec<EvaluateParam>) -> Result<Vec<String>, C
                 .into();
 
                 let raw_result: Value = deps.querier.query::<Value>(&query_msg)?;
-                let json = JSON::try_from(raw_result).map_err(|err| {
-                    ContractError::Std(StdError::GenericErr {
-                        msg: format!("{:?}", err),
-                    })
-                })?;
-                let Some(Value::String(val)) = json.get(&accessor).unwrap() else {
+                let json = JSON::from(raw_result);
+                let Value::String(val) = json.get(&accessor).unwrap() else {
                     return Err(ContractError::InvalidExpression {
                         msg: format!("Invalid Accessor {}", accessor),
                     });

--- a/contracts/modules/andromeda-shunting/src/contract.rs
+++ b/contracts/modules/andromeda-shunting/src/contract.rs
@@ -10,8 +10,7 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_std::{
-    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
-    WasmQuery,
+    attr, ensure, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, WasmQuery,
 };
 use cw2::set_contract_version;
 use cw_utils::nonpayable;

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-marketplace"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -518,13 +518,16 @@ pub fn is_context_permissioned_strict(
                 action.clone(),
                 amp_ctx.ctx.get_origin().as_str(),
             );
+            if is_origin_permissioned.is_ok() {
+                return Ok(true);
+            }
             let is_previous_sender_permissioned = contract.is_permissioned_strict(
                 deps.branch(),
                 env.clone(),
                 action,
                 amp_ctx.ctx.get_previous_sender().as_str(),
             );
-            Ok(is_origin_permissioned.is_ok() || is_previous_sender_permissioned.is_ok())
+            Ok(is_previous_sender_permissioned.is_ok())
         }
         None => Ok(contract
             .is_permissioned_strict(deps.branch(), env.clone(), action, info.sender.to_string())


### PR DESCRIPTION
# Motivation
Checking permissioning for a strict case was consuming a limited use for both origin and previous sender. These changes fix that in the same fashion as non-strict calls.

# Version Changes

Bumped all ADO versions by patch



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Version updates for multiple packages to enhance compatibility and performance.
  
- **Bug Fixes**
	- Improved JSON parsing and error handling in the `andromeda-shunting` module.

- **Documentation**
	- Updated version numbers across various packages for clarity and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->