### PR TITLE
fix: converted seconds to milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADODB now supports pre-release tagging [(#560)](https://github.com/andromedaprotocol/andromeda-core/pull/560)
 - Updated Validator Staking: Updated according to shrelock audit [(#565)](https://github.com/andromedaprotocol/andromeda-core/pull/565)
 - Conditional Splitter: Change lock_time's type from MillisecondsDuration to Expiry [(#567)](https://github.com/andromedaprotocol/andromeda-core/pull/567)
-- Vesting: Changed to use Milliseconds instead of seconds [(#567)](https://github.com/andromedaprotocol/andromeda-core/pull/578)
+- Vesting: Changed to use Milliseconds instead of seconds and removed unnecessary is_multi_batch_enabled flag [(#567)](https://github.com/andromedaprotocol/andromeda-core/pull/578)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADODB now supports pre-release tagging [(#560)](https://github.com/andromedaprotocol/andromeda-core/pull/560)
 - Updated Validator Staking: Updated according to shrelock audit [(#565)](https://github.com/andromedaprotocol/andromeda-core/pull/565)
 - Conditional Splitter: Change lock_time's type from MillisecondsDuration to Expiry [(#567)](https://github.com/andromedaprotocol/andromeda-core/pull/567)
+- Vesting: Changed to use Milliseconds instead of seconds [(#567)](https://github.com/andromedaprotocol/andromeda-core/pull/578)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -36,7 +36,6 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     let config = Config {
-        is_multi_batch_enabled: msg.is_multi_batch_enabled,
         recipient: msg.recipient,
         denom: msg.denom,
     };
@@ -184,7 +183,7 @@ fn execute_create_batch(
         last_claimed_release_time: lockup_end,
     };
 
-    save_new_batch(deps.storage, batch, &config)?;
+    save_new_batch(deps.storage, batch)?;
 
     Ok(Response::new()
         .add_attribute("action", "create_batch")

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -1,6 +1,8 @@
 use andromeda_std::{
     ado_contract::ADOContract,
-    common::{actions::call_action, context::ExecuteContext, withdraw::WithdrawalType},
+    common::{
+        actions::call_action, context::ExecuteContext, withdraw::WithdrawalType, Milliseconds,
+    },
     error::ContractError,
 };
 #[cfg(not(feature = "library"))]
@@ -101,8 +103,8 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
 
 fn execute_create_batch(
     ctx: ExecuteContext,
-    lockup_duration: Option<u64>,
-    release_unit: u64,
+    lockup_duration: Option<Milliseconds>,
+    release_unit: Milliseconds,
     release_amount: WithdrawalType,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -114,7 +116,7 @@ fn execute_create_batch(
     );
 
     let config = CONFIG.load(deps.storage)?;
-    let current_time = env.block.time.seconds();
+    let current_time = Milliseconds::from_seconds(env.block.time.seconds());
 
     ensure!(
         info.funds.len() == 1,
@@ -133,7 +135,7 @@ fn execute_create_batch(
     );
 
     ensure!(
-        release_unit > 0 && !release_amount.is_zero(),
+        !release_unit.is_zero() && !release_amount.is_zero(),
         ContractError::InvalidZeroAmount {}
     );
     ensure!(
@@ -166,7 +168,7 @@ fn execute_create_batch(
     );
 
     let lockup_end = if let Some(duration) = lockup_duration {
-        current_time + duration
+        current_time.plus_milliseconds(duration)
     } else {
         current_time
     };
@@ -238,7 +240,7 @@ fn execute_claim(
 fn execute_claim_all(
     ctx: ExecuteContext,
     limit: Option<u32>,
-    up_to_time: Option<u64>,
+    up_to_time: Option<Milliseconds>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
         deps, info, env, ..
@@ -254,9 +256,12 @@ fn execute_claim_all(
 
     let config = CONFIG.load(deps.storage)?;
 
-    let current_time = env.block.time.seconds();
+    let current_time = Milliseconds::from_seconds(env.block.time.seconds());
     let batches_with_ids = get_claimable_batches_with_ids(deps.storage, current_time, limit)?;
-    let up_to_time = cmp::min(current_time, up_to_time.unwrap_or(current_time));
+    let up_to_time = Milliseconds(cmp::min(
+        current_time.milliseconds(),
+        up_to_time.unwrap_or(current_time).milliseconds(),
+    ));
 
     let mut total_amount_to_send = Uint128::zero();
     let last_batch_id = if !batches_with_ids.is_empty() {
@@ -267,8 +272,8 @@ fn execute_claim_all(
     for (batch_id, mut batch) in batches_with_ids {
         let key = batches().key(batch_id);
 
-        let elapsed_time = up_to_time - batch.last_claimed_release_time;
-        let num_available_claims = elapsed_time / batch.release_unit;
+        let elapsed_time = up_to_time.minus_milliseconds(batch.last_claimed_release_time);
+        let num_available_claims = elapsed_time.milliseconds() / batch.release_unit.milliseconds();
 
         let amount_to_send = claim_batch(
             &deps.querier,
@@ -306,7 +311,7 @@ fn claim_batch(
     config: &Config,
     number_of_claims: Option<u64>,
 ) -> Result<Uint128, ContractError> {
-    let current_time = env.block.time.seconds();
+    let current_time = Milliseconds::from_seconds(env.block.time.seconds());
     ensure!(
         batch.lockup_end <= current_time,
         ContractError::FundsAreLocked {}
@@ -314,8 +319,8 @@ fn claim_batch(
     let total_amount = AssetInfo::native(config.denom.to_owned())
         .query_balance(querier, env.contract.address.to_owned())?;
 
-    let elapsed_time = current_time - batch.last_claimed_release_time;
-    let num_available_claims = elapsed_time / batch.release_unit;
+    let elapsed_time = current_time.minus_milliseconds(batch.last_claimed_release_time);
+    let num_available_claims = elapsed_time.milliseconds() / batch.release_unit.milliseconds();
 
     let number_of_claims = cmp::min(
         number_of_claims.unwrap_or(num_available_claims),
@@ -336,19 +341,17 @@ fn claim_batch(
         batch.amount_claimed = batch.amount_claimed.checked_add(amount_to_send)?;
 
         // Safe math version
-        let claims_release_unit = number_of_claims.checked_mul(batch.release_unit);
-        if let Some(claims_release_unit) = claims_release_unit {
-            let new_claimed_release_time = batch
-                .last_claimed_release_time
-                .checked_add(claims_release_unit);
-            if let Some(new_claimed_release_time) = new_claimed_release_time {
-                batch.last_claimed_release_time = new_claimed_release_time;
-            } else {
-                return Err(ContractError::Overflow {});
-            }
-        } else {
+        let claims_release_unit = number_of_claims.checked_mul(batch.release_unit.milliseconds());
+        if claims_release_unit.is_none() {
             return Err(ContractError::Overflow {});
         }
+
+        let claims_release_unit = Milliseconds(claims_release_unit.unwrap());
+
+        batch.last_claimed_release_time = batch
+            .last_claimed_release_time
+            .plus_milliseconds(claims_release_unit);
+
         // The unsafe version
         // batch.last_claimed_release_time += number_of_claims * batch.release_unit;
     }
@@ -411,7 +414,7 @@ fn get_batch_response(
 ) -> Result<BatchResponse, ContractError> {
     let previous_amount = batch.amount_claimed;
     let previous_last_claimed_release_time = batch.last_claimed_release_time;
-    let amount_available_to_claim = if env.block.time.seconds() >= batch.lockup_end {
+    let amount_available_to_claim = if env.block.time.seconds() >= batch.lockup_end.seconds() {
         claim_batch(querier, env, &mut batch, config, None)?
     } else {
         Uint128::zero()

--- a/contracts/finance/andromeda-vesting/src/mock.rs
+++ b/contracts/finance/andromeda-vesting/src/mock.rs
@@ -9,7 +9,6 @@ use andromeda_testing::{
 };
 use cosmwasm_std::{Addr, Empty};
 use cw_multi_test::{Contract, ContractWrapper, Executor};
-use cw_utils::Duration;
 
 pub struct MockVestingContract(Addr);
 mock_ado!(MockVestingContract, ExecuteMsg, QueryMsg);
@@ -20,19 +19,12 @@ impl MockVestingContract {
         code_id: u64,
         sender: &Addr,
         app: &mut MockApp,
-        unbonding_duration: Duration,
         recipient: Recipient,
         denom: String,
         kernel_address: impl Into<String>,
         owner: Option<String>,
     ) -> MockVestingContract {
-        let msg = mock_vesting_instantiate_msg(
-            unbonding_duration,
-            recipient,
-            denom,
-            kernel_address,
-            owner,
-        );
+        let msg = mock_vesting_instantiate_msg(recipient, denom, kernel_address, owner);
         let addr = app
             .instantiate_contract(
                 code_id,
@@ -53,14 +45,12 @@ pub fn mock_andromeda_vesting() -> Box<dyn Contract<Empty>> {
 }
 
 pub fn mock_vesting_instantiate_msg(
-    unbonding_duration: Duration,
     recipient: Recipient,
     denom: String,
     kernel_address: impl Into<String>,
     owner: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
-        unbonding_duration,
         recipient,
         denom,
         kernel_address: kernel_address.into(),

--- a/contracts/finance/andromeda-vesting/src/mock.rs
+++ b/contracts/finance/andromeda-vesting/src/mock.rs
@@ -20,7 +20,6 @@ impl MockVestingContract {
         code_id: u64,
         sender: &Addr,
         app: &mut MockApp,
-        is_multi_batch_enabled: bool,
         unbonding_duration: Duration,
         recipient: Recipient,
         denom: String,
@@ -28,7 +27,6 @@ impl MockVestingContract {
         owner: Option<String>,
     ) -> MockVestingContract {
         let msg = mock_vesting_instantiate_msg(
-            is_multi_batch_enabled,
             unbonding_duration,
             recipient,
             denom,
@@ -55,7 +53,6 @@ pub fn mock_andromeda_vesting() -> Box<dyn Contract<Empty>> {
 }
 
 pub fn mock_vesting_instantiate_msg(
-    is_multi_batch_enabled: bool,
     unbonding_duration: Duration,
     recipient: Recipient,
     denom: String,
@@ -63,7 +60,6 @@ pub fn mock_vesting_instantiate_msg(
     owner: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
-        is_multi_batch_enabled,
         unbonding_duration,
         recipient,
         denom,

--- a/contracts/finance/andromeda-vesting/src/state.rs
+++ b/contracts/finance/andromeda-vesting/src/state.rs
@@ -1,5 +1,8 @@
 use andromeda_finance::vesting::Config;
-use andromeda_std::{common::withdraw::WithdrawalType, error::ContractError};
+use andromeda_std::{
+    common::{withdraw::WithdrawalType, Milliseconds},
+    error::ContractError,
+};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{ensure, Order, Storage, Uint128};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, MultiIndex};
@@ -17,14 +20,14 @@ pub struct Batch {
     /// The amount of tokens that have been claimed.
     pub amount_claimed: Uint128,
     /// When the lockup ends.
-    pub lockup_end: u64,
+    pub lockup_end: Milliseconds,
     /// How often releases occur.
-    pub release_unit: u64,
+    pub release_unit: Milliseconds,
     /// Specifies how much is to be released after each `release_unit`. If
     /// it is a percentage, it would be the percentage of the original amount.
     pub release_amount: WithdrawalType,
     /// The time at which the last claim took place in seconds.
-    pub last_claimed_release_time: u64,
+    pub last_claimed_release_time: Milliseconds,
 }
 
 // Inspired by https://docs.cosmwasm.com/tutorials/storage/indexes/#storage-plus-indexing
@@ -49,7 +52,7 @@ pub fn batches<'a>() -> IndexedMap<'a, u64, Batch, BatchIndexes<'a>> {
                 let all_claimed = b.amount - b.amount_claimed == Uint128::zero();
                 // Allows us to skip batches that have been already fully claimed.
                 let all_claimed = u8::from(all_claimed);
-                (all_claimed, b.lockup_end)
+                (all_claimed, b.lockup_end.milliseconds())
             },
             "batch",
             "batch__promotion",
@@ -82,13 +85,13 @@ const MAX_LIMIT: u32 = 30;
 /// These are all eligible for fund claiming.
 pub(crate) fn get_claimable_batches_with_ids(
     storage: &dyn Storage,
-    current_time: u64,
+    current_time: Milliseconds,
     limit: Option<u32>,
 ) -> Result<Vec<(u64, Batch)>, ContractError> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     // As we want to keep the last item (pk) unbounded, we increment time by 1 and use exclusive (below the next tick).
     // This ensures that we only consider batches that have started vesting.
-    let max_key = (current_time + 1, 0);
+    let max_key = (current_time.milliseconds() + 1, 0);
     let bound = Bound::exclusive(max_key);
 
     let batches_with_ids: Result<Vec<(u64, Batch)>, ContractError> = batches()
@@ -138,33 +141,33 @@ mod tests {
 
     #[test]
     fn test_get_claimable_batches_with_ids() {
-        let current_time = mock_env().block.time.seconds();
+        let current_time = Milliseconds::from_seconds(mock_env().block.time.seconds());
 
         let locked_batch = Batch {
             amount: Uint128::new(100),
             amount_claimed: Uint128::zero(),
-            lockup_end: current_time + 10,
-            release_unit: 10,
+            lockup_end: current_time.plus_seconds(10),
+            release_unit: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: current_time - 1,
+            last_claimed_release_time: current_time.minus_seconds(1),
         };
 
         let unlocked_batch = Batch {
             amount: Uint128::new(100),
             amount_claimed: Uint128::zero(),
-            lockup_end: current_time - 1,
-            release_unit: 10,
+            lockup_end: current_time.minus_seconds(1),
+            release_unit: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: current_time - 1,
+            last_claimed_release_time: current_time.minus_seconds(1),
         };
 
         let unlocked_but_empty_batch = Batch {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(100),
-            lockup_end: current_time - 1,
-            release_unit: 10,
+            lockup_end: current_time.minus_seconds(1),
+            release_unit: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: current_time - 1,
+            last_claimed_release_time: current_time.minus_seconds(1),
         };
 
         let mut deps = mock_dependencies();

--- a/contracts/finance/andromeda-vesting/src/state.rs
+++ b/contracts/finance/andromeda-vesting/src/state.rs
@@ -4,7 +4,7 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{ensure, Order, Storage, Uint128};
+use cosmwasm_std::{Order, Storage, Uint128};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, MultiIndex};
 
 /// The config.
@@ -61,16 +61,9 @@ pub fn batches<'a>() -> IndexedMap<'a, u64, Batch, BatchIndexes<'a>> {
     IndexedMap::new("batch", indexes)
 }
 
-pub(crate) fn save_new_batch(
-    storage: &mut dyn Storage,
-    batch: Batch,
-    config: &Config,
-) -> Result<(), ContractError> {
+pub(crate) fn save_new_batch(storage: &mut dyn Storage, batch: Batch) -> Result<(), ContractError> {
     let next_id = NEXT_ID.may_load(storage)?.unwrap_or(1);
-    ensure!(
-        next_id == 1 || config.is_multi_batch_enabled,
-        ContractError::MultiBatchNotSupported {}
-    );
+
     batches().save(storage, next_id, &batch)?;
     NEXT_ID.save(storage, &(next_id + 1))?;
 

--- a/contracts/finance/andromeda-vesting/src/testing/tests.rs
+++ b/contracts/finance/andromeda-vesting/src/testing/tests.rs
@@ -9,7 +9,6 @@ use cosmwasm_std::{
     testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR},
     BankMsg, Decimal, DepsMut, Response, Uint128,
 };
-use cw_utils::Duration;
 
 use crate::{
     contract::{execute, instantiate, query},
@@ -19,13 +18,10 @@ use crate::{
 
 use andromeda_finance::vesting::{BatchResponse, Config, ExecuteMsg, InstantiateMsg, QueryMsg};
 
-const UNBONDING_BLOCK_DURATION: u64 = 5;
-
 fn init(deps: DepsMut) -> Response {
     let msg = InstantiateMsg {
         recipient: Recipient::from_string("recipient"),
         denom: "uusd".to_string(),
-        unbonding_duration: Duration::Height(UNBONDING_BLOCK_DURATION),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
     };

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -5,7 +5,6 @@ use andromeda_std::{
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
-use cw_utils::Duration;
 
 #[andr_instantiate]
 #[cw_serde]
@@ -14,8 +13,6 @@ pub struct InstantiateMsg {
     pub recipient: Recipient,
     /// The denom of the coin being vested.
     pub denom: String,
-    /// The unbonding duration of the native staking module.
-    pub unbonding_duration: Duration,
 }
 
 #[andr_exec]

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -1,5 +1,7 @@
 use andromeda_std::{
-    amp::Recipient, andr_exec, andr_instantiate, andr_query, common::withdraw::WithdrawalType,
+    amp::Recipient,
+    andr_exec, andr_instantiate, andr_query,
+    common::{withdraw::WithdrawalType, Milliseconds},
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
@@ -31,15 +33,15 @@ pub enum ExecuteMsg {
     /// is specified then it will only claim up to a specific time, otherwise it
     /// it will claim to the most recent release.
     ClaimAll {
-        up_to_time: Option<u64>,
+        up_to_time: Option<Milliseconds>,
         limit: Option<u32>,
     },
     /// Creates a new batch
     CreateBatch {
         /// Specifying None would mean no lock up period and funds start vesting right away.
-        lockup_duration: Option<u64>,
+        lockup_duration: Option<Milliseconds>,
         /// How often releases occur in seconds.
-        release_unit: u64,
+        release_unit: Milliseconds,
         /// Specifies how much is to be released after each `release_unit`. If
         /// it is a percentage, it would be the percentage of the original amount.
         release_amount: WithdrawalType,
@@ -87,12 +89,12 @@ pub struct BatchResponse {
     /// The number of available claims.
     pub number_of_available_claims: Uint128,
     /// When the lockup ends.
-    pub lockup_end: u64,
+    pub lockup_end: Milliseconds,
     /// How often releases occur.
-    pub release_unit: u64,
+    pub release_unit: Milliseconds,
     /// Specifies how much is to be released after each `release_unit`. If
     /// it is a percentage, it would be the percentage of the original amount.
     pub release_amount: WithdrawalType,
     /// The time at which the last claim took place in seconds.
-    pub last_claimed_release_time: u64,
+    pub last_claimed_release_time: Milliseconds,
 }

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -12,8 +12,6 @@ use cw_utils::Duration;
 pub struct InstantiateMsg {
     /// The recipient of all funds locked in this contract.
     pub recipient: Recipient,
-    /// Whether or not multi-batching has been enabled.
-    pub is_multi_batch_enabled: bool,
     /// The denom of the coin being vested.
     pub denom: String,
     /// The unbonding duration of the native staking module.
@@ -70,8 +68,6 @@ pub enum QueryMsg {
 pub struct Config {
     /// The recipient of each batch.
     pub recipient: Recipient,
-    /// Whether or not multiple batches are supported.
-    pub is_multi_batch_enabled: bool,
     /// The denom of the coin being vested.
     pub denom: String,
 }

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -90,9 +90,6 @@ pub enum ContractError {
     #[error("RewardTooLow")]
     RewardTooLow {},
 
-    #[error("IncompleteUnbondingPeriod")]
-    IncompleteUnbondingPeriod {},
-
     #[error("LockedNFT")]
     LockedNFT {},
 


### PR DESCRIPTION
# Motivation
Resolves following issues
- https://linear.app/andromedaprot/issue/SUPP-116/seconds-milliseconds-fix
- https://linear.app/andromedaprot/issue/SUPP-115/fix-enable-disable-multi-batching
- https://linear.app/andromedaprot/issue/SUPP-113/unbonding-duration-field-should-be-removed-from-contract-and-schema

# Implementation
- Updated vesting ado to use `Milliseconds` for `up_to_time`, `lockup_duration` and `release_unit` instead of `u64`
- Removed unnecessary batch flag and unbonding duration.

# Testing
Unit tests for vesting updated to use `Milliseconds`
Removed test case with disabled multi batching option


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced multiple new ADOs including Validator Staking, Asset, String Storage, Boolean Storage, Counter, Date Time, and IBC Registry ADO.
	- Added functionality for removing/replacing reward tokens in staking and a BuyNow option for auctions.
	- Implemented Denom Validation for Rates and in the IBC Registry ADO.

- **Bug Fixes**
	- Resolved issues with Splitter and Conditional Splitter lock time calculations and precision in vesting claim batch method.

- **Changes**
	- Updated time-related fields to use a new Milliseconds type for improved clarity and type safety in contracts and tests.
	- Simplified instantiation logic by removing the is_multi_batch_enabled parameter.
	- Removed the IncompleteUnbondingPeriod variant from error handling for streamlined error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->