### PR TITLE
ref: remove check for tiers with no limit in Crowdfund

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -262,7 +262,6 @@ fn execute_start_campaign(
         ContractError::Unauthorized {}
     );
 
-    // At least one tier should have no limit to start the campaign
     ensure!(is_valid_tiers(deps.storage), ContractError::InvalidTiers {});
 
     // Validate parameters

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/state.rs
@@ -183,9 +183,6 @@ pub(crate) fn get_tiers(
 
 pub(crate) fn is_valid_tiers(storage: &mut dyn Storage) -> bool {
     !TIERS.is_empty(storage)
-        && TIERS
-            .range_raw(storage, None, None, Order::Ascending)
-            .any(|res| res.unwrap().1.limit.is_none())
 }
 
 pub(crate) fn get_current_stage(storage: &dyn Storage) -> CampaignStage {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -540,19 +540,6 @@ mod test {
             orderer: mock_orderer.clone(),
         }];
 
-        let invalid_tiers = vec![Tier {
-            level: Uint64::new(1u64),
-            label: "Tier 1".to_string(),
-            limit: Some(Uint128::new(1000u128)),
-            price: Uint128::new(10u128),
-            metadata: TierMetaData {
-                extension: TokenExtension {
-                    publisher: MOCK_ADO_PUBLISHER.to_string(),
-                },
-                token_uri: None,
-            },
-        }];
-
         let env = mock_env();
         let test_cases: Vec<StartCampaignTestCase> = vec![
             StartCampaignTestCase {
@@ -589,15 +576,6 @@ mod test {
                 end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() + 100),
                 payee: "owner1".to_string(),
                 expected_res: Err(ContractError::Unauthorized {}),
-            },
-            StartCampaignTestCase {
-                name: "start_campaign with no unlimited tier".to_string(),
-                tiers: invalid_tiers,
-                presale: Some(valid_presale.clone()),
-                start_time: None,
-                end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() + 100),
-                payee: MOCK_DEFAULT_OWNER.to_string(),
-                expected_res: Err(ContractError::InvalidTiers {}),
             },
             StartCampaignTestCase {
                 name: "start_campaign with invalid presales".to_string(),


### PR DESCRIPTION
# Motivation
The contract threw an error if none of the campaigns had a limit

# Implementation
Removed the check in `is_valid_tiers` that looked for limits

# Testing
Removed test that expected an error concerning the above

# Version Changes
`crowdfund`: `2.0.3` -> `2.0.4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced campaign management with improved validation checks for starting campaigns.
	- Support for tier purchases using CW20 tokens.
	- Refined claim handling based on campaign outcomes.

- **Bug Fixes**
	- Updated logic for determining campaign stages and handling user claims.

- **Tests**
	- Expanded test cases for various purchasing scenarios and campaign validations.
	- Removed outdated test case related to unlimited tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->