### PR TITLE
ci: Deployment script for OS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,7 @@ jobs:
       TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,5 +23,11 @@ jobs:
       TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - run: sudo make build
       - run: sudo make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,5 @@ jobs:
           components: rustfmt, clippy
           profile: minimal
           override: true
-      - run: sudo make build
+      - run: make build
       - run: make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
       DEPLOYMENT_KERNEL_ADDRESS: ${{ inputs.kernel_address }}
       SLACK_WEBHOOK_URL: "${{ secrets.DEPLOY_SLACK_WEBHOOK_URL }}"
       TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
+      RUST_LOG: info
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -35,4 +36,4 @@ jobs:
           components: rustfmt, clippy
           profile: minimal
           override: true
-      - run: cargo run --p andromeda-deploy
+      - run: cargo run -p andromeda-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,21 @@ on:
         type: string
 
 jobs:
-  #   build_contracts:
-  #     if: contains('["crnbarr93", "SlayerAnsh", "joemonem", "DimitrijeDragasevic"]', github.actor)
-  #     runs-on: ubuntu-latest
-  #     steps:
-  #       - uses: actions/checkout@v4
-  #       - run: make build
-  #       - run: make version-map
+  build_contracts:
+    if: contains('["crnbarr93", "SlayerAnsh", "joemonem", "DimitrijeDragasevic"]', github.actor)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Contracts
+        run: |
+          make build
+          make version-map
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: contracts
+          path: ./artifacts/
+          if-no-files-found: error
   deploy:
     runs-on: ubuntu-latest
     env:
@@ -31,9 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
+      - name: Download Contracts
+        uses: actions/download-artifact@v2
         with:
-          toolchain: 1.75.0
-          components: rustfmt, clippy
-          profile: minimal
-          override: true
-      - run: cargo run -p andromeda-deploy
+          name: contracts
+          path: "./artifacts"
+      - name: Deploy
+        run: cargo run -p andromeda-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           if-no-files-found: error
   deploy:
     runs-on: ubuntu-latest
+    needs: build_contracts
     env:
       DEPLOYMENT_CHAIN: ${{ inputs.network }}
       DEPLOYMENT_KERNEL_ADDRESS: ${{ inputs.kernel_address }}
@@ -40,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
       - name: Download Contracts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: contracts
           path: "./artifacts"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.76.0
+          components: rustfmt, clippy
+          profile: minimal
+          override: true
       - name: Download Contracts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   deploy:
+    if: contains('["crnbarr93", "SlayerAnsh", "joemonem", "DimitrijeDragasevic"]', github.actor)
     runs-on: ubuntu-latest
     env:
       DEPLOYMENT_CHAIN: ${{ inputs.network }}
@@ -21,6 +22,5 @@ jobs:
       SLACK_WEBHOOK_URL: "${{ secrets.DEPLOY_SLACK_WEBHOOK_URL }}"
       TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
     steps:
-      - uses: actions/checkout@v4
       - run: make build
       - run: make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,14 @@ on:
         type: string
 
 jobs:
+  #   build_contracts:
+  #     if: contains('["crnbarr93", "SlayerAnsh", "joemonem", "DimitrijeDragasevic"]', github.actor)
+  #     runs-on: ubuntu-latest
+  #     steps:
+  #       - uses: actions/checkout@v4
+  #       - run: make build
+  #       - run: make version-map
   deploy:
-    if: contains('["crnbarr93", "SlayerAnsh", "joemonem", "DimitrijeDragasevic"]', github.actor)
     runs-on: ubuntu-latest
     env:
       DEPLOYMENT_CHAIN: ${{ inputs.network }}
@@ -29,6 +35,4 @@ jobs:
           components: rustfmt, clippy
           profile: minimal
           override: true
-      - run: make build
-      - run: sudo make version-map
-      - run: sudo make deploy
+      - run: cargo run --p andromeda-deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Contracts
         run: |
+          sudo make version-map
           make build
-          make version-map
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,5 +22,6 @@ jobs:
       SLACK_WEBHOOK_URL: "${{ secrets.DEPLOY_SLACK_WEBHOOK_URL }}"
       TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
     steps:
+      - uses: actions/checkout@v4
       - run: make build
       - run: make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy OS
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to deploy to"
+        required: true
+        type: string
+      kernel_address:
+        description: "Kernel address"
+        required: false
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      DEPLOYMENT_CHAIN: ${{ inputs.network }}
+      DEPLOYMENT_KERNEL_ADDRESS: ${{ inputs.kernel_address }}
+      SLACK_WEBHOOK_URL: "${{ secrets.DEPLOY_SLACK_WEBHOOK_URL }}"
+      TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+      - run: make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,5 @@ jobs:
           profile: minimal
           override: true
       - run: make build
+      - run: sudo make version-map
       - run: make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
           override: true
       - run: make build
       - run: sudo make version-map
-      - run: make deploy
+      - run: sudo make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
+          toolchain: 1.75.0
+          components: rustfmt, clippy
           profile: minimal
-          toolchain: stable
           override: true
       - run: sudo make build
-      - run: sudo make deploy
+      - run: make deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,5 +23,5 @@ jobs:
       TEST_MNEMONIC: "${{ secrets.DEPLOY_TEST_MNEMONIC }}"
     steps:
       - uses: actions/checkout@v4
