### PR TITLE
fix: validator staking distribution message for andromeda chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Vesting: Added validation to the instantiation process [(#583)](https://github.com/andromedaprotocol/andromeda-core/pull/583)
 - Fix precision issue with vestings claim batch method [(#555)](https://github.com/andromedaprotocol/andromeda-core/pull/555)
+- (validator-staking) fix: validator staking distribution message for andromeda chain [(#618)](https://github.com/andromedaprotocol/andromeda-core/pull/618)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,8 @@ dependencies = [
  "enum-repr",
  "hex",
  "lazy_static",
+ "osmosis-std-derive 0.15.3",
+ "prost 0.11.9",
  "regex",
  "schemars",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.2.4"
+version = "1.2.4-b.1"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "0.2.3"
+version = "0.2.3-b.1"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
-andromeda-std = { path = "./packages/std", default-features = false, version = "1.0.0", features = [
+andromeda-std = { path = "./packages/std", default-features = false, features = [
     "deploy",
 ] }
 andromeda-macros = { path = "./packages/std/macros", default-features = false, version = "1.0.0" }

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "0.2.3"
+version = "0.2.3-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -21,7 +21,7 @@ cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 serde = { workspace = true }
 
-andromeda-std = { workspace = true }
+andromeda-std = { workspace = true, features = ["distribution"] }
 andromeda-finance = { workspace = true }
 enum-repr = { workspace = true }
 chrono = "0.3"

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -16,8 +16,9 @@ use andromeda_std::{
     ado_base::{InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
     ado_contract::ADOContract,
     amp::AndrAddr,
-    common::{context::ExecuteContext, encode_binary},
+    common::{context::ExecuteContext, distribution::MsgWithdrawDelegatorReward, encode_binary},
     error::ContractError,
+    os::aos_querier::AOSQuerier,
 };
 use enum_repr::EnumRepr;
 
@@ -246,10 +247,23 @@ fn execute_claim(ctx: ExecuteContext, validator: Option<Addr>) -> Result<Respons
         ContractError::InvalidClaim {}
     );
 
-    let res = Response::new()
-        .add_message(DistributionMsg::WithdrawDelegatorReward {
+    let kernel_addr = ADOContract::default().get_kernel_address(deps.storage)?;
+    let curr_chain = AOSQuerier::get_current_chain(&deps.querier, &kernel_addr)?;
+
+    let withdraw_msg: CosmosMsg = if curr_chain == "andromeda" {
+        MsgWithdrawDelegatorReward {
+            delegator_address: delegator.to_string(),
+            validator_address: validator.to_string(),
+        }
+        .into()
+    } else {
+        DistributionMsg::WithdrawDelegatorReward {
             validator: validator.to_string(),
-        })
+        }
+        .into()
+    };
+    let res = Response::new()
+        .add_message(withdraw_msg)
         .add_attribute("action", "validator-claim-reward")
         .add_attribute("validator", validator.to_string());
 

--- a/contracts/os/andromeda-kernel/src/mock.rs
+++ b/contracts/os/andromeda-kernel/src/mock.rs
@@ -20,7 +20,7 @@ pub fn mock_andromeda_kernel() -> Box<dyn Contract<Empty>> {
 pub fn mock_kernel_instantiate_message(owner: Option<String>) -> InstantiateMsg {
     InstantiateMsg {
         owner,
-        chain_name: "andromeda".to_string(),
+        chain_name: "andromeda-local".to_string(),
     }
 }
 

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -11,6 +11,7 @@ primitive = []
 instantiate = []
 rates = ["andromeda-macros/rates"]
 deploy = []
+distribution = ["prost", "osmosis-std-derive"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -39,6 +40,10 @@ serde-json-wasm = "0.5.0"
 enum-repr = { workspace = true }
 sha2 = "0.10.8"
 cw-orch = { workspace = true }
+osmosis-std-derive = { version = "0.15.3", optional = true }
+prost = { version = "0.11.2", default-features = false, features = [
+    "prost-derive",
+], optional = true }
 
 [dev-dependencies]
 cw-multi-test = { version = "1.0.0" }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.2.4"
+version = "1.2.4-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/common/distribution.rs
+++ b/packages/std/src/common/distribution.rs
@@ -1,0 +1,103 @@
+use osmosis_std_derive::CosmwasmExt;
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/andromeda.distribution.v1beta1.MsgSetWithdrawAddress")]
+pub struct MsgSetWithdrawAddress {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub withdraw_address: ::prost::alloc::string::String,
+}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/andromeda.distribution.v1beta1.MsgSetWithdrawAddressResponse")]
+pub struct MsgSetWithdrawAddressResponse {}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/andromeda.distribution.v1beta1.MsgWithdrawDelegatorReward")]
+pub struct MsgWithdrawDelegatorReward {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/andromeda.distribution.v1beta1.MsgWithdrawDelegatorRewardResponse")]
+pub struct MsgWithdrawDelegatorRewardResponse {}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.base.v1beta1.Coin")]
+pub struct Coin {
+    #[prost(string, tag = "1")]
+    pub denom: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub amount: ::prost::alloc::string::String,
+}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation")]
+pub struct MsgCancelUnbondingDelegation {
+    #[prost(string, tag = "1")]
+    pub delegator_address: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub validator_address: ::prost::alloc::string::String,
+    #[prost(message, tag = "3")]
+    pub amount: ::core::option::Option<Coin>,
+    #[prost(uint64, tag = "4")]
+    pub creation_height: u64,
+}

--- a/packages/std/src/common/mod.rs
+++ b/packages/std/src/common/mod.rs
@@ -1,6 +1,8 @@
 pub mod actions;
 pub mod context;
 pub mod denom;
+#[cfg(feature = "distribution")]
+pub mod distribution;
 pub mod expiration;
 pub mod migration;
 pub mod milliseconds;


### PR DESCRIPTION
# Motivation

Andromeda currently runs a custom distribution module. The validator staking ADO needs to adjust the `WithdrawRewards` message for the custom type employed by the Andromeda chain when deployed there.

# Implementation

- Added custom protobuf for Andromeda's custom distribution module
- Added a check if current chain is "andromeda" before choosing the message type

# Testing 

- Tested on chain

# Version Changes

validator-staking => `0.2.3-b.1`
andromeda-std => `1.2.4-b.1`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced Curve ADO, IBC Registry ADO, and Denom Validation in IBC Registry ADO.
	- Added Kernel ICS20 Transfer with optional ExecuteMsg and IBC Denom Wrap/Unwrap.
	- Implemented a deployment script/CI workflow for OS.
  
- **Bug Fixes**
	- Resolved issues with validator staking distribution message for the Andromeda chain.
	- Fixed precision problems in the vesting claim batch method.

- **Changes**
	- Removed staking from the vesting contract and updated the vesting mechanism to use milliseconds.
	- Enhanced reward claiming flexibility in the validator staking contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->