### PR TITLE
ref: IBC Registry Denom Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "semver",
  "serde",
  "serde-json-wasm 0.5.2",
+ "sha2 0.10.8",
  "strum_macros",
  "thiserror",
 ]

--- a/contracts/os/andromeda-ibc-registry/src/contract.rs
+++ b/contracts/os/andromeda-ibc-registry/src/contract.rs
@@ -125,7 +125,7 @@ pub fn execute_store_denom_info(
     let mut seen_denoms = HashSet::new(); // To track unique denoms
     for info in ibc_denom_info {
         let denom = info.denom.to_lowercase();
-        verify_denom(&denom)?;
+        verify_denom(&denom, &info.denom_info)?;
 
         // Check for duplicates
         if !seen_denoms.insert(denom.clone()) {

--- a/contracts/os/andromeda-ibc-registry/src/contract.rs
+++ b/contracts/os/andromeda-ibc-registry/src/contract.rs
@@ -124,7 +124,7 @@ pub fn execute_store_denom_info(
 
     let mut seen_denoms = HashSet::new(); // To track unique denoms
     for info in ibc_denom_info {
-        let denom = info.denom.to_lowercase();
+        let denom = info.denom;
         verify_denom(&denom, &info.denom_info)?;
 
         // Check for duplicates

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -36,6 +36,7 @@ strum_macros = { workspace = true }
 cw721 = { workspace = true }
 serde-json-wasm = "0.5.0"
 enum-repr = { workspace = true }
+sha2 = "0.10.8"
 
 [dev-dependencies]
 cw-multi-test = { version = "1.0.0" }

--- a/packages/std/src/os/ibc_registry.rs
+++ b/packages/std/src/os/ibc_registry.rs
@@ -1,11 +1,11 @@
-use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Addr};
-use strum_macros::AsRefStr;
-
 use crate::{
     amp::{messages::AMPPkt, AndrAddr},
     error::ContractError,
 };
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{ensure, Addr};
+use sha2::{Digest, Sha256};
+use strum_macros::AsRefStr;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -17,6 +17,17 @@ pub struct InstantiateMsg {
 pub struct DenomInfo {
     pub path: String,
     pub base_denom: String,
+}
+impl DenomInfo {
+    pub fn get_ibc_denom(&self) -> String {
+        // Concatenate the path and base with "/"
+        let input = format!("{}/{}", self.path, self.base_denom);
+
+        // Hash the concatenated string using SHA-256
+        let hash = Sha256::digest(input.as_bytes());
+        // Return the result in the format "ibc/<SHA-256 hash in hex>"
+        format!("ibc/{:X}", hash)
+    }
 }
 #[cw_serde]
 pub struct IBCDenomInfo {
@@ -36,7 +47,7 @@ pub enum ExecuteMsg {
 }
 
 /// Ensures that the denom starts with 'ibc/'
-pub fn verify_denom(denom: &str) -> Result<(), ContractError> {
+pub fn verify_denom(denom: &str, denom_info: &DenomInfo) -> Result<(), ContractError> {
     // Ensure that the denom is formatted correctly. It should start with "ibc/"
     ensure!(
         denom.starts_with("ibc/"),
@@ -52,6 +63,13 @@ pub fn verify_denom(denom: &str) -> Result<(), ContractError> {
             msg: Some("The denom must have exactly 64 characters after 'ibc/'".to_string()),
         });
     }
+    // Ensure that the hash and base match the provided denom
+    let hashed_denom = denom_info.get_ibc_denom();
+    ensure!(
+        denom == hashed_denom,
+        ContractError::InvalidDenom { msg: None }
+    );
+
     Ok(())
 }
 
@@ -82,7 +100,11 @@ pub struct AllDenomInfoResponse {
 fn test_validate_denom() {
     // Empty denom
     let empty_denom = "".to_string();
-    let err = verify_denom(&empty_denom).unwrap_err();
+    let default_denom_info = DenomInfo {
+        path: "path".to_string(),
+        base_denom: "base_denom".to_string(),
+    };
+    let err = verify_denom(&empty_denom, &default_denom_info).unwrap_err();
     assert_eq!(
         err,
         ContractError::InvalidDenom {
@@ -91,7 +113,7 @@ fn test_validate_denom() {
     );
     // Denom that doesn't start with ibc/
     let invalid_denom = "random".to_string();
-    let err = verify_denom(&invalid_denom).unwrap_err();
+    let err = verify_denom(&invalid_denom, &default_denom_info).unwrap_err();
     assert_eq!(
         err,
         ContractError::InvalidDenom {
@@ -100,7 +122,7 @@ fn test_validate_denom() {
     );
     // Denom that's just ibc/
     let empty_ibc_denom = "ibc/".to_string();
-    let err = verify_denom(&empty_ibc_denom).unwrap_err();
+    let err = verify_denom(&empty_ibc_denom, &default_denom_info).unwrap_err();
     assert_eq!(
         err,
         ContractError::InvalidDenom {
@@ -111,5 +133,5 @@ fn test_validate_denom() {
     // Valid denom
     let valid_denom =
         "ibc/usdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdc".to_string();
-    verify_denom(&valid_denom).unwrap()
+    verify_denom(&valid_denom, &default_denom_info).unwrap()
 }

--- a/packages/std/src/os/ibc_registry.rs
+++ b/packages/std/src/os/ibc_registry.rs
@@ -35,7 +35,7 @@ impl DenomInfo {
         // Hash the concatenated string using SHA-256
         let hash = Sha256::digest(input.as_bytes());
         // Return the result in the format "ibc/<SHA-256 hash in hex>"
-        format!("ibc/{:X}", hash)
+        format!("ibc/{:X}", hash).to_lowercase()
     }
 }
 #[cw_serde]

--- a/packages/std/src/os/ibc_registry.rs
+++ b/packages/std/src/os/ibc_registry.rs
@@ -20,8 +20,17 @@ pub struct DenomInfo {
 }
 impl DenomInfo {
     pub fn get_ibc_denom(&self) -> String {
+        // Lowercase Denom Info
+        let lower_case_denom_info = DenomInfo {
+            path: self.path.to_lowercase(),
+            base_denom: self.base_denom.to_lowercase(),
+        };
+
         // Concatenate the path and base with "/"
-        let input = format!("{}/{}", self.path, self.base_denom);
+        let input = format!(
+            "{}/{}",
+            lower_case_denom_info.path, lower_case_denom_info.base_denom
+        );
 
         // Hash the concatenated string using SHA-256
         let hash = Sha256::digest(input.as_bytes());
@@ -130,8 +139,6 @@ fn test_validate_denom() {
         }
     );
 
-    // Valid denom
-    let valid_denom =
-        "ibc/usdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdc".to_string();
+    let valid_denom = default_denom_info.get_ibc_denom();
     verify_denom(&valid_denom, &default_denom_info).unwrap()
 }

--- a/tests-integration/tests/ibc_registry.rs
+++ b/tests-integration/tests/ibc_registry.rs
@@ -95,6 +95,16 @@ fn test_ibc_registry() {
         }
     );
 
+    // Test real data
+    let path = "transfer/channel-12/transfer/channel-255".to_string();
+    let base_denom = "inj".to_string();
+
+    let denom_info = DenomInfo { path, base_denom };
+    assert_eq!(
+        denom_info.get_ibc_denom(),
+        "ibc/eab02686416e4b155cfee9c247171e1c4196b218c6a254f765b0958b3af59d09".to_string()
+    );
+
     // Test authorization
     let ibc_denom_info = IBCDenomInfo {
         denom: "ibc/usdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdt".to_string(),

--- a/tests-integration/tests/ibc_registry.rs
+++ b/tests-integration/tests/ibc_registry.rs
@@ -29,13 +29,14 @@ fn test_ibc_registry() {
     let ibc_registry: MockIbcRegistry = andr.ibc_registry;
 
     // Test Store Denom Info
-
+    let denom_info = DenomInfo {
+        path: "path".to_string(),
+        base_denom: "base_denom".to_string(),
+    };
+    let denom = denom_info.get_ibc_denom();
     let ibc_denom_info = IBCDenomInfo {
-        denom: "ibc/andrandrandrandrandrandrandrandrandrandrandrandrandrandrandrandr".to_string(),
-        denom_info: DenomInfo {
-            path: "path".to_string(),
-            base_denom: "base_denom".to_string(),
-        },
+        denom: denom.clone(),
+        denom_info,
     };
     ibc_registry
         .execute_execute_store_denom_info(
@@ -46,10 +47,7 @@ fn test_ibc_registry() {
         )
         .unwrap();
 
-    let query_res = ibc_registry.query_denom_info(
-        &mut router,
-        "ibc/andrandrandrandrandrandrandrandrandrandrandrandrandrandrandrandr".to_string(),
-    );
+    let query_res = ibc_registry.query_denom_info(&mut router, denom);
     assert_eq!(
         query_res,
         DenomInfoResponse {
@@ -61,12 +59,14 @@ fn test_ibc_registry() {
     );
 
     // Store one more denom
+    let denom_info = DenomInfo {
+        path: "path2".to_string(),
+        base_denom: "base_denom2".to_string(),
+    };
+    let denom = denom_info.get_ibc_denom();
     let ibc_denom_info = IBCDenomInfo {
-        denom: "ibc/usdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdcusdc".to_string(),
-        denom_info: DenomInfo {
-            path: "path2".to_string(),
-            base_denom: "base_denom2".to_string(),
-        },
+        denom: denom.clone(),
+        denom_info,
     };
     ibc_registry
         .execute_execute_store_denom_info(


### PR DESCRIPTION
# Motivation
These changes are supposed to make the process of adding denoms to IBC registry permissionless. 

# Implementation
The provided denom should be the same as the following function's resulting `String`:
```rust
// Lowercase Denom Info
        let lower_case_denom_info = DenomInfo {
            path: self.path.to_lowercase(),
            base_denom: self.base_denom.to_lowercase(),
        };

        // Concatenate the path and base with "/"
        let input = format!(
            "{}/{}",
            lower_case_denom_info.path, lower_case_denom_info.base_denom
        );

        // Hash the concatenated string using SHA-256
        let hash = Sha256::digest(input.as_bytes());
        // Return the result in the format "ibc/<SHA-256 hash in hex>"
        format!("ibc/{:X}", hash)
```
# Testing
Unit test

# Version Changes
No change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced denomination verification process to include additional contextual data.
	- Introduced a new method to generate IBC denomination strings using SHA-256 hashing.
- **Bug Fixes**
	- Updated verification logic for denominations to improve robustness and accuracy.
- **Chores**
	- Added a new dependency for SHA-2 hashing functionality to the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->