### PR TITLE
fix: add cw20 missing receive schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include ADOBase Version in Schema  [(#574)](https://github.com/andromedaprotocol/andromeda-core/pull/574)
 - Added Kernel ICS20 Transfer with Optional ExecuteMsg [(#577)](https://github.com/andromedaprotocol/andromeda-core/pull/577)
 - Added IBC Denom Wrap/Unwrap [(#579)](https://github.com/andromedaprotocol/andromeda-core/pull/579)
+- Add CW20Receive schema for missing ado [(#594)](https://github.com/andromedaprotocol/andromeda-core/pull/594)
 
 ### Changed
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/examples/schema.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/examples/schema.rs
@@ -1,7 +1,11 @@
+use std::env::current_dir;
+
 use andromeda_fungible_tokens::cw20_staking::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
     write_api! {
         instantiate: InstantiateMsg,
         query: QueryMsg,

--- a/contracts/fungible-tokens/andromeda-cw20-staking/examples/schema.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/examples/schema.rs
@@ -1,5 +1,5 @@
-use andromeda_fungible_tokens::cw20_staking::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use cosmwasm_schema::write_api;
+use andromeda_fungible_tokens::cw20_staking::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 fn main() {
     write_api! {
@@ -8,4 +8,5 @@ fn main() {
         execute: ExecuteMsg,
 
     }
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }

--- a/contracts/fungible-tokens/andromeda-lockdrop/examples/schema.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/examples/schema.rs
@@ -1,5 +1,5 @@
-use andromeda_fungible_tokens::lockdrop::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use cosmwasm_schema::write_api;
+use andromeda_fungible_tokens::lockdrop::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 fn main() {
     write_api! {
@@ -8,4 +8,5 @@ fn main() {
         execute: ExecuteMsg,
 
     }
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }

--- a/contracts/fungible-tokens/andromeda-lockdrop/examples/schema.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/examples/schema.rs
@@ -1,7 +1,11 @@
+use std::env::current_dir;
+
 use andromeda_fungible_tokens::lockdrop::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
     write_api! {
         instantiate: InstantiateMsg,
         query: QueryMsg,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/examples/schema.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/examples/schema.rs
@@ -1,6 +1,6 @@
-use cosmwasm_schema::write_api;
+use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
-use andromeda_non_fungible_tokens::crowdfund::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_non_fungible_tokens::crowdfund::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
     write_api! {
@@ -9,4 +9,5 @@ fn main() {
         execute: ExecuteMsg,
 
     }
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/examples/schema.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/examples/schema.rs
@@ -1,8 +1,12 @@
+use std::env::current_dir;
+
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 use andromeda_non_fungible_tokens::crowdfund::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
     write_api! {
         instantiate: InstantiateMsg,
         query: QueryMsg,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/examples/schema.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/examples/schema.rs
@@ -1,7 +1,7 @@
 use std::env::current_dir;
 
 use andromeda_non_fungible_tokens::marketplace::{
-    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg
+    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
 };
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/examples/schema.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/examples/schema.rs
@@ -1,7 +1,7 @@
 use std::env::current_dir;
 
 use andromeda_non_fungible_tokens::marketplace::{
-    Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
+    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg
 };
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
@@ -14,4 +14,5 @@ fn main() {
         execute: ExecuteMsg,
     };
     export_schema_with_title(&schema_for!(Cw721HookMsg), &out_dir, "cw721receive");
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }

--- a/contracts/os/andromeda-economics/examples/schema.rs
+++ b/contracts/os/andromeda-economics/examples/schema.rs
@@ -1,7 +1,11 @@
+use std::env::current_dir;
+
 use andromeda_std::os::economics::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
     write_api! {
         instantiate: InstantiateMsg,
         query: QueryMsg,

--- a/contracts/os/andromeda-economics/examples/schema.rs
+++ b/contracts/os/andromeda-economics/examples/schema.rs
@@ -1,11 +1,11 @@
-use andromeda_std::os::economics::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use cosmwasm_schema::write_api;
+use andromeda_std::os::economics::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg,
         query: QueryMsg,
         execute: ExecuteMsg,
-
     }
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }


### PR DESCRIPTION
# Motivation

Add missing receive cw20 schema staking, lockdrop, crowdfund, marketplace and economics ado

# Implementation

- Add receive schema in example.rs for related ado
- ADOs' Modified - cw20 staking, lockdrop, crowdfund, marketplace and economics

# Testing

NA

# Version Changes
NA - Only schema generation changes

# Notes

NA

# Future work

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Validator Staking ADO and various new ADOs including `String Storage`, `Boolean Storage`, and `Counter`.
	- Introduced functionalities for removing or replacing reward tokens in staking and a BuyNow option for auctions.
	- Added CW20Receive schema for better token handling.

- **Bug Fixes**
	- Improved lock time calculations in Splitter and Conditional Splitter.
	- Fixed AMPPkt origin verification and validation in the vesting instantiation process.

- **Documentation**
	- Updated CHANGELOG.md to reflect all notable changes and enhancements. 

- **Changes**
	- Redesign of modules and improvements to primitives based on audit feedback. 
	- Updated handling of expiration in the Merkle Root and changes to `lock_time` type in Conditional Splitter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->