### PR TITLE
fix: append version after build only if version is not present

### DIFF
--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -10,6 +10,10 @@ for contract in $OUT_DIR/*.wasm; do
   echo "Processing $contract"
   contract_name=`basename $contract`
   contract_name=${contract_name//.wasm/}
+  if [[ "$contract_name" == *"@"* ]]; then
+    echo "Skipping $contract_name as it already has a version."
+    continue
+  fi
   formated_name=${contract_name//_/-}
   version=$(cargo pkgid $formated_name | cut -d# -f2 | cut -d: -f2)
   mv "$contract" "$OUT_DIR/$contract_name@$version.wasm"


### PR DESCRIPTION
# Motivation

Version appended after `make build` didn't check if wasm file already had a version or not. Added check for version and skip append version to prevent unnecessary bugs

# Implementation

- Added check for version and skip append version to prevent unnecessary bugs

# Testing

NA

# Version Changes

NA

# Notes

NA

# Future work

Specify any future work needed involving this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build script to skip processing contracts that already have a version indicator, enhancing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->