### PR TITLE
feat: Include ADOBase Version in Schema

### DIFF
--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -146,7 +146,7 @@ pub fn andr_query(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                 #[returns(andromeda_std::ado_base::version::VersionResponse)]
                 Version {},
                 #[returns(andromeda_std::ado_base::version::ADOBaseVersionResponse)]
-                ///Andromeda Base ADO Version: 1.2.3
+                #[schemars(example = "andromeda_std::ado_base::version::base_crate_version")]
                 ADOBaseVersion {},
                 #[returns(Vec<::andromeda_std::ado_base::permissioning::PermissionInfo>)]
                 Permissions { actor: String, limit: Option<u32>, start_after: Option<String> },

--- a/packages/std/macros/src/lib.rs
+++ b/packages/std/macros/src/lib.rs
@@ -146,6 +146,7 @@ pub fn andr_query(_metadata: TokenStream, input: TokenStream) -> TokenStream {
                 #[returns(andromeda_std::ado_base::version::VersionResponse)]
                 Version {},
                 #[returns(andromeda_std::ado_base::version::ADOBaseVersionResponse)]
+                ///Andromeda Base ADO Version: 1.2.3
                 ADOBaseVersion {},
                 #[returns(Vec<::andromeda_std::ado_base::permissioning::PermissionInfo>)]
                 Permissions { actor: String, limit: Option<u32>, start_after: Option<String> },

--- a/packages/std/src/ado_base/version.rs
+++ b/packages/std/src/ado_base/version.rs
@@ -13,5 +13,5 @@ pub struct ADOBaseVersionResponse {
 
 pub fn base_crate_version() -> String {
     let version = env!("CARGO_PKG_VERSION");
-    format!("ADOBase Version: {}", version)
+    format!("ADO_BASE_VERSION:{}", version)
 }

--- a/packages/std/src/ado_base/version.rs
+++ b/packages/std/src/ado_base/version.rs
@@ -10,3 +10,8 @@ pub struct ADOBaseVersionResponse {
     // andromeda-std version in semver format
     pub version: String,
 }
+
+pub fn base_crate_version() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("ADOBase Version: {}", version)
+}


### PR DESCRIPTION
# Motivation
This facilitates handling different versions by having the ADO Base version directly in the schema to be parsed. 

# Implementation
Include this code over the ADOBaseVersion query:
```rust
#[schemars(example = "andromeda_std::ado_base::version::base_crate_version")]
```

This function is in the `version.rs` file
```rust
pub fn base_crate_version() -> String {
    let version = env!("CARGO_PKG_VERSION");
    format!("ADOBase Version: {}", version)
}
```

# Testing
Generated a schema locally and was able to find the ADOBase version under as an `example` value

# Version Changes
`andromeda-std`: `1.2.3` -> `1.2.4`
