### PR TITLE
ref: rename release_unit to release_duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.4-b.1"
+version = "3.0.4-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.4-b.1"
+version = "3.0.4-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/src/state.rs
+++ b/contracts/finance/andromeda-vesting/src/state.rs
@@ -22,8 +22,8 @@ pub struct Batch {
     /// When the lockup ends.
     pub lockup_end: Milliseconds,
     /// How often releases occur.
-    pub release_unit: Milliseconds,
-    /// Specifies how much is to be released after each `release_unit`. If
+    pub release_duration: Milliseconds,
+    /// Specifies how much is to be released after each `release_duration`. If
     /// it is a percentage, it would be the percentage of the original amount.
     pub release_amount: WithdrawalType,
     /// The time at which the last claim took place in seconds.
@@ -140,7 +140,7 @@ mod tests {
             amount: Uint128::new(100),
             amount_claimed: Uint128::zero(),
             lockup_end: current_time.plus_seconds(10),
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
             last_claimed_release_time: current_time.minus_seconds(1),
         };
@@ -149,7 +149,7 @@ mod tests {
             amount: Uint128::new(100),
             amount_claimed: Uint128::zero(),
             lockup_end: current_time.minus_seconds(1),
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
             last_claimed_release_time: current_time.minus_seconds(1),
         };
@@ -158,7 +158,7 @@ mod tests {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(100),
             lockup_end: current_time.minus_seconds(1),
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
             last_claimed_release_time: current_time.minus_seconds(1),
         };

--- a/contracts/finance/andromeda-vesting/src/testing/tests.rs
+++ b/contracts/finance/andromeda-vesting/src/testing/tests.rs
@@ -247,7 +247,10 @@ fn test_create_batch() {
             .add_attribute("action", "create_batch")
             .add_attribute("amount", "100")
             .add_attribute("lockup_end", current_time.to_string())
-            .add_attribute("release_duration", Milliseconds::from_seconds(10).to_string())
+            .add_attribute(
+                "release_duration",
+                Milliseconds::from_seconds(10).to_string()
+            )
             .add_attribute("release_amount", "Amount(Uint128(10))"),
         res
     );
@@ -282,7 +285,10 @@ fn test_create_batch() {
             .add_attribute("action", "create_batch")
             .add_attribute("amount", "100")
             .add_attribute("lockup_end", (current_time.plus_seconds(100)).to_string())
-            .add_attribute("release_duration", Milliseconds::from_seconds(10).to_string())
+            .add_attribute(
+                "release_duration",
+                Milliseconds::from_seconds(10).to_string()
+            )
             .add_attribute("release_amount", "Amount(Uint128(10))"),
         res
     );
@@ -920,7 +926,12 @@ fn test_claim_all() {
 
     let release_amount = WithdrawalType::Amount(Uint128::new(10));
     // Create batch.
-    create_batch(deps.as_mut(), None, release_duration, release_amount.clone());
+    create_batch(
+        deps.as_mut(),
+        None,
+        release_duration,
+        release_amount.clone(),
+    );
 
     // Create batch with half of the release_duration.
     create_batch(

--- a/contracts/finance/andromeda-vesting/src/testing/tests.rs
+++ b/contracts/finance/andromeda-vesting/src/testing/tests.rs
@@ -33,13 +33,13 @@ fn init(deps: DepsMut) -> Response {
 fn create_batch(
     deps: DepsMut,
     lockup_duration: Option<Milliseconds>,
-    release_unit: Milliseconds,
+    release_duration: Milliseconds,
     release_amount: WithdrawalType,
 ) -> Response {
-    // Create batch with half of the release_unit.
+    // Create batch with half of the release_duration.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration,
-        release_unit,
+        release_duration,
         release_amount,
     };
 
@@ -116,7 +116,7 @@ fn test_create_batch_unauthorized() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(1),
+        release_duration: Milliseconds::from_seconds(1),
         release_amount: WithdrawalType::Amount(Uint128::zero()),
     };
 
@@ -135,7 +135,7 @@ fn test_create_batch_no_funds() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(1),
+        release_duration: Milliseconds::from_seconds(1),
         release_amount: WithdrawalType::Amount(Uint128::zero()),
     };
 
@@ -158,7 +158,7 @@ fn test_create_batch_invalid_denom() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(1),
+        release_duration: Milliseconds::from_seconds(1),
         release_amount: WithdrawalType::Amount(Uint128::zero()),
     };
 
@@ -181,7 +181,7 @@ fn test_create_batch_valid_denom_zero_amount() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(1),
+        release_duration: Milliseconds::from_seconds(1),
         release_amount: WithdrawalType::Amount(Uint128::zero()),
     };
 
