### PR TITLE
fix: added validation to vesting Instantiate message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix permissioning limited use consumptions and blacklist bypass scenario [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
 - Fix precision issue with vestings claim batch method [(#555)](https://github.com/andromedaprotocol/andromeda-core/pull/555)
 - Fix shunting ado to work with rust version 1.75.0 [(#565)](https://github.com/andromedaprotocol/andromeda-core/pull/565)
-
+- Vesting: Added validation to the instantiation process [(#583)](https://github.com/andromedaprotocol/andromeda-core/pull/583)
 ### Removed
 
 - Schemas are no longer tracked [(#430)](https://github.com/andromedaprotocol/andromeda-core/pull/430)

--- a/contracts/finance/andromeda-vesting/src/contract.rs
+++ b/contracts/finance/andromeda-vesting/src/contract.rs
@@ -35,6 +35,7 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
+    msg.validate(&deps)?;
     let config = Config {
         recipient: msg.recipient,
         denom: msg.denom,

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -1,10 +1,11 @@
 use andromeda_std::{
     amp::Recipient,
     andr_exec, andr_instantiate, andr_query,
-    common::{withdraw::WithdrawalType, Milliseconds},
+    common::{denom::validate_native_denom, withdraw::WithdrawalType, Milliseconds},
+    error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{DepsMut, Uint128};
 
 #[andr_instantiate]
 #[cw_serde]
@@ -90,4 +91,11 @@ pub struct BatchResponse {
     pub release_amount: WithdrawalType,
     /// The time at which the last claim took place in seconds.
     pub last_claimed_release_time: Milliseconds,
+}
+
+impl InstantiateMsg {
+    pub fn validate(&self, deps: &DepsMut) -> Result<(), ContractError> {
+        validate_native_denom(deps.as_ref(), self.denom.clone())?;
+        self.recipient.validate(&deps.as_ref())
+    }
 }


### PR DESCRIPTION
# Motivation

Resolves https://linear.app/andromedaprot/issue/SUPP-141/check-denom-validation-on-contract

# Implementation

Added `validate` trait to `InstantiateMsg` in `vesting` package.

# Testing

Added test cases with invalid denom and invalid recipient.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced various Application Domain Objects (ADOs) including Validator Staking ADO and multiple storage ADOs.
	- Added a BuyNow option for auctions and enhanced reward token management in staking.
	- Implemented Denom Validation for rates and IBC Registry ADO.

- **Bug Fixes**
	- Improved lock time calculations in the Splitter and Conditional Splitter.
	- Added validation steps for instantiation and batch operations.

- **Tests**
	- Expanded the test suite to cover additional scenarios for instantiation, batch creation, and claiming logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->