### PR TITLE
feat: Restake Permission

### DIFF
--- a/contracts/finance/andromeda-validator-staking/src/mock.rs
+++ b/contracts/finance/andromeda-validator-staking/src/mock.rs
@@ -9,7 +9,11 @@ use andromeda_testing::{
 };
 use cw_multi_test::{Contract, ContractWrapper};
 
-use andromeda_std::{amp::AndrAddr, error::ContractError};
+use andromeda_std::{
+    ado_base::permissioning::{Permission, PermissioningMessage},
+    amp::AndrAddr,
+    error::ContractError,
+};
 
 pub struct MockValidatorStaking(Addr);
 mock_ado!(MockValidatorStaking, ExecuteMsg, QueryMsg);
@@ -24,6 +28,28 @@ impl MockValidatorStaking {
     ) -> ExecuteResult {
         let msg = mock_execute_stake(validator);
         self.execute(app, &msg, sender, &funds)
+    }
+
+    pub fn execute_set_permission(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        actors: Vec<AndrAddr>,
+        action: String,
+        permission: Permission,
+    ) -> ExecuteResult {
+        let msg = mock_set_permission(actors, action, permission);
+        self.execute(app, &msg, sender, &[])
+    }
+
+    pub fn execute_permission_action(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        action: String,
+    ) -> ExecuteResult {
+        let msg = mock_permission_action(action);
+        self.execute(app, &msg, sender, &[])
     }
 
     pub fn execute_redelegate(
@@ -147,7 +173,20 @@ pub fn mock_execute_withdraw_fund(
 pub fn mock_execute_update_default_validator(validator: Addr) -> ExecuteMsg {
     ExecuteMsg::UpdateDefaultValidator { validator }
 }
-
+pub fn mock_set_permission(
+    actors: Vec<AndrAddr>,
+    action: String,
+    permission: Permission,
+) -> ExecuteMsg {
+    ExecuteMsg::Permissioning(PermissioningMessage::SetPermission {
+        actors,
+        action,
+        permission,
+    })
+}
+pub fn mock_permission_action(action: String) -> ExecuteMsg {
+    ExecuteMsg::Permissioning(PermissioningMessage::PermissionAction { action })
+}
 pub fn mock_get_staked_tokens(validator: Option<Addr>) -> QueryMsg {
     QueryMsg::StakedTokens { validator }
 }

--- a/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
+++ b/contracts/finance/andromeda-validator-staking/src/testing/tests.rs
@@ -13,7 +13,6 @@ use cosmwasm_std::{
 use andromeda_finance::validator_staking::{ExecuteMsg, InstantiateMsg};
 
 const OWNER: &str = "owner";
-const ANYONE: &str = "anyone";
 
 fn init(deps: DepsMut, default_validator: Addr) -> Result<Response, ContractError> {
     let msg = InstantiateMsg {
@@ -146,31 +145,6 @@ fn test_unauthorized_unstake() {
     };
 
     let info = mock_info("other", &[coin(100, "uandr")]);
-    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
-    assert_eq!(res, ContractError::Unauthorized {});
-}
-
-#[test]
-fn test_unauthorized_claim() {
-    let mut deps = mock_dependencies_custom();
-    let default_validator = Addr::unchecked(DEFAULT_VALIDATOR);
-    let valid_validator = Addr::unchecked(VALID_VALIDATOR);
-    init(deps.as_mut(), default_validator).unwrap();
-
-    let msg = ExecuteMsg::Stake {
-        validator: Some(valid_validator.clone()),
-    };
-
-    let info = mock_info(OWNER, &[coin(100, "uandr")]);
-
-    execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-
-    let msg = ExecuteMsg::Claim {
-        validator: Some(valid_validator.clone()),
-        restake: None,
-    };
-
-    let info = mock_info(ANYONE, &[coin(100, "uandr")]);
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
     assert_eq!(res, ContractError::Unauthorized {});
 }

--- a/packages/andromeda-finance/src/validator_staking.rs
+++ b/packages/andromeda-finance/src/validator_staking.rs
@@ -4,6 +4,8 @@ use cosmwasm_std::{Addr, Coin, DepsMut, Timestamp, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+pub const RESTAKING_ACTION: &str = "restake";
+
 #[andr_instantiate]
 #[cw_serde]
 pub struct InstantiateMsg {


### PR DESCRIPTION
# Motivation
@crnbarr93 's [suggestion](https://github.com/andromedaprotocol/andromeda-core/pull/622#discussion_r1846701394) 
# Implementation
Contract owner should permission the `restake` action, then set permission to actors to restake on his behalf. Normal claiming is still restricted to contract owner only. 

# Testing
Added integration test. 

# Version Changes
`validator-staking`: `3.0.3-beta` -> ?

# Notes
The "restake" action is hard-coded, not derived from an `ExecuteMsg` name. 

# Future work
Give permission for `Claim` as well?
