### PR TITLE
feat: ICS20 Acknowledgements for Kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
+ "cw-orch 0.23.0",
  "cw-storage-plus 1.2.0",
  "cw20",
 ]
@@ -4773,6 +4774,7 @@ dependencies = [
  "andromeda-cw20-staking",
  "andromeda-cw721",
  "andromeda-data-storage",
+ "andromeda-economics",
  "andromeda-ecosystem",
  "andromeda-finance",
  "andromeda-fungible-tokens",

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -116,7 +116,6 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
 
 fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
-
     ensure!(
         !info.funds.is_empty(),
         ContractError::InvalidFunds {

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -12,7 +12,7 @@ use andromeda_std::{
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
     attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdError, SubMsg, Uint128,
+    Reply, Response, StdError, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw_utils::nonpayable;
 

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -12,7 +12,7 @@ use andromeda_std::{
 use andromeda_std::{ado_contract::ADOContract, common::context::ExecuteContext};
 use cosmwasm_std::{
     attr, ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdError, SubMsg, Uint128, WasmMsg, WasmQuery,
+    Reply, Response, StdError, SubMsg, Uint128,
 };
 use cw_utils::nonpayable;
 

--- a/contracts/finance/andromeda-splitter/src/interface.rs
+++ b/contracts/finance/andromeda-splitter/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::contract::{execute, instantiate, query};
+use crate::contract::{execute, instantiate, query, reply};
 use andromeda_finance::splitter::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use cw_orch::{interface, prelude::*};
 pub const CONTRACT_ID: &str = "splitter_contract";
@@ -9,6 +9,6 @@ pub struct SplitterContract<Chain: CwEnv>;
 // Implement the Uploadable trait so it can be uploaded to the mock.
 impl<Chain> Uploadable for SplitterContract<Chain> {
     fn wrapper() -> Box<dyn MockContract<Empty>> {
-        Box::new(ContractWrapper::new_with_empty(execute, instantiate, query))
+        Box::new(ContractWrapper::new_with_empty(execute, instantiate, query).with_reply(reply))
     }
 }

--- a/contracts/fungible-tokens/andromeda-ics20/src/ibc.rs
+++ b/contracts/fungible-tokens/andromeda-ics20/src/ibc.rs
@@ -199,7 +199,6 @@ pub fn ibc_packet_receive(
     _env: Env,
     msg: IbcPacketReceiveMsg,
 ) -> Result<IbcReceiveResponse, Never> {
-    println!("packet_received");
     let packet = msg.packet;
 
     do_ibc_packet_receive(deps, &packet).or_else(|err| {
@@ -305,7 +304,6 @@ pub fn ibc_packet_ack(
     _env: Env,
     msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    println!("packed_acknowledged");
     // Design decision: should we trap error like in receive?
     // TODO: unsure... as it is now a failed ack handling would revert the tx and would be
     // retried again and again. is that good?

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -31,6 +31,7 @@ andromeda-std = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }
+cw-orch = "=0.23.0"
 
 [dev-dependencies]
 # andromeda-testing = { workspace = true, optional = true }

--- a/contracts/os/andromeda-economics/src/interface.rs
+++ b/contracts/os/andromeda-economics/src/interface.rs
@@ -1,0 +1,18 @@
+use crate::contract::{execute, instantiate, query, reply};
+use andromeda_std::os::economics::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cw_orch::{interface, prelude::*};
+pub const CONTRACT_ID: &str = "economics_contract";
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, Empty id = CONTRACT_ID)]
+pub struct EconomicsContract<Chain: CwEnv>;
+
+// Implement the Uploadable trait so it can be uploaded to the mock.
+impl<Chain> Uploadable for EconomicsContract<Chain> {
+    fn wrapper() -> Box<dyn MockContract<Empty>> {
+        Box::new(
+            ContractWrapper::new_with_empty(execute, instantiate, query)
+                .with_reply(reply)
+                .with_reply(crate::contract::reply),
+        )
+    }
+}

--- a/contracts/os/andromeda-economics/src/lib.rs
+++ b/contracts/os/andromeda-economics/src/lib.rs
@@ -7,3 +7,8 @@ mod state;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod interface;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::interface::EconomicsContract;

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -38,13 +38,14 @@ serde = { workspace = true }
 schemars = "0.8.10"
 hex = "0.4.3"
 itertools = "0.10"
-cw-orch = "=0.23.0"
+
 
 andromeda-std = { workspace = true }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }
+cw-orch = "=0.23.0"
 
 [dev-dependencies]
 # andromeda-testing = { workspace = true, optional = true }

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -11,7 +11,7 @@ use cosmwasm_std::{
 };
 
 use crate::ibc::{IBCLifecycleComplete, SudoMsg};
-use crate::reply::{on_reply_create_ado, on_reply_ibc_hooks_packet_send, on_reply_transfer_funds};
+use crate::reply::{on_reply_create_ado, on_reply_ibc_hooks_packet_send, on_reply_ibc_transfer};
 use crate::state::CURR_CHAIN;
 use crate::{execute, query, sudo};
 
@@ -56,7 +56,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
     match ReplyId::from_repr(msg.id) {
         Some(ReplyId::CreateADO) => on_reply_create_ado(deps, env, msg),
         Some(ReplyId::IBCHooksPacketSend) => on_reply_ibc_hooks_packet_send(deps, msg),
-        Some(ReplyId::TransferFunds) => on_reply_transfer_funds(deps, env, msg),
+        Some(ReplyId::IBCTransfer) => on_reply_ibc_transfer(deps, env, msg),
         _ => Ok(Response::default()),
     }
 }
@@ -83,8 +83,8 @@ pub fn execute(
             packet,
         ),
         ExecuteMsg::Send { message } => execute::send(execute_env, message),
-        ExecuteMsg::TransferReply { packet_sequence } => {
-            execute::transfer_reply(execute_env, packet_sequence)
+        ExecuteMsg::TriggerRelay { packet_sequence } => {
+            execute::trigger_relay(execute_env, packet_sequence)
         }
         ExecuteMsg::UpsertKeyAddress { key, value } => {
             execute::upsert_key_address(execute_env, key, value)

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -11,7 +11,7 @@ use cosmwasm_std::{
 };
 
 use crate::ibc::{IBCLifecycleComplete, SudoMsg};
-use crate::reply::{on_reply_create_ado, on_reply_ibc_hooks_packet_send};
+use crate::reply::{on_reply_create_ado, on_reply_ibc_hooks_packet_send, on_reply_transfer_funds};
 use crate::state::CURR_CHAIN;
 use crate::{execute, query, sudo};
 
@@ -56,7 +56,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
     match ReplyId::from_repr(msg.id) {
         Some(ReplyId::CreateADO) => on_reply_create_ado(deps, env, msg),
         Some(ReplyId::IBCHooksPacketSend) => on_reply_ibc_hooks_packet_send(deps, msg),
-        // Some(ReplyId::TransferFunds) => on_reply_transfer_funds(deps, env, msg),
+        Some(ReplyId::TransferFunds) => on_reply_transfer_funds(deps, env, msg),
         _ => Ok(Response::default()),
     }
 }
@@ -83,7 +83,9 @@ pub fn execute(
             packet,
         ),
         ExecuteMsg::Send { message } => execute::send(execute_env, message),
-        // ExecuteMsg::TransferReply { message } => execute::transfer_reply(execute_env, message),
+        ExecuteMsg::TransferReply { packet_sequence } => {
+            execute::transfer_reply(execute_env, packet_sequence)
+        }
         ExecuteMsg::UpsertKeyAddress { key, value } => {
             execute::upsert_key_address(execute_env, key, value)
         }

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -50,7 +50,7 @@ pub fn transfer_reply(
             })?;
 
     let channel_info = CHAIN_TO_CHANNEL
-        .may_load(ctx.deps.storage, &chain)?
+        .may_load(ctx.deps.storage, chain)?
         .ok_or_else(|| ContractError::InvalidPacket {
             error: Some(format!("Channel not found for chain {}", chain)),
         })?;

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -96,7 +96,7 @@ fn handle_ibc_transfer_funds_reply(
             error: Some(format!("Direct channel not found for chain {}", chain)),
         })?;
     let kernel_msg = IbcExecuteMsg::SendMessageWithFunds {
-        recipient: AndrAddr::from_string(ics20_packet_info.recipient.clone()),
+        recipient: AndrAddr::from_string(ics20_packet_info.recipient.clone().get_raw_path()),
         message: ics20_packet_info.message.clone(),
         funds: ics20_packet_info.funds,
     };
@@ -107,16 +107,11 @@ fn handle_ibc_transfer_funds_reply(
     };
 
     Ok(Response::default()
+        .add_message(CosmosMsg::Ibc(msg))
         .add_attribute(format!("method:{sequence}"), "execute_send_message")
         .add_attribute(format!("channel:{sequence}"), channel)
         .add_attribute("receiving_kernel_address:{}", channel_info.kernel_address)
-        .add_attribute("chain:{}", chain)
-        .add_submessage(SubMsg {
-            id: ReplyId::TransferFunds.repr(),
-            msg: CosmosMsg::Ibc(msg),
-            gas_limit: None,
-            reply_on: cosmwasm_std::ReplyOn::Always,
-        }))
+        .add_attribute("chain:{}", chain))
 }
 
 pub fn amp_receive(

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -697,7 +697,7 @@ impl MsgHandler {
             .map_or_else(
                 || {
                     Err(ContractError::InvalidPacket {
-                        error: Some("Rransfer funds must contain funds in the AMPMsg".to_string()),
+                        error: Some("Transfer funds must contain funds in the AMPMsg".to_string()),
                     })
                 },
                 Ok,

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -683,10 +683,10 @@ impl MsgHandler {
                 Ok,
             )?
             .clone();
-        let recipient_raw_path = recipient.get_raw_path().to_string();
+        // let recipient_raw_path = recipient.get_raw_path().to_string();
         let msg = IbcMsg::Transfer {
             channel_id: channel.clone(),
-            to_address: recipient_raw_path.clone(),
+            to_address: channel_info.kernel_address.clone(),
             amount: coin.clone(),
             timeout: env.block.time.plus_seconds(PACKET_LIFETIME).into(),
         };

--- a/contracts/os/andromeda-kernel/src/ibc.rs
+++ b/contracts/os/andromeda-kernel/src/ibc.rs
@@ -118,7 +118,6 @@ pub fn ibc_packet_ack(
     _env: Env,
     _msg: IbcPacketAckMsg,
 ) -> Result<IbcBasicResponse, ContractError> {
-    println!("ack received");
     Ok(IbcBasicResponse::new())
 }
 

--- a/contracts/os/andromeda-kernel/src/interface.rs
+++ b/contracts/os/andromeda-kernel/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::contract::{execute, instantiate, query};
+use crate::contract::{execute, instantiate, query, reply};
 use andromeda_std::os::kernel::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use cw_orch::{interface, prelude::*};
 pub const CONTRACT_ID: &str = "kernel_contract";
@@ -11,6 +11,7 @@ impl<Chain> Uploadable for KernelContract<Chain> {
     fn wrapper() -> Box<dyn MockContract<Empty>> {
         Box::new(
             ContractWrapper::new_with_empty(execute, instantiate, query)
+                .with_reply(reply)
                 .with_reply(crate::contract::reply)
                 .with_ibc(
                     crate::ibc::ibc_channel_open,

--- a/contracts/os/andromeda-kernel/src/reply.rs
+++ b/contracts/os/andromeda-kernel/src/reply.rs
@@ -1,8 +1,8 @@
 use crate::{
     proto::MsgTransferResponse,
     state::{
-        IBCHooksPacketSendState, OutgoingPacket, ADO_OWNER, OUTGOING_IBC_HOOKS_PACKETS,
-        OUTGOING_IBC_PACKETS,
+        IBCHooksPacketSendState, OutgoingPacket, ADO_OWNER, CHANNEL_TO_EXECUTE_MSG,
+        OUTGOING_IBC_HOOKS_PACKETS, OUTGOING_IBC_PACKETS, PENDING_MSG_AND_FUNDS,
     },
 };
 use andromeda_std::{
@@ -13,8 +13,8 @@ use andromeda_std::{
     os::aos_querier::AOSQuerier,
 };
 use cosmwasm_std::{
-    ensure, wasm_execute, Addr, DepsMut, Empty, Env, Reply, Response, SubMsg, SubMsgResponse,
-    SubMsgResult,
+    ensure, wasm_execute, Addr, CosmosMsg, DepsMut, Empty, Env, Reply, Response, SubMsg,
+    SubMsgResponse, SubMsgResult,
 };
 
 /// Handles the reply from an ADO creation
@@ -95,71 +95,73 @@ pub fn on_reply_ibc_hooks_packet_send(
 }
 
 // Handles the reply from an ICS20 funds transfer
-// pub fn on_reply_transfer_funds(
-//     deps: DepsMut,
-//     env: Env,
-//     msg: Reply,
-// ) -> Result<Response, ContractError> {
-//     if let Reply {
-//         id: 106,
-//         result: SubMsgResult::Ok(SubMsgResponse { events, .. }),
-//     } = msg
-//     {
-//         if let Some(send_packet_event) = events.iter().find(|e| e.ty == "send_packet") {
-//             let packet_data = send_packet_event
-//                 .attributes
-//                 .iter()
-//                 .find(|attr| attr.key == "packet_data")
-//                 .map(|attr| attr.value.clone())
-//                 .unwrap_or_default();
-//             let packet_sequence = send_packet_event
-//                 .attributes
-//                 .iter()
-//                 .find(|attr| attr.key == "packet_sequence")
-//                 .map(|attr| attr.value.clone())
-//                 .unwrap_or_default();
-//             let src_channel = send_packet_event
-//                 .attributes
-//                 .iter()
-//                 .find(|attr| attr.key == "packet_src_channel")
-//                 .map(|attr| attr.value.clone())
-//                 .unwrap_or_default();
-//             let dst_channel = send_packet_event
-//                 .attributes
-//                 .iter()
-//                 .find(|attr| attr.key == "packet_dst_channel")
-//                 .map(|attr| attr.value.clone())
-//                 .unwrap_or_default();
+pub fn on_reply_transfer_funds(
+    deps: DepsMut,
+    _env: Env,
+    msg: Reply,
+) -> Result<Response, ContractError> {
+    if let Reply {
+        id: 106,
+        result: SubMsgResult::Ok(SubMsgResponse { events, .. }),
+    } = msg
+    {
+        if let Some(send_packet_event) = events.iter().find(|e| e.ty == "send_packet") {
+            let packet_data = send_packet_event
+                .attributes
+                .iter()
+                .find(|attr| attr.key == "packet_data")
+                .map(|attr| attr.value.clone())
+                .unwrap_or_default();
+            let packet_sequence = send_packet_event
+                .attributes
+                .iter()
+                .find(|attr| attr.key == "packet_sequence")
+                .map(|attr| attr.value.clone())
+                .unwrap_or_default();
+            let src_channel = send_packet_event
+                .attributes
+                .iter()
+                .find(|attr| attr.key == "packet_src_channel")
+                .map(|attr| attr.value.clone())
+                .unwrap_or_default();
+            let dst_channel = send_packet_event
+                .attributes
+                .iter()
+                .find(|attr| attr.key == "packet_dst_channel")
+                .map(|attr| attr.value.clone())
+                .unwrap_or_default();
+            let pending_execute_msg = PENDING_MSG_AND_FUNDS.load(deps.storage)?;
+            CHANNEL_TO_EXECUTE_MSG.save(
+                deps.storage,
+                packet_sequence.clone(),
+                &pending_execute_msg,
+            )?;
+            PENDING_MSG_AND_FUNDS.remove(deps.storage);
+            // You can now use these extracted values as needed
+            // For example, you might want to store them or include them in the response
+            return Ok(Response::new()
+                .add_attribute("action", "transfer_funds_reply")
+                .add_attribute("packet_data", packet_data)
+                .add_attribute("packet_sequence", packet_sequence)
+                .add_attribute("src_channel", src_channel)
+                .add_attribute("dst_channel", dst_channel));
+        }
+    }
+    // Refund original message sender
+    let ics20_packet_info = PENDING_MSG_AND_FUNDS.load(deps.storage)?;
+    let refund_recipient = ics20_packet_info.sender;
+    let refund_coin = ics20_packet_info.funds;
+    let refund_msg = CosmosMsg::Bank(cosmwasm_std::BankMsg::Send {
+        to_address: refund_recipient.clone(),
+        amount: vec![refund_coin.clone()],
+    });
 
-//             // You can now use these extracted values as needed
-//             // For example, you might want to store them or include them in the response
-//             return Ok(Response::new()
-//                 .add_attribute("action", "transfer_funds_reply")
-//                 .add_attribute("packet_data", packet_data)
-//                 .add_attribute("packet_sequence", packet_sequence)
-//                 .add_attribute("src_channel", src_channel)
-//                 .add_attribute("dst_channel", dst_channel));
-//         }
-//     }
+    // Clear data
+    PENDING_MSG_AND_FUNDS.remove(deps.storage);
 
-//     Err(ContractError::InvalidPacket { error: None })
-//     // let new_owner = ADO_OWNER.load(deps.as_ref().storage)?;
-//     // let ado_addr = get_reply_address(msg)?;
-
-//     // let curr_owner =
-//     //     AOSQuerier::ado_owner_getter(&deps.querier, &Addr::unchecked(ado_addr.clone()))?;
-//     // let mut res = Response::default();
-//     // if curr_owner == env.contract.address {
-//     //     let msg = AndromedaMsg::Ownership(OwnershipMessage::UpdateOwner {
-//     //         new_owner,
-//     //         expiration: None,
-//     //     });
-//     //     let wasm_msg = wasm_execute(ado_addr, &msg, vec![])?;
-//     //     let sub_msg: SubMsg<Empty> =
-//     //         SubMsg::reply_on_success(wasm_msg, ReplyId::UpdateOwnership as u64);
-//     //     res = res.add_submessage(sub_msg);
-//     // }
-
-//     // Ok(Response::default())
-//     // .set_data(to_json_binary(&ado_addr)?)
-// }
+    Ok(Response::default()
+        .add_message(refund_msg)
+        .add_attribute("action", "refund")
+        .add_attribute("recipient", refund_recipient)
+        .add_attribute("amount_refunded", refund_coin.to_string()))
+}

--- a/contracts/os/andromeda-kernel/src/reply.rs
+++ b/contracts/os/andromeda-kernel/src/reply.rs
@@ -95,7 +95,7 @@ pub fn on_reply_ibc_hooks_packet_send(
 }
 
 // Handles the reply from an ICS20 funds transfer
-pub fn on_reply_transfer_funds(
+pub fn on_reply_ibc_transfer(
     deps: DepsMut,
     _env: Env,
     msg: Reply,

--- a/contracts/os/andromeda-kernel/src/state.rs
+++ b/contracts/os/andromeda-kernel/src/state.rs
@@ -3,6 +3,8 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Coin};
 use cw_storage_plus::{Item, Map};
 
+pub const TRIGGER_KEY: &str = "trigger_key";
+
 #[cw_serde]
 pub struct IBCHooksPacketSendState {
     pub channel_id: String,

--- a/contracts/os/andromeda-kernel/src/state.rs
+++ b/contracts/os/andromeda-kernel/src/state.rs
@@ -1,4 +1,4 @@
-use andromeda_std::os::kernel::ChannelInfo;
+use andromeda_std::os::kernel::{ChannelInfo, Ics20PacketInfo};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Coin};
 use cw_storage_plus::{Item, Map};
@@ -37,8 +37,8 @@ pub const OUTGOING_IBC_PACKETS: Map<(&String, u64), OutgoingPacket> =
     Map::new("outgoing_ibc_packets");
 pub const IBC_FUND_RECOVERY: Map<&Addr, Vec<Coin>> = Map::new("ibc_fund_recovery");
 
-// /// Used to temporarily store the most recent ExecuteMsg to be sent in a reply for ICS20 transfer
-// pub const PENDING_EXECUTE_MSG: Item<Binary> = Item::new("pending_execute_msg");
+/// Used to temporarily store the most recent ExecuteMsg with the corresponding Coin to be sent in a reply for ICS20 transfer
+pub const PENDING_MSG_AND_FUNDS: Item<Ics20PacketInfo> = Item::new("pending_execute_msg");
 
-// /// Used to store sequence/channel against an ExecuteMsg, to be sent after an ack of ICS20
-// pub const CHANNEL_TO_EXECUTE_MSG: Map<String, Binary> = Map::new("channel_to_execute_msg");
+/// Used to store sequence/channel against an ExecuteMsg, to be sent after an ack of ICS20
+pub const CHANNEL_TO_EXECUTE_MSG: Map<String, Ics20PacketInfo> = Map::new("channel_to_execute_msg");

--- a/packages/std/src/common/reply.rs
+++ b/packages/std/src/common/reply.rs
@@ -9,7 +9,7 @@ pub enum ReplyId {
     IBCHooksPacketSend = 103,
     Recovery = 104,
     RegisterUsername = 105,
-    TransferFunds = 106,
+    IBCTransfer = 106,
     // App
     ClaimOwnership = 200,
     AssignApp = 201,

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -41,9 +41,9 @@ pub enum ExecuteMsg {
     Send {
         message: AMPMsg,
     },
-    // TransferReply {
-    //     message: AMPMsg,
-    // },
+    TransferReply {
+        packet_sequence: String,
+    },
     /// Upserts a key address to the kernel, restricted to the owner of the kernel
     UpsertKeyAddress {
         key: String,
@@ -145,4 +145,15 @@ pub enum IbcExecuteMsg {
         username: String,
         address: String,
     },
+}
+
+#[cw_serde]
+pub struct Ics20PacketInfo {
+    // Can be used for refunds in case the first Transfer msg fails
+    pub sender: String,
+    pub recipient: AndrAddr,
+    pub message: Binary,
+    pub funds: Coin,
+    // The restricted wallet will probably already have access to this
+    pub channel: String,
 }

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -41,7 +41,7 @@ pub enum ExecuteMsg {
     Send {
         message: AMPMsg,
     },
-    TransferReply {
+    TriggerRelay {
         packet_sequence: String,
     },
     /// Upserts a key address to the kernel, restricted to the owner of the kernel

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -107,6 +107,9 @@ andromeda-shunting = { path = "../contracts/modules/andromeda-shunting", feature
 andromeda-kernel = { path = "../contracts/os/andromeda-kernel", features = [
     "testing",
 ] }
+andromeda-economics = { path = "../contracts/os/andromeda-economics", features = [
+    "testing",
+] }
 andromeda-ibc-registry = { path = "../contracts/os/andromeda-ibc-registry", features = [
     "testing",
 ] }

--- a/tests-integration/tests/kernel_orch.rs
+++ b/tests-integration/tests/kernel_orch.rs
@@ -5,12 +5,15 @@ use andromeda_data_storage::counter::{
     CounterRestriction, ExecuteMsg as CounterExecuteMsg, GetCurrentAmountResponse,
     InstantiateMsg as CounterInstantiateMsg, State,
 };
+use andromeda_finance::splitter::{
+    AddressPercent, ExecuteMsg as SplitterExecuteMsg, InstantiateMsg as SplitterInstantiateMsg,
+};
 use andromeda_kernel::KernelContract;
 use andromeda_splitter::SplitterContract;
 use andromeda_std::{
     amp::{
         messages::{AMPMsg, AMPMsgConfig},
-        AndrAddr,
+        AndrAddr, Recipient,
     },
     os::{
         self,
@@ -18,7 +21,7 @@ use andromeda_std::{
     },
 };
 use andromeda_vfs::VFSContract;
-use cosmwasm_std::{to_json_binary, Addr, Binary, Uint128};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Decimal, Uint128, WasmQuery};
 use cw_orch::prelude::*;
 use cw_orch_interchain::{prelude::*, types::IbcPacketOutcome, InterchainEnv};
 use ibc_relayer_types::core::ics24_host::identifier::PortId;
@@ -450,68 +453,273 @@ fn test_kernel_ibc_funds_only() {
         .unwrap();
 
     // For testing a successful outcome of the first packet sent out in the tx, you can use:
+    if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
+        // Packet has been successfully acknowledged and decoded, the transaction has gone through correctly
+    } else {
+        panic!("packet timed out");
+        // There was a decode error or the packet timed out
+        // Else the packet timed-out, you may have a relayer error or something is wrong in your application
+    };
+}
+#[test]
+fn test_kernel_ibc_funds_and_execute_msg() {
+    // Here `juno-1` is the chain-id and `juno` is the address prefix for this chain
+    let sender = Addr::unchecked("sender_for_all_chains").into_string();
+
+    let interchain = MockInterchainEnv::new(vec![("juno", &sender), ("osmosis", &sender)]);
+
+    let juno = interchain.chain("juno").unwrap();
+    let osmosis = interchain.chain("osmosis").unwrap();
+
+    juno.set_balance(sender.clone(), vec![Coin::new(100000000000000, "juno")])
+        .unwrap();
+
+    let kernel_juno = KernelContract::new(juno.clone());
+    let vfs_juno = VFSContract::new(juno.clone());
+    let kernel_osmosis = KernelContract::new(osmosis.clone());
+    let counter_osmosis = CounterContract::new(osmosis.clone());
+    let vfs_osmosis = VFSContract::new(osmosis.clone());
+    let adodb_osmosis = ADODBContract::new(osmosis.clone());
+    let splitter_osmosis = SplitterContract::new(osmosis.clone());
+
+    kernel_juno.upload().unwrap();
+    vfs_juno.upload().unwrap();
+    kernel_osmosis.upload().unwrap();
+    counter_osmosis.upload().unwrap();
+    vfs_osmosis.upload().unwrap();
+    adodb_osmosis.upload().unwrap();
+    splitter_osmosis.upload().unwrap();
+
+    let init_msg_juno = &InstantiateMsg {
+        owner: None,
+        chain_name: "juno".to_string(),
+    };
+    let init_msg_osmosis = &InstantiateMsg {
+        owner: None,
+        chain_name: "osmosis".to_string(),
+    };
+
+    kernel_juno.instantiate(init_msg_juno, None, None).unwrap();
+    kernel_osmosis
+        .instantiate(init_msg_osmosis, None, None)
+        .unwrap();
+
+    // Set up channel from juno to osmosis
+    let channel_receipt = interchain
+        .create_contract_channel(&kernel_juno, &kernel_osmosis, "andr-kernel-1", None)
+        .unwrap();
+
+    // After channel creation is complete, we get the channel id, which is necessary for ICA remote execution
+    let juno_channel = channel_receipt
+        .interchain_channel
+        .get_chain("juno")
+        .unwrap()
+        .channel
+        .unwrap();
+
+    // Set up channel from juno to osmosis for ICS20 transfers
+    let channel_receipt = interchain
+        .create_channel(
+            "juno",
+            "osmosis",
+            &PortId::transfer(),
+            &PortId::transfer(),
+            "ics20-1",
+            None,
+        )
+        .unwrap();
+
+    let channel = channel_receipt
+        .interchain_channel
+        .get_ordered_ports_from("juno")
+        .unwrap();
+
+    // After channel creation is complete, we get the channel id, which is necessary for ICA remote execution
+    let _juno_channel_ics20 = channel_receipt
+        .interchain_channel
+        .get_chain("juno")
+        .unwrap()
+        .channel
+        .unwrap();
+
+    vfs_juno
+        .instantiate(
+            &os::vfs::InstantiateMsg {
+                kernel_address: kernel_juno.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    vfs_osmosis
+        .instantiate(
+            &os::vfs::InstantiateMsg {
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    adodb_osmosis
+        .instantiate(
+            &os::adodb::InstantiateMsg {
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    adodb_osmosis
+        .execute(
+            &os::adodb::ExecuteMsg::Publish {
+                code_id: 2,
+                ado_type: "counter".to_string(),
+                action_fees: None,
+                version: "1.0.2".to_string(),
+                publisher: None,
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_juno
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "vfs".to_string(),
+                value: vfs_juno.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_osmosis
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "vfs".to_string(),
+                value: vfs_osmosis.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_osmosis
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "adodb".to_string(),
+                value: adodb_osmosis.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_juno
+        .execute(
+            &ExecuteMsg::AssignChannels {
+                ics20_channel_id: Some(channel.clone().0.channel.unwrap().to_string()),
+                direct_channel_id: Some(juno_channel.to_string()),
+                chain: "osmosis".to_string(),
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_osmosis
+        .execute(
+            &ExecuteMsg::AssignChannels {
+                ics20_channel_id: Some(channel.0.channel.unwrap().to_string()),
+                direct_channel_id: Some(juno_channel.to_string()),
+                chain: "juno".to_string(),
+                kernel_address: kernel_juno.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    let kernel_juno_send_request = kernel_juno
+        .execute(
+            &ExecuteMsg::Send {
+                message: AMPMsg {
+                    recipient: AndrAddr::from_string(format!(
+                        "ibc://osmosis/{}",
+                        kernel_osmosis.address().unwrap()
+                    )),
+                    message: to_json_binary(&SplitterExecuteMsg::Send {}).unwrap(),
+                    funds: vec![Coin {
+                        denom: "juno".to_string(),
+                        amount: Uint128::new(100),
+                    }],
+                    config: AMPMsgConfig {
+                        reply_on: cosmwasm_std::ReplyOn::Always,
+                        exit_at_error: false,
+                        gas_limit: None,
+                        direct: true,
+                        ibc_config: None,
+                    },
+                },
+            },
+            Some(&[Coin {
+                denom: "juno".to_string(),
+                amount: Uint128::new(100),
+            }]),
+        )
+        .unwrap();
+
+    let packet_lifetime = interchain
+        .wait_ibc("juno", kernel_juno_send_request)
+        .unwrap();
+
+    // For testing a successful outcome of the first packet sent out in the tx, you can use:
     if let IbcPacketOutcome::Success { ack, .. } = &packet_lifetime.packets[0].outcome {
-        println!("the ack is: {:?}", ack);
-        // // Let's instantiate a splitter
-        // splitter_osmosis
-        //     .instantiate(
-        //         &SplitterInstantiateMsg {
-        //             recipients: vec![AddressPercent {
-        //                 recipient: Recipient {
-        //                     address: AndrAddr::from_string(sender),
-        //                     msg: None,
-        //                     ibc_recovery_address: None,
-        //                 },
-        //                 percent: Decimal::one(),
-        //             }],
-        //             lock_time: None,
-        //             kernel_address: kernel_osmosis.address().unwrap().into_string(),
-        //             owner: None,
-        //         },
-        //         None,
-        //         None,
-        //     )
-        //     .unwrap();
-        // // Construct an Execute msg from the kernel on juno inteded for the splitter on osmosis
-        // let kernel_juno_splitter_request = kernel_juno
-        //     .execute(
-        //         &ExecuteMsg::TransferReply {
-        //             message: AMPMsg {
-        //                 recipient: AndrAddr::from_string(format!(
-        //                     "ibc://osmosis/{}",
-        //                     splitter_osmosis.address().unwrap()
-        //                 )),
-        //                 message: to_json_binary(&SplitterExecuteMsg::Send {}).unwrap(),
-        //                 funds: vec![Coin {
-        //                     //TODO what is the denom on osmosis after the transfer call?
-        //                     denom: "juno".to_string(),
-        //                     amount: Uint128::new(100),
-        //                 }],
-        //                 config: AMPMsgConfig {
-        //                     reply_on: cosmwasm_std::ReplyOn::Always,
-        //                     exit_at_error: false,
-        //                     gas_limit: None,
-        //                     direct: true,
-        //                     ibc_config: None,
-        //                 },
-        //             },
-        //         },
-        //         None,
-        //     )
-        //     .unwrap();
+        // This section covers the actions that take place after a successful ack from the ICS20 transfer is received
+        // Let's instantiate a splitter
+        splitter_osmosis
+            .instantiate(
+                &SplitterInstantiateMsg {
+                    recipients: vec![AddressPercent {
+                        recipient: Recipient {
+                            address: AndrAddr::from_string(sender),
+                            msg: None,
+                            ibc_recovery_address: None,
+                        },
+                        percent: Decimal::one(),
+                    }],
+                    lock_time: None,
+                    kernel_address: kernel_osmosis.address().unwrap().into_string(),
+                    owner: None,
+                },
+                None,
+                None,
+            )
+            .unwrap();
+        // Construct an Execute msg from the kernel on juno inteded for the splitter on osmosis
+        let kernel_juno_splitter_request = kernel_juno
+            .execute(
+                &ExecuteMsg::TransferReply {
+                    packet_sequence: "1".to_string(),
+                },
+                None,
+            )
+            .unwrap();
 
-        // let packet_lifetime = interchain
-        //     .wait_ibc("juno", kernel_juno_splitter_request)
-        //     .unwrap();
+        let packet_lifetime = interchain
+            .wait_ibc("juno", kernel_juno_splitter_request)
+            .unwrap();
 
-        // // For testing a successful outcome of the first packet sent out in the tx, you can use:
-        // if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
-        //     // Packet has been successfully acknowledged and decoded, the transaction has gone through correctly
-        // } else {
-        //     panic!("packet timed out");
-        //     // There was a decode error or the packet timed out
-        //     // Else the packet timed-out, you may have a relayer error or something is wrong in your application
-        // };
+        // For testing a successful outcome of the first packet sent out in the tx, you can use:
+        if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
+            // Packet has been successfully acknowledged and decoded, the transaction has gone through correctly
+        } else {
+            panic!("packet timed out");
+            // There was a decode error or the packet timed out
+            // Else the packet timed-out, you may have a relayer error or something is wrong in your application
+        };
 
         // Packet has been successfully acknowledged and decoded, the transaction has gone through correctly
     } else {
@@ -520,4 +728,3 @@ fn test_kernel_ibc_funds_only() {
         // Else the packet timed-out, you may have a relayer error or something is wrong in your application
     };
 }
-//

--- a/tests-integration/tests/kernel_orch.rs
+++ b/tests-integration/tests/kernel_orch.rs
@@ -738,10 +738,21 @@ fn test_kernel_ibc_funds_and_execute_msg() {
 
     // For testing a successful outcome of the first packet sent out in the tx, you can use:
     if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
+        // Register trigger address
+        kernel_juno
+            .execute(
+                &ExecuteMsg::UpsertKeyAddress {
+                    key: "trigger_key".to_string(),
+                    value: sender,
+                },
+                None,
+            )
+            .unwrap();
+
         // Construct an Execute msg from the kernel on juno inteded for the splitter on osmosis
         let kernel_juno_splitter_request = kernel_juno
             .execute(
-                &ExecuteMsg::TransferReply {
+                &ExecuteMsg::TriggerRelay {
                     packet_sequence: "1".to_string(),
                 },
                 None,

--- a/tests-integration/tests/kernel_orch.rs
+++ b/tests-integration/tests/kernel_orch.rs
@@ -22,7 +22,7 @@ use andromeda_std::{
     },
 };
 use andromeda_vfs::VFSContract;
-use cosmwasm_std::{to_json_binary, Addr, Binary, Decimal, Uint128, WasmQuery};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Decimal, Uint128};
 use cw_orch::prelude::*;
 use cw_orch_interchain::{prelude::*, types::IbcPacketOutcome, InterchainEnv};
 use ibc_relayer_types::core::ics24_host::identifier::PortId;
@@ -737,7 +737,7 @@ fn test_kernel_ibc_funds_and_execute_msg() {
         .unwrap();
 
     // For testing a successful outcome of the first packet sent out in the tx, you can use:
-    if let IbcPacketOutcome::Success { ack, .. } = &packet_lifetime.packets[0].outcome {
+    if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
         // Construct an Execute msg from the kernel on juno inteded for the splitter on osmosis
         let kernel_juno_splitter_request = kernel_juno
             .execute(


### PR DESCRIPTION
# Motivation
Handles sending an `ExecuteMsg` after receiving a successful ICS20 ack, failed ICS20 transfers refund the original sender. 

# Implementation
Created `IbcExecuteMsg::SendMessageWithFunds` which sends the original message that the sender intended alongside the funds that were transferred using ICS20, the denom of the funds is adjusted on the source chain before being sent to the destination chain. 

# Testing
Tests can be found in `kernel_orch.rs`

# Version Changes
No changes yet

# Notes
`cw-orch` doesn't handle IBC denoms correctly so we have a specific section that only compiles during tests to accommodate that. 

# Future work
Handle unhappy paths
