### PR TITLE
fix: update build_all.sh to append version after build

### DIFF
--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -3,3 +3,14 @@ docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/optimizer:0.16.1
+
+OUT_DIR="artifacts"
+
+for contract in $OUT_DIR/*.wasm; do
+  echo "Processing $contract"
+  contract_name=`basename $contract`
+  contract_name=${contract_name//.wasm/}
+  formated_name=${contract_name//_/-}
+  version=$(cargo pkgid $formated_name | cut -d# -f2 | cut -d: -f2)
+  mv "$contract" "$OUT_DIR/$contract_name@$version.wasm"
+done


### PR DESCRIPTION
# Motivation

Rust optimizer created wasm files didn't had version added to filename. Additional script run after rust optimizer docker run is complete to rename files with package version

# Implementation

Run additional script to append contract version to wasm files after rust optimizer has created all wasm files

# Testing

NA

# Version Changes
NA

# Notes

NA

# Future work

NA