@@ -191,7 +191,7 @@ fn test_create_batch_valid_denom_zero_amount() {
 }
 
 #[test]
-fn test_create_batch_release_unit_zero() {
+fn test_create_batch_release_duration_zero() {
     let mut deps = mock_dependencies_custom(&[coin(100000, MOCK_NATIVE_DENOM)]);
     init(deps.as_mut());
 
@@ -199,7 +199,7 @@ fn test_create_batch_release_unit_zero() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::zero(),
+        release_duration: Milliseconds::zero(),
         release_amount: WithdrawalType::Amount(Uint128::zero()),
     };
 
@@ -217,7 +217,7 @@ fn test_create_batch_release_amount_zero() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(10),
+        release_duration: Milliseconds::from_seconds(10),
         release_amount: WithdrawalType::Amount(Uint128::zero()),
     };
 
@@ -235,7 +235,7 @@ fn test_create_batch() {
 
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(10),
+        release_duration: Milliseconds::from_seconds(10),
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -247,7 +247,7 @@ fn test_create_batch() {
             .add_attribute("action", "create_batch")
             .add_attribute("amount", "100")
             .add_attribute("lockup_end", current_time.to_string())
-            .add_attribute("release_unit", Milliseconds::from_seconds(10).to_string())
+            .add_attribute("release_duration", Milliseconds::from_seconds(10).to_string())
             .add_attribute("release_amount", "Amount(Uint128(10))"),
         res
     );
@@ -259,7 +259,7 @@ fn test_create_batch() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::zero(),
             lockup_end: current_time,
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
             last_claimed_release_time: current_time,
         },
@@ -271,7 +271,7 @@ fn test_create_batch() {
     // Try to create another batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: Some(Milliseconds::from_seconds(100)),
-        release_unit: Milliseconds::from_seconds(10),
+        release_duration: Milliseconds::from_seconds(10),
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -282,7 +282,7 @@ fn test_create_batch() {
             .add_attribute("action", "create_batch")
             .add_attribute("amount", "100")
             .add_attribute("lockup_end", (current_time.plus_seconds(100)).to_string())
-            .add_attribute("release_unit", Milliseconds::from_seconds(10).to_string())
+            .add_attribute("release_duration", Milliseconds::from_seconds(10).to_string())
             .add_attribute("release_amount", "Amount(Uint128(10))"),
         res
     );
@@ -294,7 +294,7 @@ fn test_create_batch() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::zero(),
             lockup_end: current_time.plus_seconds(100),
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
             last_claimed_release_time: current_time.plus_seconds(100),
         },
