### PR TITLE
Fix Case Sensitive Erros, Bump ibc registry ado and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Authorized CW721 Addresses to Marketplace [(#542)](https://github.com/andromedaprotocol/andromeda-core/pull/542)
 - Added BuyNow option for Auction [(#533)](https://github.com/andromedaprotocol/andromeda-core/pull/533)
 - Added IBC Registry ADO [(#566)](https://github.com/andromedaprotocol/andromeda-core/pull/566)
+- Added Denom Validation in IBC Registry ADO [(#571)](https://github.com/andromedaprotocol/andromeda-core/pull/571)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-ibc-registry"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",

--- a/contracts/os/andromeda-ibc-registry/Cargo.toml
+++ b/contracts/os/andromeda-ibc-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-ibc-registry"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -469,7 +469,7 @@ pub enum ContractError {
     #[error("Invalid zero amount")]
     InvalidZeroAmount {},
 
-    #[error("Invalid Denom")]
+    #[error("Invalid Denom {msg:?}")]
     InvalidDenom { msg: Option<String> },
 
     #[error("Allowance is expired")]

--- a/packages/std/src/os/ibc_registry.rs
+++ b/packages/std/src/os/ibc_registry.rs
@@ -22,8 +22,8 @@ impl DenomInfo {
     pub fn get_ibc_denom(&self) -> String {
         // Lowercase Denom Info
         let lower_case_denom_info = DenomInfo {
-            path: self.path.to_lowercase(),
-            base_denom: self.base_denom.to_lowercase(),
+            path: self.path.clone(),
+            base_denom: self.base_denom.clone(),
         };
 
         // Concatenate the path and base with "/"
@@ -75,8 +75,14 @@ pub fn verify_denom(denom: &str, denom_info: &DenomInfo) -> Result<(), ContractE
     // Ensure that the hash and base match the provided denom
     let hashed_denom = denom_info.get_ibc_denom();
     ensure!(
-        denom == hashed_denom,
-        ContractError::InvalidDenom { msg: None }
+        denom.to_lowercase() == hashed_denom.to_lowercase(),
+        ContractError::InvalidDenom {
+            msg: Some(format!(
+                "Denom hash does not match. Expected: {expected}, Actual: {actual}",
+                expected = hashed_denom,
+                actual = denom
+            )),
+        }
     );
 
     Ok(())

--- a/packages/std/src/os/ibc_registry.rs
+++ b/packages/std/src/os/ibc_registry.rs
@@ -20,17 +20,8 @@ pub struct DenomInfo {
 }
 impl DenomInfo {
     pub fn get_ibc_denom(&self) -> String {
-        // Lowercase Denom Info
-        let lower_case_denom_info = DenomInfo {
-            path: self.path.clone(),
-            base_denom: self.base_denom.clone(),
-        };
-
         // Concatenate the path and base with "/"
-        let input = format!(
-            "{}/{}",
-            lower_case_denom_info.path, lower_case_denom_info.base_denom
-        );
+        let input = format!("{}/{}", self.path, self.base_denom);
 
         // Hash the concatenated string using SHA-256
         let hash = Sha256::digest(input.as_bytes());


### PR DESCRIPTION
# Motivation

Fix Case Sensitive Errors in denom validation, Bump IBC Registry ADO version for denom validation update.

# Implementation

- Updated Cargo.toml file
- Update InvalidDenom contract error to include msg in its response
- Remove lowercase conversion for denom and base_path
- Add lowercase conversion for hashed denom and provided denom


# Version Changes

- IBC Registry ADO - 1.0.0 -> 1.0.1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented Denom Validation in the IBC Registry ADO to enhance data integrity.
  
- **Bug Fixes**
	- Improved error handling for invalid denominations with more informative error messages. 

- **Chores**
	- Updated the version of the "andromeda-ibc-registry" package from 1.0.0 to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->