-      - run: make build
-      - run: make deploy
+      - run: sudo make build
+      - run: sudo make deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Denom Validation in IBC Registry ADO [(#571)](https://github.com/andromedaprotocol/andromeda-core/pull/571)
 - Added Kernel ICS20 Transfer with Optional ExecuteMsg [(#577)](https://github.com/andromedaprotocol/andromeda-core/pull/577)
 - Added IBC Denom Wrap/Unwrap [(#579)](https://github.com/andromedaprotocol/andromeda-core/pull/579)
+- Added deployment script/CI workflow for OS [(#612)](https://github.com/andromedaprotocol/andromeda-core/pull/612)
 
 ### Changed
 
@@ -47,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Denom Validation for Rates [(#568)](https://github.com/andromedaprotocol/andromeda-core/pull/568)
 - Added BuyNow option for Auction [(#533)](https://github.com/andromedaprotocol/andromeda-core/pull/533)
 - Include ADOBase Version in Schema [(#574)](https://github.com/andromedaprotocol/andromeda-core/pull/574)
-
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "andromeda-macros",
  "andromeda-std",
  "andromeda-vfs",
+ "chrono 0.4.38",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
@@ -361,16 +362,19 @@ dependencies = [
  "cw20-base",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
+ "dotenv",
  "enum-repr",
  "env_logger",
  "hex",
  "lazy_static",
  "log",
  "regex",
+ "reqwest 0.11.27",
  "schemars",
  "semver",
  "serde",
  "serde-json-wasm 0.5.2",
+ "serde_json",
  "sha2 0.10.8",
  "strum_macros",
  "thiserror",
@@ -2138,6 +2142,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dyn-clone"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "andromeda-deploy"
+version = "0.0.1"
+dependencies = [
+ "andromeda-adodb",
+ "andromeda-economics",
+ "andromeda-ibc-registry",
+ "andromeda-kernel",
+ "andromeda-macros",
+ "andromeda-std",
+ "andromeda-vfs",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-asset",
+ "cw-multi-test",
+ "cw-orch",
+ "cw-orch-daemon",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "cw20",
+ "cw20-base",
+ "cw721 0.18.0",
+ "cw721-base 0.18.0",
+ "enum-repr",
+ "env_logger",
+ "hex",
+ "lazy_static",
+ "log",
+ "regex",
+ "schemars",
+ "semver",
+ "serde",
+ "serde-json-wasm 0.5.2",
+ "sha2 0.10.8",
+ "strum_macros",
+ "thiserror",
+]
+
+[[package]]
 name = "andromeda-economics"
 version = "1.1.1"
 dependencies = [
@@ -650,6 +689,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-asset",
  "cw-multi-test",
+ "cw-orch",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -820,6 +860,55 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1140,6 +1229,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "const-oid"
@@ -2163,6 +2258,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,6 +3031,12 @@ name = "ipnet"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -5209,6 +5339,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ build:
 	@echo "Building all contracts..."
 	@./scripts/build_all.sh || exit 1
 	@echo "Build complete! \033[0;32m\xE2\x9C\x94\033[0m"
-	@./scripts/build_version_map.sh || exit 1
 
 # Builds all contracts and generates a version map
 build-arm:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ build-arm:
 	@echo "Build complete! \033[0;32m\xE2\x9C\x94\033[0m"
 	@./scripts/build_version_map.sh || exit 1
 
+# Attaches contract versions to the wasm files
+attach-contract-versions:
+	@echo "Attaching contract versions..."
+	@./scripts/attach_contract_versions.sh
+	@echo "Contract versions attached! \033[0;32m\xE2\x9C\x94\033[0m"
+
 # Runs unit tests
 unit-test:
 	@echo "Running unit tests..."

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ build:
 	@echo "Build complete! \033[0;32m\xE2\x9C\x94\033[0m"
 	@./scripts/build_version_map.sh || exit 1
 
+# Builds all contracts and generates a version map
+build-arm:
+	@echo "Building all contracts..."
+	@./scripts/build_all_arm.sh || exit 1
+	@echo "Build complete! \033[0;32m\xE2\x9C\x94\033[0m"
+	@./scripts/build_version_map.sh || exit 1
+
 # Runs unit tests
 unit-test:
 	@echo "Running unit tests..."

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,7 @@ integration-test:
 test: unit-test integration-test
 	@echo "All tests complete! \033[0;32m\xE2\x9C\x94\033[0m"
 
-
+deploy:
+	@echo "Deploying OS..."
+	@RUST_LOG=info cargo run --package andromeda-deploy
+	@echo "OS deployed! \033[0;32m\xE2\x9C\x94\033[0m"

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -169,7 +169,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::ChainName {} => encode_binary(&query::chain_name(deps)?),
         // Base queries
         QueryMsg::Version {} => encode_binary(&ADOContract::default().query_version(deps)?),
-        QueryMsg::Type {} => encode_binary(&ADOContract::default().query_type(deps)?),
+        QueryMsg::AdoType {} => encode_binary(&ADOContract::default().query_type(deps)?),
         QueryMsg::Owner {} => encode_binary(&ADOContract::default().query_contract_owner(deps)?),
     }
 }

--- a/packages/deploy/Cargo.toml
+++ b/packages/deploy/Cargo.toml
@@ -52,6 +52,10 @@ andromeda-ibc-registry = { version = "1.0.1", path = "../../contracts/os/androme
 andromeda-std = { workspace = true }
 env_logger = "0.11.5" # or whatever the latest version is
 log = "0.4" # env_logger depends on the log crate
+dotenv = "0.15.0"
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+serde_json = "1.0"
+chrono = "0.4"
 
 [dev-dependencies]
 cw-multi-test = { version = "1.0.0" }

--- a/packages/deploy/Cargo.toml
+++ b/packages/deploy/Cargo.toml
@@ -1,15 +1,10 @@
 [package]
-name = "andromeda-std"
-version = "1.2.4"
+name = "andromeda-deploy"
+version = "0.0.1"
 edition = "2021"
 rust-version = "1.75.0"
-description = "The standard library for creating an Andromeda Digital Object"
+description = "The deploy tool for aOS"
 license = "MIT"
-
-[features]
-primitive = []
-instantiate = []
-rates = ["andromeda-macros/rates"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -38,6 +33,25 @@ serde-json-wasm = "0.5.0"
 enum-repr = { workspace = true }
 sha2 = "0.10.8"
 cw-orch = { workspace = true }
+cw-orch-daemon = "0.24.2"
+andromeda-kernel = { version = "1.1.1", path = "../../contracts/os/andromeda-kernel", features = [
+    "testing",
+] }
+andromeda-adodb = { version = "1.1.1", path = "../../contracts/os/andromeda-adodb", features = [
+    "testing",
+] }
+andromeda-vfs = { version = "1.1.1", path = "../../contracts/os/andromeda-vfs", features = [
+    "testing",
+] }
+andromeda-economics = { version = "1.1.1", path = "../../contracts/os/andromeda-economics", features = [
+    "testing",
+] }
+andromeda-ibc-registry = { version = "1.0.1", path = "../../contracts/os/andromeda-ibc-registry", features = [
+    "testing",
+] }
+andromeda-std = { workspace = true }
+env_logger = "0.11.5" # or whatever the latest version is
+log = "0.4" # env_logger depends on the log crate
 
 [dev-dependencies]
 cw-multi-test = { version = "1.0.0" }

--- a/packages/deploy/src/chains.rs
+++ b/packages/deploy/src/chains.rs
@@ -1,0 +1,21 @@
+use cw_orch::{
+    environment::{ChainKind, NetworkInfo},
+    prelude::ChainInfo,
+};
+
+pub const ANDROMEDA_NETWORK: NetworkInfo = NetworkInfo {
+    chain_name: "andromeda",
+    pub_address_prefix: "andr",
+    coin_type: 118u32,
+};
+
+pub const ANDROMEDA_TESTNET: ChainInfo = ChainInfo {
+    chain_id: "galileo-4",
+    gas_denom: "uandr",
+    fcd_url: None,
+    gas_price: 0.025,
+    grpc_urls: &["http://137.184.182.11:9090/"],
+    lcd_url: Some("http://137.184.182.11:1317/"),
+    network_info: ANDROMEDA_NETWORK,
+    kind: ChainKind::Testnet,
+};

--- a/packages/deploy/src/chains.rs
+++ b/packages/deploy/src/chains.rs
@@ -19,3 +19,13 @@ pub const ANDROMEDA_TESTNET: ChainInfo = ChainInfo {
     network_info: ANDROMEDA_NETWORK,
     kind: ChainKind::Testnet,
 };
+
+pub const ALL_CHAINS: &[ChainInfo] = &[ANDROMEDA_TESTNET];
+
+pub fn get_chain(chain: String) -> ChainInfo {
+    ALL_CHAINS
+        .iter()
+        .find(|c| c.chain_id == chain || c.network_info.chain_name == chain)
+        .unwrap()
+        .clone()
+}

--- a/packages/deploy/src/contract_interface.rs
+++ b/packages/deploy/src/contract_interface.rs
@@ -1,0 +1,26 @@
+#[macro_export]
+macro_rules! contract_interface {
+    ($contract_name:ident, $module_path:ident, $package_path:ident, $contract_id:expr, $wasm_path:expr) => {
+        #[interface($package_path::InstantiateMsg, $package_path::ExecuteMsg, $package_path::QueryMsg, MigrateMsg, id = $contract_id)]
+        pub struct $contract_name;
+
+        impl<Chain> Uploadable for $contract_name<Chain> {
+            fn wrapper() -> Box<dyn MockContract<Empty>> {
+                Box::new(
+                    ContractWrapper::new_with_empty(
+                        $module_path::contract::execute,
+                        $module_path::contract::instantiate,
+                        $module_path::contract::query,
+                    )
+                    .with_migrate($module_path::contract::migrate),
+                )
+            }
+
+            fn wasm(_chain: &ChainInfoOwned) -> WasmPath {
+                artifacts_dir_from_workspace!()
+                    .find_wasm_path($wasm_path)
+                    .unwrap()
+            }
+        }
+    };
+}

--- a/packages/deploy/src/contracts.rs
+++ b/packages/deploy/src/contracts.rs
@@ -9,7 +9,7 @@ contract_interface!(
     andromeda_kernel,
     kernel,
     "andromeda_kernel",
-    "andromeda_kernel@1.1.1.wasm"
+    "andromeda_kernel.wasm"
 );
 
 contract_interface!(
@@ -17,7 +17,7 @@ contract_interface!(
     andromeda_adodb,
     adodb,
     "andromeda_adodb",
-    "andromeda_adodb@1.1.2.wasm"
+    "andromeda_adodb.wasm"
 );
 
 contract_interface!(
@@ -25,7 +25,7 @@ contract_interface!(
     andromeda_vfs,
     vfs,
     "andromeda_vfs",
-    "andromeda_vfs@1.1.1.wasm"
+    "andromeda_vfs.wasm"
 );
 
 contract_interface!(
@@ -33,7 +33,7 @@ contract_interface!(
     andromeda_economics,
     economics,
     "andromeda_economics",
-    "andromeda_economics@1.1.1.wasm"
+    "andromeda_economics.wasm"
 );
 
 contract_interface!(
@@ -41,5 +41,5 @@ contract_interface!(
     andromeda_ibc_registry,
     ibc_registry,
     "andromeda_ibc_registry",
-    "andromeda_ibc_registry@1.0.1.wasm"
+    "andromeda_ibc_registry.wasm"
 );

--- a/packages/deploy/src/contracts.rs
+++ b/packages/deploy/src/contracts.rs
@@ -1,0 +1,45 @@
+use crate::contract_interface;
+use andromeda_std::ado_base::MigrateMsg;
+use andromeda_std::os::*;
+use cw_orch::interface;
+use cw_orch::prelude::*;
+
+contract_interface!(
+    KernelContract,
+    andromeda_kernel,
+    kernel,
+    "andromeda_kernel",
+    "andromeda_kernel@1.1.1.wasm"
+);
+
+contract_interface!(
+    ADODBContract,
+    andromeda_adodb,
+    adodb,
+    "andromeda_adodb",
+    "andromeda_adodb@1.1.2.wasm"
+);
+
+contract_interface!(
+    VFSContract,
+    andromeda_vfs,
+    vfs,
+    "andromeda_vfs",
+    "andromeda_vfs@1.1.1.wasm"
+);
+
+contract_interface!(
+    EconomicsContract,
+    andromeda_economics,
+    economics,
+    "andromeda_economics",
+    "andromeda_economics@1.1.1.wasm"
+);
+
+contract_interface!(
+    IBCRegistryContract,
+    andromeda_ibc_registry,
+    ibc_registry,
+    "andromeda_ibc_registry",
+    "andromeda_ibc_registry@1.0.1.wasm"
+);

--- a/packages/deploy/src/error.rs
+++ b/packages/deploy/src/error.rs
@@ -1,0 +1,1 @@
+pub enum Error {}

--- a/packages/deploy/src/error.rs
+++ b/packages/deploy/src/error.rs
@@ -1,1 +1,8 @@
-pub enum Error {}
+use cw_orch::prelude::CwOrchError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DeployError {
+    #[error("{0}")]
+    CwOrchError(#[from] CwOrchError),
+}

--- a/packages/deploy/src/lib.rs
+++ b/packages/deploy/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod chains;
 pub mod contract_interface;
 pub mod contracts;
+pub mod error;
 pub mod os;

--- a/packages/deploy/src/lib.rs
+++ b/packages/deploy/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod chains;
+pub mod contract_interface;
+pub mod contracts;
+pub mod os;

--- a/packages/deploy/src/main.rs
+++ b/packages/deploy/src/main.rs
@@ -1,7 +1,69 @@
-use andromeda_deploy::os::deploy;
+use cw_orch::core::serde_json;
+use reqwest::blocking::Client;
+use std::env;
+
+use andromeda_deploy::os;
+use chrono::Local;
+use dotenv::dotenv;
+
+fn send_slack_notification(message: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let webhook_url = env::var("SLACK_WEBHOOK_URL").ok();
+    if webhook_url.is_none() {
+        return Ok(());
+    }
+
+    let payload = serde_json::json!({
+        "text": message,
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": message
+                }
+            }
+        ]
+    });
+
+    Client::new()
+        .post(webhook_url.unwrap())
+        .json(&payload)
+        .send()?;
+
+    Ok(())
+}
 
 fn main() {
-    deploy(Some(
-        "andr1kq0h4da4gwlz40flq34admwvqv7guxwplugrz4l6nsj9rqqxn8tqeup4d8".to_string(),
-    ));
+    dotenv().ok();
+
+    let chain = env::var("CHAIN").expect("CHAIN must be set");
+    let kernel_address = env::var("KERNEL_ADDRESS").ok();
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+
+    // Send start notification
+    let start_message = format!(
+        "🚀 *Deployment Started*\n```\n| Chain          | {} |\n| Time           | {} |\n| Kernel Address | {} |```",
+        chain,
+        timestamp,
+        kernel_address.as_deref().unwrap_or("Not provided")
+    );
+
+    if let Err(e) = send_slack_notification(&start_message) {
+        eprintln!("Failed to send Slack notification: {}", e);
+    }
+
+    os::deploy(chain.clone(), kernel_address.clone());
+
+    // Send completion notification
+    let completion_timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let completion_message = format!(
+        "✅ *Deployment Completed*\n```\n| Chain          | {} |\n| Time           | {} |\n| Kernel Address | {} |```",
+        chain,
+        completion_timestamp,
+        kernel_address.as_deref().unwrap_or("Not provided")
+    );
+
+    if let Err(e) = send_slack_notification(&completion_message) {
+        eprintln!("Failed to send Slack notification: {}", e);
+    }
 }

--- a/packages/deploy/src/main.rs
+++ b/packages/deploy/src/main.rs
@@ -1,0 +1,7 @@
+use andromeda_deploy::os::deploy;
+
+fn main() {
+    deploy(Some(
+        "andr1kq0h4da4gwlz40flq34admwvqv7guxwplugrz4l6nsj9rqqxn8tqeup4d8".to_string(),
+    ));
+}

--- a/packages/deploy/src/os.rs
+++ b/packages/deploy/src/os.rs
@@ -1,0 +1,151 @@
+use andromeda_std::ado_base::MigrateMsg;
+use andromeda_std::amp::AndrAddr;
+use andromeda_std::os::*;
+use cw_orch::prelude::*;
+use cw_orch_daemon::{DaemonBase, DaemonBuilder, TxSender, Wallet};
+use kernel::{ExecuteMsgFns, QueryMsgFns};
+
+use crate::chains::ANDROMEDA_TESTNET;
+use crate::contracts::*;
+
+struct OperatingSystemDeployment {
+    daemon: DaemonBase<Wallet>,
+    kernel: KernelContract<DaemonBase<Wallet>>,
+    adodb: ADODBContract<DaemonBase<Wallet>>,
+    vfs: VFSContract<DaemonBase<Wallet>>,
+    economics: EconomicsContract<DaemonBase<Wallet>>,
+    ibc_registry: IBCRegistryContract<DaemonBase<Wallet>>,
+}
+
+impl OperatingSystemDeployment {
+    pub fn new() -> Self {
+        let daemon = DaemonBuilder::new(ANDROMEDA_TESTNET).build().unwrap();
+        let kernel = KernelContract::new(daemon.clone());
+        let adodb = ADODBContract::new(daemon.clone());
+        let vfs = VFSContract::new(daemon.clone());
+        let economics = EconomicsContract::new(daemon.clone());
+        let ibc_registry = IBCRegistryContract::new(daemon.clone());
+
+        Self {
+            daemon,
+            kernel,
+            adodb,
+            vfs,
+            economics,
+            ibc_registry,
+        }
+    }
+
+    pub fn upload(&self) {
+        self.kernel.upload().unwrap();
+        self.adodb.upload().unwrap();
+        self.vfs.upload().unwrap();
+        self.economics.upload().unwrap();
+        self.ibc_registry.upload().unwrap();
+    }
+
+    /// Instantiates OS contracts
+    ///
+    /// If a kernel is provided we look to migrate the existing contracts instead of creating new ones.
+    pub fn instantiate(&self, kernel_address: Option<String>) {
+        let sender = self.daemon.sender().address();
+
+        // If kernel address is provided, use it and migrate the contract to the new version
+        if let Some(address) = kernel_address {
+            let code_id = self.kernel.code_id().unwrap();
+            self.kernel.set_address(&Addr::unchecked(address));
+            self.kernel.migrate(&MigrateMsg {}, code_id).unwrap();
+        } else {
+            let kernel_msg = kernel::InstantiateMsg {
+                owner: Some(sender.to_string()),
+                chain_name: ANDROMEDA_TESTNET.network_info.chain_name.to_string(),
+            };
+            self.kernel
+                .instantiate(&kernel_msg, Some(&sender), None)
+                .unwrap();
+            println!("Kernel address: {}", self.kernel.address().unwrap());
+        };
+
+        let adodb_addr = self.kernel.key_address("adodb").ok();
+        if let Some(addr) = adodb_addr {
+            let code_id = self.adodb.code_id().unwrap();
+            self.adodb.set_address(&addr);
+            self.adodb.migrate(&MigrateMsg {}, code_id).unwrap();
+        } else {
+            let adodb_msg = adodb::InstantiateMsg {
+                owner: Some(sender.to_string()),
+                kernel_address: self.kernel.address().unwrap().to_string(),
+            };
+            self.adodb
+                .instantiate(&adodb_msg, Some(&sender), None)
+                .unwrap();
+        }
+
+        let vfs_addr = self.kernel.key_address("vfs").ok();
+        if let Some(addr) = vfs_addr {
+            let code_id = self.vfs.code_id().unwrap();
+            self.vfs.set_address(&addr);
+            self.vfs.migrate(&MigrateMsg {}, code_id).unwrap();
+        } else {
+            let vfs_msg = vfs::InstantiateMsg {
+                owner: Some(sender.to_string()),
+                kernel_address: self.kernel.address().unwrap().to_string(),
+            };
+            self.vfs.instantiate(&vfs_msg, Some(&sender), None).unwrap();
+        }
+
+        let economics_addr = self.kernel.key_address("economics").ok();
+        if let Some(addr) = economics_addr {
+            let code_id = self.economics.code_id().unwrap();
+            self.economics.set_address(&addr);
+            self.economics.migrate(&MigrateMsg {}, code_id).unwrap();
+        } else {
+            let economics_msg = economics::InstantiateMsg {
+                owner: Some(sender.to_string()),
+                kernel_address: self.kernel.address().unwrap().to_string(),
+            };
+            self.economics
+                .instantiate(&economics_msg, Some(&sender), None)
+                .unwrap();
+        }
+
+        let ibc_registry_addr = self.kernel.key_address("ibc_registry").ok();
+        if let Some(addr) = ibc_registry_addr {
+            let code_id = self.ibc_registry.code_id().unwrap();
+            self.ibc_registry.set_address(&addr);
+            self.ibc_registry.migrate(&MigrateMsg {}, code_id).unwrap();
+        } else {
+            let ibc_registry_msg = ibc_registry::InstantiateMsg {
+                owner: Some(sender.to_string()),
+                kernel_address: self.kernel.address().unwrap(),
+                service_address: AndrAddr::from_string(sender.to_string()),
+            };
+            self.ibc_registry
+                .instantiate(&ibc_registry_msg, Some(&sender), None)
+                .unwrap();
+        }
+    }
+
+    fn register_modules(&self) {
+        self.kernel
+            .upsert_key_address("vfs", self.vfs.address().unwrap())
+            .unwrap();
+        self.kernel
+            .upsert_key_address("adodb", self.adodb.address().unwrap())
+            .unwrap();
+        self.kernel
+            .upsert_key_address("economics", self.economics.address().unwrap())
+            .unwrap();
+        self.kernel
+            .upsert_key_address("ibc_registry", self.ibc_registry.address().unwrap())
+            .unwrap();
+    }
+}
+
+pub fn deploy(kernel_address: Option<String>) {
+    env_logger::init();
+    let os_deployment = OperatingSystemDeployment::new();
+    os_deployment.upload();
+    os_deployment.instantiate(kernel_address);
+    os_deployment.register_modules();
+}

--- a/packages/deploy/src/os.rs
+++ b/packages/deploy/src/os.rs
@@ -5,7 +5,7 @@ use cw_orch::prelude::*;
 use cw_orch_daemon::{DaemonBase, DaemonBuilder, TxSender, Wallet};
 use kernel::{ExecuteMsgFns, QueryMsgFns};
 
-use crate::chains::ANDROMEDA_TESTNET;
+use crate::chains::{get_chain, ANDROMEDA_TESTNET};
 use crate::contracts::*;
 
 struct OperatingSystemDeployment {
@@ -18,8 +18,8 @@ struct OperatingSystemDeployment {
 }
 
 impl OperatingSystemDeployment {
-    pub fn new() -> Self {
-        let daemon = DaemonBuilder::new(ANDROMEDA_TESTNET).build().unwrap();
+    pub fn new(chain: ChainInfo) -> Self {
+        let daemon = DaemonBuilder::new(chain).build().unwrap();
         let kernel = KernelContract::new(daemon.clone());
         let adodb = ADODBContract::new(daemon.clone());
         let vfs = VFSContract::new(daemon.clone());
@@ -142,9 +142,10 @@ impl OperatingSystemDeployment {
     }
 }
 
-pub fn deploy(kernel_address: Option<String>) {
+pub fn deploy(chain: String, kernel_address: Option<String>) -> Result<String> {
     env_logger::init();
-    let os_deployment = OperatingSystemDeployment::new();
+    let chain = get_chain(chain);
+    let os_deployment = OperatingSystemDeployment::new(chain);
     os_deployment.upload();
     os_deployment.instantiate(kernel_address);
     os_deployment.register_modules();

--- a/packages/deploy/src/os.rs
+++ b/packages/deploy/src/os.rs
@@ -1,3 +1,4 @@
+use crate::error::DeployError;
 use andromeda_std::ado_base::MigrateMsg;
 use andromeda_std::amp::AndrAddr;
 use andromeda_std::os::*;
@@ -36,84 +37,84 @@ impl OperatingSystemDeployment {
         }
     }
 
-    pub fn upload(&self) {
-        self.kernel.upload().unwrap();
-        self.adodb.upload().unwrap();
-        self.vfs.upload().unwrap();
-        self.economics.upload().unwrap();
-        self.ibc_registry.upload().unwrap();
+    pub fn upload(&self) -> Result<(), DeployError> {
+        self.kernel.upload()?;
+        self.adodb.upload()?;
+        self.vfs.upload()?;
+        self.economics.upload()?;
+        self.ibc_registry.upload()?;
+        Ok(())
     }
 
     /// Instantiates OS contracts
     ///
     /// If a kernel is provided we look to migrate the existing contracts instead of creating new ones.
-    pub fn instantiate(&self, kernel_address: Option<String>) {
+    pub fn instantiate(&self, kernel_address: Option<String>) -> Result<(), DeployError> {
         let sender = self.daemon.sender().address();
 
         // If kernel address is provided, use it and migrate the contract to the new version
         if let Some(address) = kernel_address {
             let code_id = self.kernel.code_id().unwrap();
             self.kernel.set_address(&Addr::unchecked(address));
-            self.kernel.migrate(&MigrateMsg {}, code_id).unwrap();
+            self.kernel.migrate(&MigrateMsg {}, code_id)?;
         } else {
             let kernel_msg = kernel::InstantiateMsg {
                 owner: Some(sender.to_string()),
                 chain_name: ANDROMEDA_TESTNET.network_info.chain_name.to_string(),
             };
-            self.kernel
-                .instantiate(&kernel_msg, Some(&sender), None)
-                .unwrap();
+            self.kernel.instantiate(&kernel_msg, Some(&sender), None)?;
             println!("Kernel address: {}", self.kernel.address().unwrap());
         };
+
+        // For each module we check if it's been instantiated already.
+        // If it has, we migrate it to the new code id.
+        // If it hasn't, we instantiate it.
 
         let adodb_addr = self.kernel.key_address("adodb").ok();
         if let Some(addr) = adodb_addr {
             let code_id = self.adodb.code_id().unwrap();
             self.adodb.set_address(&addr);
-            self.adodb.migrate(&MigrateMsg {}, code_id).unwrap();
+            self.adodb.migrate(&MigrateMsg {}, code_id)?;
         } else {
             let adodb_msg = adodb::InstantiateMsg {
                 owner: Some(sender.to_string()),
                 kernel_address: self.kernel.address().unwrap().to_string(),
             };
-            self.adodb
-                .instantiate(&adodb_msg, Some(&sender), None)
-                .unwrap();
+            self.adodb.instantiate(&adodb_msg, Some(&sender), None)?;
         }
 
         let vfs_addr = self.kernel.key_address("vfs").ok();
         if let Some(addr) = vfs_addr {
             let code_id = self.vfs.code_id().unwrap();
             self.vfs.set_address(&addr);
-            self.vfs.migrate(&MigrateMsg {}, code_id).unwrap();
+            self.vfs.migrate(&MigrateMsg {}, code_id)?;
         } else {
             let vfs_msg = vfs::InstantiateMsg {
                 owner: Some(sender.to_string()),
                 kernel_address: self.kernel.address().unwrap().to_string(),
             };
-            self.vfs.instantiate(&vfs_msg, Some(&sender), None).unwrap();
+            self.vfs.instantiate(&vfs_msg, Some(&sender), None)?;
         }
 
         let economics_addr = self.kernel.key_address("economics").ok();
         if let Some(addr) = economics_addr {
             let code_id = self.economics.code_id().unwrap();
             self.economics.set_address(&addr);
-            self.economics.migrate(&MigrateMsg {}, code_id).unwrap();
+            self.economics.migrate(&MigrateMsg {}, code_id)?;
         } else {
             let economics_msg = economics::InstantiateMsg {
                 owner: Some(sender.to_string()),
                 kernel_address: self.kernel.address().unwrap().to_string(),
             };
             self.economics
-                .instantiate(&economics_msg, Some(&sender), None)
-                .unwrap();
+                .instantiate(&economics_msg, Some(&sender), None)?;
         }
 
         let ibc_registry_addr = self.kernel.key_address("ibc_registry").ok();
         if let Some(addr) = ibc_registry_addr {
             let code_id = self.ibc_registry.code_id().unwrap();
             self.ibc_registry.set_address(&addr);
-            self.ibc_registry.migrate(&MigrateMsg {}, code_id).unwrap();
+            self.ibc_registry.migrate(&MigrateMsg {}, code_id)?;
         } else {
             let ibc_registry_msg = ibc_registry::InstantiateMsg {
                 owner: Some(sender.to_string()),
@@ -121,32 +122,39 @@ impl OperatingSystemDeployment {
                 service_address: AndrAddr::from_string(sender.to_string()),
             };
             self.ibc_registry
-                .instantiate(&ibc_registry_msg, Some(&sender), None)
-                .unwrap();
+                .instantiate(&ibc_registry_msg, Some(&sender), None)?;
         }
+        Ok(())
     }
 
-    fn register_modules(&self) {
+    fn register_modules(&self) -> Result<(), DeployError> {
         self.kernel
-            .upsert_key_address("vfs", self.vfs.address().unwrap())
-            .unwrap();
+            .upsert_key_address("vfs", self.vfs.address().unwrap())?;
         self.kernel
-            .upsert_key_address("adodb", self.adodb.address().unwrap())
-            .unwrap();
+            .upsert_key_address("adodb", self.adodb.address().unwrap())?;
         self.kernel
-            .upsert_key_address("economics", self.economics.address().unwrap())
-            .unwrap();
+            .upsert_key_address("economics", self.economics.address().unwrap())?;
         self.kernel
-            .upsert_key_address("ibc_registry", self.ibc_registry.address().unwrap())
-            .unwrap();
+            .upsert_key_address("ibc_registry", self.ibc_registry.address().unwrap())?;
+        Ok(())
     }
 }
 
-pub fn deploy(chain: String, kernel_address: Option<String>) -> Result<String> {
+pub fn deploy(chain: String, kernel_address: Option<String>) -> Result<String, DeployError> {
     env_logger::init();
     let chain = get_chain(chain);
     let os_deployment = OperatingSystemDeployment::new(chain);
-    os_deployment.upload();
-    os_deployment.instantiate(kernel_address);
-    os_deployment.register_modules();
+    log::info!("Starting OS deployment process");
+
+    log::info!("Uploading contracts");
+    os_deployment.upload()?;
+
+    log::info!("Instantiating contracts");
+    os_deployment.instantiate(kernel_address)?;
+
+    log::info!("Registering modules");
+    os_deployment.register_modules()?;
+
+    log::info!("OS deployment process completed");
+    Ok(os_deployment.kernel.address().unwrap().to_string())
 }

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -139,7 +139,7 @@ impl<'a> ADOContract<'a> {
 
         // New version has to be newer/greater than the old version
         ensure!(
-            storage_version < version,
+            storage_version <= version,
             ContractError::CannotMigrate {
                 previous_contract: stored.version,
             }

--- a/packages/std/src/os/adodb.rs
+++ b/packages/std/src/os/adodb.rs
@@ -15,6 +15,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+#[derive(cw_orch::ExecuteFns)]
 pub enum ExecuteMsg {
     Publish {
         code_id: u64,

--- a/packages/std/src/os/ibc_registry.rs
+++ b/packages/std/src/os/ibc_registry.rs
@@ -40,7 +40,7 @@ pub struct IBCDenomInfo {
 }
 
 #[cw_serde]
-#[derive(AsRefStr)]
+#[derive(AsRefStr, cw_orch::ExecuteFns)]
 pub enum ExecuteMsg {
     /// Receives an AMP Packet for relaying
     #[serde(rename = "amp_receive")]

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -35,6 +35,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+#[derive(cw_orch::ExecuteFns)]
 pub enum ExecuteMsg {
     /// Receives an AMP Packet for relaying
     #[serde(rename = "amp_receive")]
@@ -102,7 +103,7 @@ pub struct ChainNameResponse {
 }
 
 #[cw_serde]
-#[derive(QueryResponses)]
+#[derive(cw_orch::QueryFns, QueryResponses)]
 pub enum QueryMsg {
     #[returns(cosmwasm_std::Addr)]
     KeyAddress { key: String },
@@ -118,7 +119,8 @@ pub enum QueryMsg {
     #[returns(crate::ado_base::version::VersionResponse)]
     Version {},
     #[returns(crate::ado_base::ado_type::TypeResponse)]
-    Type {},
+    #[serde(rename = "type")]
+    AdoType {},
     #[returns(crate::ado_base::ownership::ContractOwnerResponse)]
     Owner {},
 }

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -149,6 +149,7 @@ impl PathDetails {
 }
 
 #[cw_serde]
+#[derive(cw_orch::ExecuteFns)]
 pub enum ExecuteMsg {
     AddPath {
         #[schemars(regex = "COMPONENT_NAME_REGEX")]

--- a/scripts/attach_contract_versions.sh
+++ b/scripts/attach_contract_versions.sh
@@ -1,0 +1,14 @@
+OUT_DIR="artifacts"
+
+for contract in $OUT_DIR/*.wasm; do
+  echo "Processing $contract"
+  contract_name=`basename $contract`
+  contract_name=${contract_name//.wasm/}
+  if [[ "$contract_name" == *"@"* ]]; then
+    echo "Skipping $contract_name as it already has a version."
+    continue
+  fi
+  formated_name=${contract_name//_/-}
+  version=$(cargo pkgid $formated_name | cut -d# -f2 | cut -d: -f2)
+  mv "$contract" "$OUT_DIR/$contract_name@$version.wasm"
+done

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -3,18 +3,3 @@ docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/optimizer:0.16.1
-
-OUT_DIR="artifacts"
-
-for contract in $OUT_DIR/*.wasm; do
-  echo "Processing $contract"
-  contract_name=`basename $contract`
-  contract_name=${contract_name//.wasm/}
-  if [[ "$contract_name" == *"@"* ]]; then
-    echo "Skipping $contract_name as it already has a version."
-    continue
-  fi
-  formated_name=${contract_name//_/-}
-  version=$(cargo pkgid $formated_name | cut -d# -f2 | cut -d: -f2)
-  mv "$contract" "$OUT_DIR/$contract_name@$version.wasm"
-done

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -2,7 +2,7 @@
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/optimizer:0.16.1
+  cosmwasm/optimizer-arm64:0.16.1
 
 OUT_DIR="artifacts"
 

--- a/scripts/build_all_arm.sh
+++ b/scripts/build_all_arm.sh
@@ -3,18 +3,3 @@ docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/optimizer-arm64:0.16.1
-
-OUT_DIR="artifacts"
-
-for contract in $OUT_DIR/*.wasm; do
-  echo "Processing $contract"
-  contract_name=`basename $contract`
-  contract_name=${contract_name//.wasm/}
-  if [[ "$contract_name" == *"@"* ]]; then
-    echo "Skipping $contract_name as it already has a version."
-    continue
-  fi
-  formated_name=${contract_name//_/-}
-  version=$(cargo pkgid $formated_name | cut -d# -f2 | cut -d: -f2)
-  mv "$contract" "$OUT_DIR/$contract_name@$version.wasm"
-done

--- a/scripts/build_all_arm.sh
+++ b/scripts/build_all_arm.sh
@@ -2,7 +2,7 @@
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/optimizer:0.16.1
+  cosmwasm/optimizer-arm64:0.16.1
 
 OUT_DIR="artifacts"
 


### PR DESCRIPTION
# Motivation

These changes add a new package that allows deployment of the operating system on to a given chain. Currently only `galileo-4` is supported but support for other chains can be implemented easily in future.

# Implementation

A new `deploy` package was added. It utilises `cw-orchestrator` to upload and instantiate/migrate the OS contracts and complete any required setup steps. This can be run using the following:

```sh
make build
make deploy
```

The following environment variables are required:
- `DEPLOYMENT_CHAIN` - the chain id or name of the chain
- `TEST_MNEMONIC` - the mnemonic of the wallet you wish to use

The following environment variables are optional:
- `DEPLOYMENT_KERNEL_ADDRESS` - the kernel address you wish to update
- `SLACK_WEBHOOK_URL` - used for slack notifications

# Future work

This should be extended to also deploy available/chosen ADOs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new deployment workflow for easier manual deployment with input parameters.
  - Added a deployment script that integrates with Slack for notifications about deployment status.
  - Implemented several new contract interfaces for better contract management.
  - Enhanced the `ExecuteMsg` enums across various modules to support new execution functions.
  - Added support for building ARM contracts.
  - Introduced scripts for attaching contract versions to WebAssembly files.

- **Bug Fixes**
  - Enhanced validation for usernames and paths in the VFS module.
  - Improved migration logic in the ADOContract to allow version equality.

- **Documentation**
  - Updated `CHANGELOG.md` to reflect notable changes and enhancements.

- **Chores**
  - Added a new script for building WebAssembly contracts using Docker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->