### PR TITLE
fix: add cw20 receive schema for auction

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-auction/examples/schema.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/examples/schema.rs
@@ -2,7 +2,9 @@ use std::env::current_dir;
 
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
-use andromeda_non_fungible_tokens::auction::{Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_non_fungible_tokens::auction::{
+    Cw20HookMsg, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
+};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -13,4 +15,5 @@ fn main() {
         execute: ExecuteMsg,
     };
     export_schema_with_title(&schema_for!(Cw721HookMsg), &out_dir, "cw721receive");
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }


### PR DESCRIPTION
# Motivation

Add cw20 receive schema for auction

# Implementation

- Add cw20 receive schema for auction

# Testing

NA

# Contracts Updated
- Auction

# Version Changes

NA

# Notes

NA

# Future work

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced schema generation to support the `Cw20HookMsg` type for improved auction functionality.
	- Added a new schema export for `Cw20HookMsg`, generating a file named "cw20receive".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->