### PR TITLE
chore: changelog entry and version modification for vesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AMPPkt verify origin fix [(#552)](https://github.com/andromedaprotocol/andromeda-core/pull/552)
 - Fix permissioning limited use consumptions and blacklist bypass scenario [(#553)](https://github.com/andromedaprotocol/andromeda-core/pull/553)
 - Crowdfund: fixed error related to `QueryMsg::Tiers` message handler [(#563)](https://github.com/andromedaprotocol/andromeda-core/pull/563)
+- Vesting: Recipient validation for VFS paths [(#641)](https://github.com/andromedaprotocol/andromeda-core/pull/641)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.4-beta"
+version = "3.0.4-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.4-beta"
+version = "3.0.4-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 


### PR DESCRIPTION
# Motivation
Make versioning format consistent. Add changelog entry for this [PR](https://github.com/andromedaprotocol/andromeda-core/pull/641)

# Implementation
Version went from `3.0.4-beta` to `3.0.4-b.1`

# Testing
None

# Version Changes
Version went from `3.0.4-beta` to `3.0.4-b.1`

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced several new ADOs: Curve ADO, IBC Registry ADO, and MultiSig ADO.
	- Added functionalities for Denom Validation in IBC Registry ADO and Kernel ICS20 Transfer with optional ExecuteMsg.
	- Implemented IBC Denom Wrap/Unwrap and recipient validation for VFS paths.
	- Added a deployment script and CI workflow for OS, along with deployable interfaces for all ADOs.

- **Bug Fixes**
	- Enhanced validation during vesting instantiation and fixed a precision issue in the vesting claim batch method.
	- Resolved validator staking distribution message issues for the Andromeda chain.

- **Chores**
	- Updated the `CHANGELOG.md` to reflect these changes and removed schemas from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->