### PR TITLE
Version changed to 0.x.0-beta for undeployed contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-boolean"
-version = "2.0.3"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-counter"
-version = "1.0.2"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-curve"
-version = "1.0.0"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-date-time"
-version = "1.0.1"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-multisig"
-version = "1.0.0"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-graph"
-version = "1.1.0"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-point"
-version = "1.0.0"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-string-storage"
-version = "1.0.3"
+version = "0.1.0-beta"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",

--- a/contracts/data-storage/andromeda-boolean/Cargo.toml
+++ b/contracts/data-storage/andromeda-boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-boolean"
-version = "2.0.3"
+version = "0.1.0-beta"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-counter/Cargo.toml
+++ b/contracts/data-storage/andromeda-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-counter"
-version = "1.0.2"
+version = "0.1.0-beta"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-graph/Cargo.toml
+++ b/contracts/data-storage/andromeda-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-graph"
-version = "1.1.0"
+version = "0.1.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/data-storage/andromeda-point/Cargo.toml
+++ b/contracts/data-storage/andromeda-point/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-point"
-version = "1.0.0"
+version = "0.1.0-beta"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/data-storage/andromeda-string-storage/Cargo.toml
+++ b/contracts/data-storage/andromeda-string-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-string-storage"
-version = "1.0.3"
+version = "0.1.0-beta"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/finance/andromeda-fixed-multisig/Cargo.toml
+++ b/contracts/finance/andromeda-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-multisig"
-version = "1.0.0"
+version = "0.1.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-curve/Cargo.toml
+++ b/contracts/modules/andromeda-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-curve"
-version = "1.0.0"
+version = "0.1.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-date-time/Cargo.toml
+++ b/contracts/modules/andromeda-date-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-date-time"
-version = "1.0.1"
+version = "0.1.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 


### PR DESCRIPTION
# Implementation
New contracts that are not yet deployed will have their version changed to 0.x.0-beta.

## List of ADOs to beta version
- Boolean ADO
- Counter ADO
- Graph ADO
- Point ADO
- String ADO
- Fixed Multisig ADO
- Curve ADO
- Date Time ADO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- All packages have transitioned to a pre-release version (`0.1.0-beta`), indicating new features and improvements are being introduced.
	- Added a new dependency, `cw3-fixed-multisig`, to the `andromeda-fixed-multisig` package.

- **Bug Fixes**
	- Adjustments made to the versioning scheme across multiple packages for better clarity.

- **Chores**
	- Updated dependencies and features management across various packages to streamline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->