@@ -330,7 +330,7 @@ fn test_claim_batch_still_locked() {
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: Some(Milliseconds::from_seconds(100)),
-        release_unit: Milliseconds::from_seconds(10),
+        release_duration: Milliseconds::from_seconds(10),
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -356,7 +356,7 @@ fn test_claim_batch_no_funds_available() {
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit: Milliseconds::from_seconds(10),
+        release_duration: Milliseconds::from_seconds(10),
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -380,12 +380,12 @@ fn test_claim_batch_single_claim() {
     init(deps.as_mut());
     let info = mock_info("owner", &coins(100, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -398,7 +398,7 @@ fn test_claim_batch_single_claim() {
     // Skip time.
     let mut env = mock_env();
     // A single release is available.
-    env.block.time = env.block.time.plus_seconds(release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(release_duration.seconds());
 
     // Query created batch.
     let msg = QueryMsg::Batch { id: 1 };
@@ -413,7 +413,7 @@ fn test_claim_batch_single_claim() {
             amount_available_to_claim: Uint128::new(10),
             number_of_available_claims: Uint128::new(1),
             lockup_end,
-            release_unit,
+            release_duration,
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
             last_claimed_release_time: lockup_end,
         },
@@ -447,9 +447,9 @@ fn test_claim_batch_single_claim() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(10),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_milliseconds(release_unit),
+            last_claimed_release_time: lockup_end.plus_milliseconds(release_duration),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -461,12 +461,12 @@ fn test_claim_batch_not_nice_numbers_single_release() {
     init(deps.as_mut());
     let info = mock_info("owner", &coins(10, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -479,7 +479,7 @@ fn test_claim_batch_not_nice_numbers_single_release() {
     // Skip time.
     let mut env = mock_env();
     // A single release is available.
-    env.block.time = env.block.time.plus_seconds(release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(release_duration.seconds());
 
     // Claim batch.
     let msg = ExecuteMsg::Claim {
@@ -508,9 +508,9 @@ fn test_claim_batch_not_nice_numbers_single_release() {
             amount: Uint128::new(10),
             amount_claimed: Uint128::new(7),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_milliseconds(release_unit),
+            last_claimed_release_time: lockup_end.plus_milliseconds(release_duration),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -523,14 +523,14 @@ fn test_claim_batch_not_nice_numbers_multiple_releases() {
     let vesting_amount = 1_000_000_000_000_000_000u128;
     let info = mock_info("owner", &coins(vesting_amount, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(1); // 1 second
+    let release_duration = Milliseconds::from_seconds(1); // 1 second
     let duration: u64 = 60 * 60 * 24 * 365 * 5; // 5 years
     let percent_release = Decimal::from_ratio(Uint128::one(), Uint128::from(duration));
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Percentage(percent_release),
     };
 
@@ -543,7 +543,7 @@ fn test_claim_batch_not_nice_numbers_multiple_releases() {
     // Skip time.
     let mut env = mock_env();
     // Two releases are out.
-    env.block.time = env.block.time.plus_seconds(2 * release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(2 * release_duration.seconds());
 
     // Claim batch.
     let msg = ExecuteMsg::Claim {
@@ -572,9 +572,9 @@ fn test_claim_batch_not_nice_numbers_multiple_releases() {
             amount: Uint128::new(vesting_amount),
             amount_claimed: Uint128::new(12683916792),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(1),
+            release_duration: Milliseconds::from_seconds(1),
             release_amount: WithdrawalType::Percentage(percent_release),
-            last_claimed_release_time: lockup_end.plus_seconds(2 * release_unit.seconds()),
+            last_claimed_release_time: lockup_end.plus_seconds(2 * release_duration.seconds()),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -600,7 +600,7 @@ fn test_claim_batch_not_nice_numbers_multiple_releases() {
             amount: Uint128::new(vesting_amount),
             amount_claimed: Uint128::from(vesting_amount),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(1),
+            release_duration: Milliseconds::from_seconds(1),
             release_amount: WithdrawalType::Percentage(percent_release),
             last_claimed_release_time: lockup_end.plus_seconds(duration + 2),
         },
@@ -614,12 +614,12 @@ fn test_claim_batch_middle_of_interval() {
     init(deps.as_mut());
     let info = mock_info("owner", &coins(100, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -637,14 +637,14 @@ fn test_claim_batch_middle_of_interval() {
 
     let mut env = mock_env();
     // Only halfway to first release.
-    env.block.time = env.block.time.plus_seconds(release_unit.seconds() / 2);
+    env.block.time = env.block.time.plus_seconds(release_duration.seconds() / 2);
 
     let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
 
     assert_eq!(ContractError::WithdrawalIsEmpty {}, res.unwrap_err());
 
     // First release available and halfway to second -> result is rounding down.
-    env.block.time = env.block.time.plus_seconds(release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(release_duration.seconds());
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
 
     assert_eq!(
@@ -666,9 +666,9 @@ fn test_claim_batch_middle_of_interval() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(10),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_milliseconds(release_unit),
+            last_claimed_release_time: lockup_end.plus_milliseconds(release_duration),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -680,12 +680,12 @@ fn test_claim_batch_multiple_claims() {
     init(deps.as_mut());
     let info = mock_info("owner", &coins(100, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -698,7 +698,7 @@ fn test_claim_batch_multiple_claims() {
     let mut env = mock_env();
 
     // 4 releases are available.
-    env.block.time = env.block.time.plus_seconds(4 * release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(4 * release_duration.seconds());
 
     // Claim only the first release.
     let msg = ExecuteMsg::Claim {
@@ -726,9 +726,9 @@ fn test_claim_batch_multiple_claims() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(10),
             lockup_end,
-            release_unit,
+            release_duration,
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_milliseconds(release_unit),
+            last_claimed_release_time: lockup_end.plus_milliseconds(release_duration),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -759,9 +759,9 @@ fn test_claim_batch_multiple_claims() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(40),
             lockup_end,
-            release_unit,
+            release_duration,
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_seconds(4 * release_unit.seconds()),
+            last_claimed_release_time: lockup_end.plus_seconds(4 * release_duration.seconds()),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -773,12 +773,12 @@ fn test_claim_batch_all_releases() {
     init(deps.as_mut());
     let info = mock_info("owner", &coins(100, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -790,9 +790,9 @@ fn test_claim_batch_all_releases() {
 
     let mut env = mock_env();
 
-    // All releases are available and then some (10 * release_unit would be when all releases
+    // All releases are available and then some (10 * release_duration would be when all releases
     // become available).
-    env.block.time = env.block.time.plus_seconds(15 * release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(15 * release_duration.seconds());
 
     // Claim only the first release.
     let msg = ExecuteMsg::Claim {
@@ -820,9 +820,9 @@ fn test_claim_batch_all_releases() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(100),
             lockup_end,
-            release_unit,
+            release_duration,
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_seconds(15 * release_unit.seconds()),
+            last_claimed_release_time: lockup_end.plus_seconds(15 * release_duration.seconds()),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -839,12 +839,12 @@ fn test_claim_batch_too_high_of_claim() {
     init(deps.as_mut());
     let info = mock_info("owner", &coins(100, "uusd"));
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     // Create batch.
     let msg = ExecuteMsg::CreateBatch {
         lockup_duration: None,
-        release_unit,
+        release_duration,
         release_amount: WithdrawalType::Amount(Uint128::new(10)),
     };
 
@@ -856,7 +856,7 @@ fn test_claim_batch_too_high_of_claim() {
 
     let mut env = mock_env();
     // A single release is available.
-    env.block.time = env.block.time.plus_seconds(release_unit.seconds());
+    env.block.time = env.block.time.plus_seconds(release_duration.seconds());
 
     // Try to claim 3 releases.
     let msg = ExecuteMsg::Claim {
@@ -886,9 +886,9 @@ fn test_claim_batch_too_high_of_claim() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(10),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(10),
+            release_duration: Milliseconds::from_seconds(10),
             release_amount: WithdrawalType::Amount(Uint128::new(10)),
-            last_claimed_release_time: lockup_end.plus_milliseconds(release_unit),
+            last_claimed_release_time: lockup_end.plus_milliseconds(release_duration),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -916,21 +916,21 @@ fn test_claim_all() {
     let mut deps = mock_dependencies_custom(&[coin(100000, MOCK_NATIVE_DENOM)]);
     init(deps.as_mut());
 
-    let release_unit = Milliseconds::from_seconds(10);
+    let release_duration = Milliseconds::from_seconds(10);
 
     let release_amount = WithdrawalType::Amount(Uint128::new(10));
     // Create batch.
-    create_batch(deps.as_mut(), None, release_unit, release_amount.clone());
+    create_batch(deps.as_mut(), None, release_duration, release_amount.clone());
 
-    // Create batch with half of the release_unit.
+    // Create batch with half of the release_duration.
     create_batch(
         deps.as_mut(),
         None,
-        Milliseconds::from_seconds(release_unit.seconds() / 2),
+        Milliseconds::from_seconds(release_duration.seconds() / 2),
         release_amount.clone(),
     );
 
-    // Create batch with a different release_unit scale (not a factor).
+    // Create batch with a different release_duration scale (not a factor).
     create_batch(
         deps.as_mut(),
         None,
@@ -942,7 +942,7 @@ fn test_claim_all() {
     create_batch(
         deps.as_mut(),
         Some(Milliseconds::from_seconds(100)),
-        release_unit,
+        release_duration,
         release_amount.clone(),
     );
 
@@ -952,7 +952,7 @@ fn test_claim_all() {
 
     // Speed up time.
     let mut env = mock_env();
-    env.block.time = env.block.time.plus_seconds(release_unit.seconds() * 2);
+    env.block.time = env.block.time.plus_seconds(release_duration.seconds() * 2);
 
     // Query batches
     let msg = QueryMsg::Batches {
@@ -972,7 +972,7 @@ fn test_claim_all() {
                 amount_available_to_claim: Uint128::new(20),
                 number_of_available_claims: Uint128::new(2),
                 lockup_end,
-                release_unit,
+                release_duration,
                 release_amount: WithdrawalType::Amount(Uint128::new(10)),
                 last_claimed_release_time: lockup_end,
             },
@@ -983,7 +983,7 @@ fn test_claim_all() {
                 amount_available_to_claim: Uint128::new(40),
                 number_of_available_claims: Uint128::new(4),
                 lockup_end,
-                release_unit: Milliseconds::from_seconds(release_unit.seconds() / 2),
+                release_duration: Milliseconds::from_seconds(release_duration.seconds() / 2),
                 release_amount: WithdrawalType::Amount(Uint128::new(10)),
                 last_claimed_release_time: lockup_end,
             },
@@ -994,7 +994,7 @@ fn test_claim_all() {
                 amount_available_to_claim: Uint128::new(10),
                 number_of_available_claims: Uint128::new(1),
                 lockup_end,
-                release_unit: Milliseconds::from_seconds(12),
+                release_duration: Milliseconds::from_seconds(12),
                 release_amount: WithdrawalType::Amount(Uint128::new(10)),
                 last_claimed_release_time: lockup_end,
             },
@@ -1005,7 +1005,7 @@ fn test_claim_all() {
                 amount_available_to_claim: Uint128::zero(),
                 number_of_available_claims: Uint128::zero(),
                 lockup_end: lockup_end.plus_seconds(100),
-                release_unit,
+                release_duration,
                 release_amount: WithdrawalType::Amount(Uint128::new(10)),
                 last_claimed_release_time: lockup_end.plus_seconds(100),
             },
@@ -1040,9 +1040,9 @@ fn test_claim_all() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(20),
             lockup_end,
-            release_unit,
+            release_duration,
             release_amount: release_amount.clone(),
-            last_claimed_release_time: lockup_end.plus_seconds(release_unit.seconds() * 2),
+            last_claimed_release_time: lockup_end.plus_seconds(release_duration.seconds() * 2),
         },
         batches().load(deps.as_ref().storage, 1u64).unwrap()
     );
@@ -1052,9 +1052,9 @@ fn test_claim_all() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(40),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(release_unit.seconds() / 2),
+            release_duration: Milliseconds::from_seconds(release_duration.seconds() / 2),
             release_amount: release_amount.clone(),
-            last_claimed_release_time: lockup_end.plus_seconds(release_unit.seconds() * 2),
+            last_claimed_release_time: lockup_end.plus_seconds(release_duration.seconds() * 2),
         },
         batches().load(deps.as_ref().storage, 2u64).unwrap()
     );
@@ -1064,7 +1064,7 @@ fn test_claim_all() {
             amount: Uint128::new(100),
             amount_claimed: Uint128::new(10),
             lockup_end,
-            release_unit: Milliseconds::from_seconds(12),
+            release_duration: Milliseconds::from_seconds(12),
             release_amount,
             last_claimed_release_time: lockup_end.plus_seconds(12),
         },

--- a/packages/andromeda-finance/src/vesting.rs
+++ b/packages/andromeda-finance/src/vesting.rs
@@ -37,8 +37,8 @@ pub enum ExecuteMsg {
         /// Specifying None would mean no lock up period and funds start vesting right away.
         lockup_duration: Option<Milliseconds>,
         /// How often releases occur in seconds.
-        release_unit: Milliseconds,
-        /// Specifies how much is to be released after each `release_unit`. If
+        release_duration: Milliseconds,
+        /// Specifies how much is to be released after each `release_duration`. If
         /// it is a percentage, it would be the percentage of the original amount.
         release_amount: WithdrawalType,
     },
@@ -85,8 +85,8 @@ pub struct BatchResponse {
     /// When the lockup ends.
     pub lockup_end: Milliseconds,
     /// How often releases occur.
-    pub release_unit: Milliseconds,
-    /// Specifies how much is to be released after each `release_unit`. If
+    pub release_duration: Milliseconds,
+    /// Specifies how much is to be released after each `release_duration`. If
     /// it is a percentage, it would be the percentage of the original amount.
     pub release_amount: WithdrawalType,
     /// The time at which the last claim took place in seconds.


### PR DESCRIPTION
# Motivation
The variable needs to end with `duration` for consistency. 

# Implementation
rename `release_unit` to `release_duration`

# Testing
None

# Version Changes
`vesting`: `3.0.4-b.1` -> `3.0.4-b.2`

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version of the `andromeda-vesting` package to `3.0.4-b.2`.
	- Enhanced clarity in the contract's functionality with consistent terminology by renaming `release_unit` to `release_duration`.

- **Bug Fixes**
	- Improved validation checks to ensure `release_duration` is not zero.

- **Documentation**
	- Updated comments throughout the codebase to reflect the new naming convention for `release_duration`. 

- **Tests**
	- Adjusted test cases to align with the updated naming and ensure consistency in functionality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->