### PR TITLE
ref: Expiry in Crowdfund

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.0.4"
+version = "2.1.4"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.0.4"
+version = "2.1.4"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/mock.rs
@@ -5,7 +5,7 @@ use andromeda_non_fungible_tokens::crowdfund::{
     CampaignConfig, CampaignSummaryResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg,
     PresaleTierOrder, QueryMsg, SimpleTierOrder, Tier, TierMetaData,
 };
-use andromeda_std::common::Milliseconds;
+use andromeda_std::common::expiration::Expiry;
 use andromeda_testing::{
     mock::MockApp,
     mock_ado,
@@ -60,8 +60,8 @@ impl MockCrowdfund {
         &self,
         sender: Addr,
         app: &mut MockApp,
-        start_time: Option<Milliseconds>,
-        end_time: Milliseconds,
+        start_time: Option<Expiry>,
+        end_time: Expiry,
         presale: Option<Vec<PresaleTierOrder>>,
     ) -> ExecuteResult {
         let msg = mock_start_campaign_msg(start_time, end_time, presale);
@@ -138,8 +138,8 @@ pub fn mock_add_tier_msg(
 }
 
 pub fn mock_start_campaign_msg(
-    start_time: Option<Milliseconds>,
-    end_time: Milliseconds,
+    start_time: Option<Expiry>,
+    end_time: Expiry,
     presale: Option<Vec<PresaleTierOrder>>,
 ) -> ExecuteMsg {
     ExecuteMsg::StartCampaign {

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -5,7 +5,7 @@ use andromeda_non_fungible_tokens::{
     },
     cw721::{ExecuteMsg as Cw721ExecuteMsg, TokenExtension},
 };
-
+use andromeda_std::common::expiration::Expiry;
 use andromeda_std::{
     common::{reply::ReplyId, MillisecondsExpiration},
     error::ContractError,
@@ -99,7 +99,7 @@ mod test {
     };
     use andromeda_std::{
         amp::{messages::AMPPkt, AndrAddr, Recipient},
-        common::{denom::Asset, encode_binary},
+        common::{denom::Asset, encode_binary, Milliseconds},
         testing::mock_querier::MOCK_CW20_CONTRACT,
     };
     use cosmwasm_std::{coin, coins, testing::MOCK_CONTRACT_ADDR, wasm_execute, BankMsg, Coin};
@@ -519,8 +519,8 @@ mod test {
         name: String,
         tiers: Vec<Tier>,
         presale: Option<Vec<PresaleTierOrder>>,
-        start_time: Option<MillisecondsExpiration>,
-        end_time: MillisecondsExpiration,
+        start_time: Option<Expiry>,
+        end_time: Expiry,
         expected_res: Result<Response, ContractError>,
         payee: String,
     }
@@ -547,13 +547,13 @@ mod test {
                 tiers: mock_campaign_tiers(),
                 presale: Some(valid_presale.clone()),
                 start_time: None,
-                end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() + 100),
+                end_time: Expiry::FromNow(Milliseconds::from_seconds(100)),
                 payee: MOCK_DEFAULT_OWNER.to_string(),
                 expected_res: Ok(Response::new()
                     .add_attribute("action", "start_campaign")
                     .add_attribute(
                         "end_time",
-                        MillisecondsExpiration::from_seconds(env.block.time.seconds() + 100),
+                        Expiry::FromNow(Milliseconds::from_seconds(100)).to_string(),
                     )
                     .add_submessage(SubMsg::reply_on_error(
                         CosmosMsg::Wasm(WasmMsg::Execute {
@@ -573,7 +573,7 @@ mod test {
                 tiers: mock_campaign_tiers(),
                 presale: Some(valid_presale.clone()),
                 start_time: None,
-                end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() + 100),
+                end_time: Expiry::FromNow(Milliseconds::from_seconds(100)),
                 payee: "owner1".to_string(),
                 expected_res: Err(ContractError::Unauthorized {}),
             },
@@ -582,7 +582,7 @@ mod test {
                 tiers: mock_campaign_tiers(),
                 presale: Some(invalid_presale.clone()),
                 start_time: None,
-                end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() + 100),
+                end_time: Expiry::FromNow(Milliseconds::from_seconds(100)),
                 payee: MOCK_DEFAULT_OWNER.to_string(),
                 expected_res: Err(ContractError::InvalidTier {
                     operation: "set_tier_orders".to_string(),
@@ -594,18 +594,16 @@ mod test {
                 tiers: mock_campaign_tiers(),
                 presale: Some(valid_presale.clone()),
                 start_time: None,
-                end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() - 100),
+                end_time: Expiry::AtTime(Milliseconds::from_seconds(0)),
                 payee: MOCK_DEFAULT_OWNER.to_string(),
-                expected_res: Err(ContractError::StartTimeAfterEndTime {}),
+                expected_res: Err(ContractError::InvalidExpiration {}),
             },
             StartCampaignTestCase {
                 name: "start_campaign with invalid start_time".to_string(),
                 tiers: mock_campaign_tiers(),
                 presale: Some(valid_presale.clone()),
-                start_time: Some(MillisecondsExpiration::from_seconds(
-                    env.block.time.seconds() + 1000,
-                )),
-                end_time: MillisecondsExpiration::from_seconds(env.block.time.seconds() + 500),
+                start_time: Some(Expiry::FromNow(Milliseconds::from_seconds(10000000))),
+                end_time: Expiry::FromNow(Milliseconds::from_seconds(500)),
                 payee: MOCK_DEFAULT_OWNER.to_string(),
                 expected_res: Err(ContractError::StartTimeAfterEndTime {}),
             },
@@ -621,8 +619,8 @@ mod test {
             let info = mock_info(&test.payee, &[]);
 
             let msg = ExecuteMsg::StartCampaign {
-                start_time: test.start_time,
-                end_time: test.end_time,
+                start_time: test.start_time.clone(),
+                end_time: test.end_time.clone(),
                 presale: test.presale.clone(),
             };
 
@@ -632,11 +630,11 @@ mod test {
             if res.is_ok() {
                 assert_eq!(
                     CAMPAIGN_DURATION.load(&deps.storage).unwrap().start_time,
-                    test.start_time
+                    test.start_time.map(|exp| exp.get_time(&env.block))
                 );
                 assert_eq!(
                     CAMPAIGN_DURATION.load(&deps.storage).unwrap().end_time,
-                    test.end_time
+                    test.end_time.get_time(&env.block)
                 );
                 assert_eq!(
                     CAMPAIGN_STAGE.load(&deps.storage).unwrap(),

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -1,6 +1,7 @@
 use andromeda_std::amp::addresses::AndrAddr;
 use andromeda_std::amp::Recipient;
 use andromeda_std::common::denom::Asset;
+use andromeda_std::common::expiration::Expiry;
 use andromeda_std::common::{MillisecondsExpiration, OrderBy};
 use andromeda_std::error::ContractError;
 use andromeda_std::{andr_exec, andr_instantiate, andr_query};
@@ -30,8 +31,8 @@ pub enum ExecuteMsg {
     RemoveTier { level: Uint64 },
     /// Start the campaign
     StartCampaign {
-        start_time: Option<MillisecondsExpiration>,
-        end_time: MillisecondsExpiration,
+        start_time: Option<Expiry>,
+        end_time: Expiry,
         presale: Option<Vec<PresaleTierOrder>>,
     },
     /// Purchase tiers

--- a/tests-integration/tests/crowdfund_app.rs
+++ b/tests-integration/tests/crowdfund_app.rs
@@ -17,7 +17,7 @@ use andromeda_splitter::mock::{
 };
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
-    common::{denom::Asset, encode_binary, Milliseconds},
+    common::{denom::Asset, encode_binary, expiration::Expiry, Milliseconds},
 };
 use andromeda_testing::{
     mock::{mock_app, MockApp},
@@ -265,7 +265,7 @@ fn test_successful_crowdfund_app_native(setup: TestCase) {
         owner.clone(),
         &mut router,
         start_time,
-        end_time,
+        Expiry::AtTime(end_time),
         Some(presale),
     );
     let summary = crowdfund.query_campaign_summary(&mut router);
@@ -357,7 +357,7 @@ fn test_crowdfund_app_native_discard(
         owner.clone(),
         &mut router,
         start_time,
-        end_time,
+        Expiry::AtTime(end_time),
         Some(presale),
     );
     let summary = crowdfund.query_campaign_summary(&mut router);
@@ -460,7 +460,7 @@ fn test_crowdfund_app_native_with_ado_recipient(
         owner.clone(),
         &mut router,
         start_time,
-        end_time,
+        Expiry::AtTime(end_time),
         Some(presale),
     );
     let summary = crowdfund.query_campaign_summary(&mut router);
@@ -548,7 +548,7 @@ fn test_failed_crowdfund_app_native(setup: TestCase) {
         owner.clone(),
         &mut router,
         start_time,
-        end_time,
+        Expiry::AtTime(end_time),
         Some(presale),
     );
     let summary = crowdfund.query_campaign_summary(&mut router);
@@ -642,7 +642,7 @@ fn test_successful_crowdfund_app_cw20(#[with(false)] setup: TestCase) {
         owner.clone(),
         &mut router,
         start_time,
-        end_time,
+        Expiry::AtTime(end_time),
         Some(presale),
     );
     let summary = crowdfund.query_campaign_summary(&mut router);
@@ -726,7 +726,7 @@ fn test_failed_crowdfund_app_cw20(#[with(false)] setup: TestCase) {
         owner.clone(),
         &mut router,
         start_time,
-        end_time,
+        Expiry::AtTime(end_time),
         Some(presale),
     );
     let summary = crowdfund.query_campaign_summary(&mut router);


### PR DESCRIPTION
# Motivation
Closes #588 

# Implementation
Use `Expiry` in `StartCampaign`.

# Testing
Some tests had to be adjusted. 

# Version Changes
crowdfund: `"2.0.4"` to `"2.1.4"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Updated campaign timing handling to use a more structured `Expiry` type for start and end times.
  
- **Bug Fixes**
    - Improved claim processing logic to ensure claims are handled based on the campaign's current status (successful or failed).

- **Tests**
    - Updated test cases to reflect the new `Expiry` type for campaign timing, ensuring validity in various scenarios.

- **Chores**
    - Incremented version number of the `andromeda-crowdfund` package from `2.0.4` to `2.1.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->