### PR TITLE
feat: Marketplace & Auction Adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include ADOBase Version in Schema  [(#574)](https://github.com/andromedaprotocol/andromeda-core/pull/574)
 - Added Kernel ICS20 Transfer with Optional ExecuteMsg [(#577)](https://github.com/andromedaprotocol/andromeda-core/pull/577)
 - Added IBC Denom Wrap/Unwrap [(#579)](https://github.com/andromedaprotocol/andromeda-core/pull/579)
+- Auction & Marketplace: Added Multiple Authorized Addresses During Init, Add and Remove Authorized Addresses [(#589)](https://github.com/andromedaprotocol/andromeda-core/pull/589)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-marketplace"
-version = "2.1.4"
+version = "2.2.4"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.1.4"
+version = "2.2.4"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.1.4"
+version = "2.2.4"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -79,15 +79,17 @@ pub fn instantiate(
             )?;
         }
     }
-    if let Some(authorized_cw20_address) = msg.authorized_cw20_address {
-        let addr = authorized_cw20_address.get_raw_address(&deps.as_ref())?;
-        ADOContract::default().permission_action(SEND_CW20_ACTION, deps.storage)?;
-        ADOContract::set_permission(
-            deps.storage,
-            SEND_CW20_ACTION,
-            addr,
-            Permission::Local(LocalPermission::Whitelisted(None)),
-        )?;
+    if let Some(authorized_cw20_addresses) = msg.authorized_cw20_addresses {
+        for cw20_address in authorized_cw20_addresses {
+            let addr = cw20_address.get_raw_address(&deps.as_ref())?;
+            ADOContract::default().permission_action(SEND_CW20_ACTION, deps.storage)?;
+            ADOContract::set_permission(
+                deps.storage,
+                SEND_CW20_ACTION,
+                addr,
+                Permission::Local(LocalPermission::Whitelisted(None)),
+            )?;
+        }
     }
 
     Ok(resp)

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -2,10 +2,9 @@ use crate::state::{
     auction_infos, read_auction_infos, read_bids, BIDS, NEXT_AUCTION_ID, TOKEN_AUCTION_STATE,
 };
 use andromeda_non_fungible_tokens::auction::{
-    validate_auction, AuctionIdsResponse, AuctionInfo, AuctionStateResponse,
-    AuthorizedAddressesResponse, Bid, BidsResponse, Cw20HookMsg, Cw721HookMsg, ExecuteMsg,
-    InstantiateMsg, IsCancelledResponse, IsClaimedResponse, IsClosedResponse, QueryMsg,
-    TokenAuctionState,
+    validate_auction, AuctionIdsResponse, AuctionInfo, AuctionStateResponse, Bid, BidsResponse,
+    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, IsCancelledResponse, IsClaimedResponse,
+    IsClosedResponse, QueryMsg, TokenAuctionState,
 };
 use andromeda_std::{
     ado_base::{
@@ -17,7 +16,7 @@ use andromeda_std::{
         actions::call_action,
         denom::{
             execute_authorize_contract, execute_deauthorize_contract, validate_native_denom, Asset,
-            PermissionAction, SEND_CW20_ACTION,
+            AuthorizedAddressesResponse, PermissionAction, SEND_CW20_ACTION,
         },
         encode_binary,
         expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -12,10 +12,13 @@ use andromeda_std::{
         permissioning::{LocalPermission, Permission},
         InstantiateMsg as BaseInstantiateMsg, MigrateMsg,
     },
-    amp::{AndrAddr, Recipient},
+    amp::Recipient,
     common::{
         actions::call_action,
-        denom::{validate_native_denom, Asset, SEND_CW20_ACTION},
+        denom::{
+            execute_authorize_contract, execute_deauthorize_contract, validate_native_denom, Asset,
+            PermissionAction, SEND_CW20_ACTION,
+        },
         encode_binary,
         expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},
         Funds, Milliseconds, OrderBy,
@@ -159,11 +162,13 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
             token_id,
             token_address,
         } => execute_claim(ctx, token_id, token_address, action),
-        ExecuteMsg::AuthorizeTokenContract { addr, expiration } => {
-            execute_authorize_token_contract(ctx.deps, ctx.info, addr, expiration)
-        }
-        ExecuteMsg::DeauthorizeTokenContract { addr } => {
-            execute_deauthorize_token_contract(ctx.deps, ctx.info, addr)
+        ExecuteMsg::AuthorizeContract {
+            action,
+            addr,
+            expiration,
+        } => execute_authorize_contract(ctx.deps, ctx.info, action, addr, expiration),
+        ExecuteMsg::DeauthorizeContract { action, addr } => {
+            execute_deauthorize_contract(ctx.deps, ctx.info, action, addr)
         }
         _ => ADOContract::default().execute(ctx, msg),
     }?;
@@ -1109,57 +1114,6 @@ fn execute_claim(
     Ok(resp)
 }
 
-fn execute_authorize_token_contract(
-    deps: DepsMut,
-    info: MessageInfo,
-    token_address: AndrAddr,
-    expiration: Option<Expiry>,
-) -> Result<Response, ContractError> {
-    let contract = ADOContract::default();
-    let addr = token_address.get_raw_address(&deps.as_ref())?;
-    ensure!(
-        contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {}
-    );
-    let permission = if let Some(expiration) = expiration {
-        Permission::Local(LocalPermission::Whitelisted(Some(expiration)))
-    } else {
-        Permission::Local(LocalPermission::Whitelisted(None))
-    };
-    ADOContract::set_permission(
-        deps.storage,
-        SEND_NFT_ACTION,
-        addr.to_string(),
-        permission.clone(),
-    )?;
-
-    Ok(Response::default().add_attributes(vec![
-        attr("action", "authorize_token_contract"),
-        attr("token_address", addr),
-        attr("permission", permission.to_string()),
-    ]))
-}
-
-fn execute_deauthorize_token_contract(
-    deps: DepsMut,
-    info: MessageInfo,
-    token_address: AndrAddr,
-) -> Result<Response, ContractError> {
-    let contract = ADOContract::default();
-    let addr = token_address.get_raw_address(&deps.as_ref())?;
-    ensure!(
-        contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {}
-    );
-
-    ADOContract::remove_permission(deps.storage, SEND_NFT_ACTION, addr.to_string())?;
-
-    Ok(Response::default().add_attributes(vec![
-        attr("action", "deauthorize_token_contract"),
-        attr("token_address", addr),
-    ]))
-}
-
 fn purchase_token(
     deps: Deps,
     _info: &MessageInfo,
@@ -1296,11 +1250,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             token_address,
         } => encode_binary(&query_is_closed(deps, env, token_id, token_address)?),
         QueryMsg::AuthorizedAddresses {
+            action,
             start_after,
             limit,
             order_by,
         } => encode_binary(&query_authorized_addresses(
             deps,
+            action,
             start_after,
             limit,
             order_by,
@@ -1443,13 +1399,14 @@ fn query_owner_of(
 
 fn query_authorized_addresses(
     deps: Deps,
+    action: PermissionAction,
     start_after: Option<String>,
     limit: Option<u32>,
     order_by: Option<OrderBy>,
 ) -> Result<AuthorizedAddressesResponse, ContractError> {
     let addresses = ADOContract::default().query_permissioned_actors(
         deps,
-        SEND_NFT_ACTION,
+        action.as_str(),
         start_after,
         limit,
         order_by,

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -10,7 +10,7 @@ use andromeda_std::ado_base::rates::{Rate, RatesMessage};
 use andromeda_std::amp::messages::AMPPkt;
 use andromeda_std::amp::AndrAddr;
 use andromeda_std::amp::Recipient;
-use andromeda_std::common::denom::Asset;
+use andromeda_std::common::denom::{Asset, PermissionAction};
 use andromeda_std::common::expiration::Expiry;
 use andromeda_testing::mock::MockApp;
 use andromeda_testing::{
@@ -209,7 +209,8 @@ pub fn mock_authorize_token_address(
     token_address: impl Into<String>,
     expiration: Option<Expiry>,
 ) -> ExecuteMsg {
-    ExecuteMsg::AuthorizeTokenContract {
+    ExecuteMsg::AuthorizeContract {
+        action: PermissionAction::SendNft,
         addr: AndrAddr::from_string(token_address.into()),
         expiration,
     }

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -168,13 +168,13 @@ pub fn mock_auction_instantiate_msg(
     kernel_address: impl Into<String>,
     owner: Option<String>,
     authorized_token_addresses: Option<Vec<AndrAddr>>,
-    authorized_cw20_address: Option<AndrAddr>,
+    authorized_cw20_addresses: Option<Vec<AndrAddr>>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         kernel_address: kernel_address.into(),
         owner,
         authorized_token_addresses,
-        authorized_cw20_address,
+        authorized_cw20_addresses,
     }
 }
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -47,7 +47,7 @@ fn init(deps: DepsMut) -> Response {
         owner: None,
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         authorized_token_addresses: Some(vec![AndrAddr::from_string(MOCK_TOKEN_ADDR)]),
-        authorized_cw20_address: None,
+        authorized_cw20_addresses: None,
     };
 
     let info = mock_info("owner", &[]);
@@ -59,7 +59,7 @@ fn init_cw20(deps: DepsMut, _modules: Option<Vec<Module>>) -> Response {
         owner: None,
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         authorized_token_addresses: Some(vec![AndrAddr::from_string(MOCK_TOKEN_ADDR)]),
-        authorized_cw20_address: Some(AndrAddr::from_string(MOCK_CW20_CONTRACT)),
+        authorized_cw20_addresses: Some(vec![AndrAddr::from_string(MOCK_CW20_CONTRACT)]),
     };
 
     let info = mock_info("owner", &[]);

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-marketplace"
-version = "2.1.4"
+version = "2.2.4"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -3,12 +3,9 @@ use crate::state::{
 };
 use std::vec;
 
-use andromeda_non_fungible_tokens::{
-    auction::AuthorizedAddressesResponse,
-    marketplace::{
-        Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, SaleIdsResponse,
-        SaleStateResponse, Status,
-    },
+use andromeda_non_fungible_tokens::marketplace::{
+    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, SaleIdsResponse,
+    SaleStateResponse, Status,
 };
 use andromeda_std::{
     ado_base::{
@@ -21,8 +18,8 @@ use andromeda_std::{
         actions::call_action,
         context::ExecuteContext,
         denom::{
-            execute_authorize_contract, execute_deauthorize_contract, Asset, PermissionAction,
-            SEND_CW20_ACTION, SEND_NFT_ACTION,
+            execute_authorize_contract, execute_deauthorize_contract, Asset,
+            AuthorizedAddressesResponse, PermissionAction, SEND_CW20_ACTION, SEND_NFT_ACTION,
         },
         encode_binary,
         expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -1,6 +1,5 @@
-use andromeda_non_fungible_tokens::{
-    auction::AuthorizedAddressesResponse,
-    marketplace::{Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, Status},
+use andromeda_non_fungible_tokens::marketplace::{
+    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, Status,
 };
 use andromeda_std::{
     ado_base::{
@@ -10,7 +9,9 @@ use andromeda_std::{
     ado_contract::ADOContract,
     amp::{AndrAddr, Recipient},
     common::{
-        denom::{Asset, PermissionAction, SEND_CW20_ACTION, SEND_NFT_ACTION},
+        denom::{
+            Asset, AuthorizedAddressesResponse, PermissionAction, SEND_CW20_ACTION, SEND_NFT_ACTION,
+        },
         encode_binary,
         expiration::{expiration_from_milliseconds, Expiry, MILLISECONDS_TO_NANOSECONDS_RATIO},
         reply::ReplyId,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -1134,7 +1134,7 @@ fn test_query_authorized_addresses() {
         order_by: None,
     };
     let cw20_res: AuthorizedAddressesResponse =
-        from_json(&query(deps.as_ref(), mock_env(), cw20_query).unwrap()).unwrap();
+        from_json(query(deps.as_ref(), mock_env(), cw20_query).unwrap()).unwrap();
     assert_eq!(
         cw20_res.addresses,
         vec!["cw20_contract1".to_string(), "cw20_contract2".to_string()]
@@ -1148,7 +1148,7 @@ fn test_query_authorized_addresses() {
         order_by: None,
     };
     let nft_res: AuthorizedAddressesResponse =
-        from_json(&query(deps.as_ref(), mock_env(), nft_query).unwrap()).unwrap();
+        from_json(query(deps.as_ref(), mock_env(), nft_query).unwrap()).unwrap();
     assert_eq!(
         nft_res.addresses,
         vec!["nft_contract1".to_string(), "nft_contract2".to_string()]

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -1167,13 +1167,13 @@ fn test_authorize_token_contract() {
 
     let owner_info = mock_info("owner", &[]);
     let token_address = AndrAddr::from_string("nft_contract");
-    let expiration = Some(Expiry::FromNow(Milliseconds(100)));
+    let expiration = Expiry::FromNow(Milliseconds(100));
 
     // Test successful authorization
     let msg = ExecuteMsg::AuthorizeContract {
         action: PermissionAction::SendNft,
         addr: token_address.clone(),
-        expiration: expiration.clone(),
+        expiration: Some(expiration.clone()),
     };
     let res = execute(deps.as_mut(), mock_env(), owner_info.clone(), msg).unwrap();
     assert_eq!(
@@ -1181,7 +1181,7 @@ fn test_authorize_token_contract() {
         vec![
             attr("action", "authorize_contract"),
             attr("address", "nft_contract"),
-            attr("permission", format!("whitelisted:{}", expiration.unwrap())),
+            attr("permission", format!("whitelisted:{}", expiration)),
         ]
     );
 

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -14,7 +14,7 @@ use cw721::{Cw721ReceiveMsg, Expiration};
 #[cw_serde]
 pub struct InstantiateMsg {
     pub authorized_token_addresses: Option<Vec<AndrAddr>>,
-    pub authorized_cw20_address: Option<AndrAddr>,
+    pub authorized_cw20_addresses: Option<Vec<AndrAddr>>,
 }
 
 #[andr_exec]

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -1,5 +1,5 @@
 use andromeda_std::amp::{AndrAddr, Recipient};
-use andromeda_std::common::denom::{Asset, PermissionAction};
+use andromeda_std::common::denom::{Asset, AuthorizedAddressesResponse, PermissionAction};
 use andromeda_std::common::expiration::Expiry;
 use andromeda_std::common::{MillisecondsExpiration, OrderBy};
 use andromeda_std::error::ContractError;
@@ -284,11 +284,6 @@ pub struct AuctionStateResponse {
     pub is_cancelled: bool,
     pub owner: String,
     pub recipient: Option<Recipient>,
-}
-
-#[cw_serde]
-pub struct AuthorizedAddressesResponse {
-    pub addresses: Vec<String>,
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -1,5 +1,5 @@
 use andromeda_std::amp::{AndrAddr, Recipient};
-use andromeda_std::common::denom::Asset;
+use andromeda_std::common::denom::{Asset, PermissionAction};
 use andromeda_std::common::expiration::Expiry;
 use andromeda_std::common::{MillisecondsExpiration, OrderBy};
 use andromeda_std::error::ContractError;
@@ -54,12 +54,14 @@ pub enum ExecuteMsg {
         token_address: String,
     },
     /// Restricted to owner
-    AuthorizeTokenContract {
+    AuthorizeContract {
+        action: PermissionAction,
         addr: AndrAddr,
         expiration: Option<Expiry>,
     },
     /// Restricted to owner
-    DeauthorizeTokenContract {
+    DeauthorizeContract {
+        action: PermissionAction,
         addr: AndrAddr,
     },
 }
@@ -123,6 +125,7 @@ pub enum QueryMsg {
     /// Gets all of the authorized addresses for the auction
     #[returns(AuthorizedAddressesResponse)]
     AuthorizedAddresses {
+        action: PermissionAction,
         start_after: Option<String>,
         limit: Option<u32>,
         order_by: Option<OrderBy>,

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -1,14 +1,15 @@
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
     andr_exec, andr_instantiate, andr_query,
-    common::expiration::Expiry,
-    common::{denom::Asset, MillisecondsDuration},
+    common::{denom::Asset, expiration::Expiry, MillisecondsDuration, OrderBy},
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw20::Cw20ReceiveMsg;
 use cw721::{Cw721ReceiveMsg, Expiration};
 use std::fmt::{Display, Formatter, Result};
+
+use crate::auction::AuthorizedAddressesResponse;
 
 #[andr_instantiate]
 #[cw_serde]
@@ -123,6 +124,13 @@ pub enum QueryMsg {
         token_address: String,
         start_after: Option<String>,
         limit: Option<u64>,
+    },
+    #[returns(AuthorizedAddressesResponse)]
+    AuthorizedAddresses {
+        action: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+        order_by: Option<OrderBy>,
     },
 }
 

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -50,6 +50,16 @@ pub enum ExecuteMsg {
     DeauthorizeCw20Contract {
         addr: AndrAddr,
     },
+
+    /// Restricted to owner
+    AuthorizeTokenContract {
+        addr: AndrAddr,
+        expiration: Option<Expiry>,
+    },
+    /// Restricted to owner
+    DeauthorizeTokenContract {
+        addr: AndrAddr,
+    },
 }
 
 #[cw_serde]

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -14,7 +14,7 @@ use std::fmt::{Display, Formatter, Result};
 #[cw_serde]
 #[serde(rename_all = "snake_case")]
 pub struct InstantiateMsg {
-    pub authorized_cw20_address: Option<AndrAddr>,
+    pub authorized_cw20_addresses: Option<Vec<AndrAddr>>,
     pub authorized_token_addresses: Option<Vec<AndrAddr>>,
 }
 
@@ -39,6 +39,15 @@ pub enum ExecuteMsg {
     CancelSale {
         token_id: String,
         token_address: String,
+    },
+    /// Restricted to owner
+    AuthorizeCw20Contract {
+        addr: AndrAddr,
+        expiration: Option<Expiry>,
+    },
+    /// Restricted to owner
+    DeauthorizeCw20Contract {
+        addr: AndrAddr,
     },
 }
 

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -1,7 +1,11 @@
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
     andr_exec, andr_instantiate, andr_query,
-    common::{denom::Asset, expiration::Expiry, MillisecondsDuration, OrderBy},
+    common::{
+        denom::{Asset, PermissionAction},
+        expiration::Expiry,
+        MillisecondsDuration, OrderBy,
+    },
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
@@ -42,22 +46,14 @@ pub enum ExecuteMsg {
         token_address: String,
     },
     /// Restricted to owner
-    AuthorizeCw20Contract {
+    AuthorizeContract {
+        action: PermissionAction,
         addr: AndrAddr,
         expiration: Option<Expiry>,
     },
     /// Restricted to owner
-    DeauthorizeCw20Contract {
-        addr: AndrAddr,
-    },
-
-    /// Restricted to owner
-    AuthorizeTokenContract {
-        addr: AndrAddr,
-        expiration: Option<Expiry>,
-    },
-    /// Restricted to owner
-    DeauthorizeTokenContract {
+    DeauthorizeContract {
+        action: PermissionAction,
         addr: AndrAddr,
     },
 }
@@ -137,7 +133,7 @@ pub enum QueryMsg {
     },
     #[returns(AuthorizedAddressesResponse)]
     AuthorizedAddresses {
-        action: String,
+        action: PermissionAction,
         start_after: Option<String>,
         limit: Option<u32>,
         order_by: Option<OrderBy>,

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -2,7 +2,7 @@ use andromeda_std::{
     amp::{AndrAddr, Recipient},
     andr_exec, andr_instantiate, andr_query,
     common::{
-        denom::{Asset, PermissionAction},
+        denom::{Asset, AuthorizedAddressesResponse, PermissionAction},
         expiration::Expiry,
         MillisecondsDuration, OrderBy,
     },
@@ -12,8 +12,6 @@ use cosmwasm_std::Uint128;
 use cw20::Cw20ReceiveMsg;
 use cw721::{Cw721ReceiveMsg, Expiration};
 use std::fmt::{Display, Formatter, Result};
-
-use crate::auction::AuthorizedAddressesResponse;
 
 #[andr_instantiate]
 #[cw_serde]

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -1,12 +1,19 @@
 use std::fmt::{Display, Formatter, Result as StdResult};
 
-use crate::{ado_contract::ADOContract, amp::AndrAddr, error::ContractError};
+use crate::{
+    ado_base::permissioning::{LocalPermission, Permission},
+    ado_contract::ADOContract,
+    amp::AndrAddr,
+    error::ContractError,
+};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    coin, ensure, to_json_binary, wasm_execute, BankMsg, Deps, DepsMut, Env, QueryRequest, SubMsg,
-    Uint128, WasmQuery,
+    attr, coin, ensure, to_json_binary, wasm_execute, BankMsg, Deps, DepsMut, Env, MessageInfo,
+    QueryRequest, Response, SubMsg, Uint128, WasmQuery,
 };
 use cw20::{Cw20ExecuteMsg, Cw20QueryMsg, TokenInfoResponse};
+
+use super::expiration::Expiry;
 pub const SEND_CW20_ACTION: &str = "SEND_CW20";
 pub const SEND_NFT_ACTION: &str = "SEND_NFT";
 
@@ -110,4 +117,116 @@ pub fn validate_native_denom(deps: Deps, denom: String) -> Result<(), ContractEr
     );
 
     Ok(())
+}
+
+pub fn execute_authorize_contract(
+    deps: DepsMut,
+    info: MessageInfo,
+    action: PermissionAction,
+    address: AndrAddr,
+    expiration: Option<Expiry>,
+) -> Result<Response, ContractError> {
+    let contract = ADOContract::default();
+    ensure!(
+        contract.is_contract_owner(deps.storage, info.sender.as_str())?,
+        ContractError::Unauthorized {}
+    );
+
+    let permission = expiration.map_or(
+        Permission::Local(LocalPermission::Whitelisted(None)),
+        |expiration| Permission::Local(LocalPermission::Whitelisted(Some(expiration))),
+    );
+
+    ADOContract::set_permission(
+        deps.storage,
+        action.as_str(),
+        address.to_string(),
+        permission.clone(),
+    )?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "authorize_contract"),
+        attr("address", address),
+        attr("permission", permission.to_string()),
+    ]))
+}
+
+pub fn execute_deauthorize_contract(
+    deps: DepsMut,
+    info: MessageInfo,
+    action: PermissionAction,
+    address: AndrAddr,
+) -> Result<Response, ContractError> {
+    let contract = ADOContract::default();
+    ensure!(
+        contract.is_contract_owner(deps.storage, info.sender.as_str())?,
+        ContractError::Unauthorized {}
+    );
+
+    let raw_address = address.get_raw_address(&deps.as_ref())?;
+
+    ADOContract::remove_permission(deps.storage, action.as_str(), raw_address.to_string())?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "deauthorize_contract"),
+        attr("address", raw_address),
+        attr("deauthorized_action", action.as_str()),
+    ]))
+}
+
+#[cw_serde]
+pub enum PermissionAction {
+    SendCw20,
+    SendNft,
+}
+
+impl PermissionAction {
+    pub fn as_str(&self) -> &str {
+        match self {
+            PermissionAction::SendCw20 => SEND_CW20_ACTION,
+            PermissionAction::SendNft => SEND_NFT_ACTION,
+        }
+    }
+}
+
+impl TryFrom<String> for PermissionAction {
+    type Error = ContractError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            SEND_CW20_ACTION => Ok(PermissionAction::SendCw20),
+            SEND_NFT_ACTION => Ok(PermissionAction::SendNft),
+            _ => Err(ContractError::InvalidAction { action: value }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_permission_action() {
+        // Test as_str() method
+        assert_eq!(PermissionAction::SendCw20.as_str(), SEND_CW20_ACTION);
+        assert_eq!(PermissionAction::SendNft.as_str(), SEND_NFT_ACTION);
+        // Test TryFrom<String> implementation
+        assert_eq!(
+            PermissionAction::try_from(SEND_CW20_ACTION.to_string()),
+            Ok(PermissionAction::SendCw20)
+        );
+        assert_eq!(
+            PermissionAction::try_from(SEND_NFT_ACTION.to_string()),
+            Ok(PermissionAction::SendNft)
+        );
+
+        // Test invalid action
+        let invalid_action = "INVALID_ACTION".to_string();
+        assert_eq!(
+            PermissionAction::try_from(invalid_action.clone()),
+            Err(ContractError::InvalidAction {
+                action: invalid_action
+            })
+        );
+    }
 }

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -124,6 +124,27 @@ pub struct AuthorizedAddressesResponse {
     pub addresses: Vec<String>,
 }
 
+pub fn authorize_addresses(
+    deps: &mut DepsMut,
+    action: &str,
+    addresses: Vec<AndrAddr>,
+) -> Result<(), ContractError> {
+    if !addresses.is_empty() {
+        ADOContract::default().permission_action(action, deps.storage)?;
+    }
+
+    for address in addresses {
+        let addr = address.get_raw_address(&deps.as_ref())?;
+        ADOContract::set_permission(
+            deps.storage,
+            action,
+            addr.to_string(),
+            Permission::Local(LocalPermission::Whitelisted(None)),
+        )?;
+    }
+    Ok(())
+}
+
 pub fn execute_authorize_contract(
     deps: DepsMut,
     info: MessageInfo,

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -119,6 +119,11 @@ pub fn validate_native_denom(deps: Deps, denom: String) -> Result<(), ContractEr
     Ok(())
 }
 
+#[cw_serde]
+pub struct AuthorizedAddressesResponse {
+    pub addresses: Vec<String>,
+}
+
 pub fn execute_authorize_contract(
     deps: DepsMut,
     info: MessageInfo,

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -87,6 +87,9 @@ pub enum ContractError {
     #[error("InvalidDelegation")]
     InvalidDelegation {},
 
+    #[error("Invalid action: {action}. Expected either SEND_NFT or SEND_CW20")]
+    InvalidAction { action: String },
+
     #[error("RewardTooLow")]
     RewardTooLow {},
 

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -529,7 +529,10 @@ fn test_auction_app_cw20_restricted() {
             "./{}",
             cw721_component.name
         ))]),
-        Some(AndrAddr::from_string(format!("./{}", cw20_component.name))),
+        Some(vec![AndrAddr::from_string(format!(
+            "./{}",
+            cw20_component.name
+        ))]),
     );
     let auction_component = AppComponent::new(
         "auction".to_string(),


### PR DESCRIPTION
# Motivation
Closes #585 , #586 and #587

# Implementation
Implement ability to add or remove authorized cw20 and cw721 addresses, allow multiple cw20 addresses to be set during instantiation for marketplace and auction, query function for those addresses.

# Testing
Unit tests

# Version Changes
Marketplace `"2.1.4"` -> `"2.2.4"`
Auction `"2.1.4"` -> `"2.2.4"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced contract functionality to authorize multiple CW20 and token contracts.
	- Added new methods for authorizing and deauthorizing contracts, along with querying authorized addresses.
	- Updated initialization to support multiple authorized CW20 addresses.
	- Introduced a new `PermissionAction` enum for managing contract permissions.
	- Added a bidding mechanism with permissioning for CW20 tokens in auction tests.

- **Bug Fixes**
	- Improved error handling for unauthorized access attempts during contract operations.
	- Added a new error variant to handle invalid actions.

- **Tests**
	- Introduced comprehensive test cases for new authorization features and permission management.
	- Updated existing tests to reflect changes in CW20 address handling and auction logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->