### PR TITLE
Release 3 Changelog and Backport tags

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,3 +13,11 @@ pull_request_rules:
       backport:
         branches:
           - v1.1.x
+  - name: backport to release/3 branch
+    conditions:
+      - base=development
+      - label=backport/release/3
+    actions:
+      backport:
+        branches:
+          - release/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Curve ADO [(#515)](https://github.com/andromedaprotocol/andromeda-core/pull/515)
+### Changed
+
+### Fixed
+
+## Release 3
+
+### Added
+
 - Added IBC Registry ADO [(#566)](https://github.com/andromedaprotocol/andromeda-core/pull/566)
 - Added Denom Validation in IBC Registry ADO [(#571)](https://github.com/andromedaprotocol/andromeda-core/pull/571)
 - Added Kernel ICS20 Transfer with Optional ExecuteMsg [(#577)](https://github.com/andromedaprotocol/andromeda-core/pull/577)
@@ -17,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added deployment script/CI workflow for OS [(#616)](https://github.com/andromedaprotocol/andromeda-core/pull/616)
 - Added deployable interfaces to all ADOs [(#620)](https://github.com/andromedaprotocol/andromeda-core/pull/620)
 - Added MultiSig ADO [(#619)](https://github.com/andromedaprotocol/andromeda-core/pull/619)
+- Added Validator Staking ADO [(#330)](https://github.com/andromedaprotocol/andromeda-core/pull/330)
+- Added Restake and Redelegate to Validator Staking [(#622)](https://github.com/andromedaprotocol/andromeda-core/pull/622)
 
 ### Changed
 
@@ -35,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Validator Staking ADO [(#330)](https://github.com/andromedaprotocol/andromeda-core/pull/330)
 - Added `Asset` enum [(#415)](https://github.com/andromedaprotocol/andromeda-core/pull/415)
 - Added `ADOBaseVersion` query to all ADOs [(#416)](https://github.com/andromedaprotocol/andromeda-core/pull/416)
 - Staking: Added ability to remove/replace reward token [(#418)](https://github.com/andromedaprotocol/andromeda-core/pull/418)
@@ -54,7 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added BuyNow option for Auction [(#533)](https://github.com/andromedaprotocol/andromeda-core/pull/533)
 - Include ADOBase Version in Schema [(#574)](https://github.com/andromedaprotocol/andromeda-core/pull/574)
 - Added multi-hop support for IBC [(#604)](https://github.com/andromedaprotocol/andromeda-core/pull/604)
-- Added Restake and Redelegate to Validator Staking [(#622)](https://github.com/andromedaprotocol/andromeda-core/pull/622)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "0.3.0-b.1"
+version = "0.3.0"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.4-b.2"
+version = "3.0.4"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "0.3.0-b.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.4-b.2"
+version = "3.0.4"
 edition = "2021"
 rust-version = "1.75.0"
 


### PR DESCRIPTION
# Motivation

Adds mergify support for release 3 backporting and fixes the changelog for release 3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new pull request rule for backporting changes to the `release/3` branch.
	- Added "Validator Staking ADO" and "Restake and Redelegate" features in the Release 3 section of the changelog.

- **Bug Fixes**
	- Updated validations and fixes related to the vesting process and validator staking distribution messages.

- **Documentation**
	- Enhanced organization of the CHANGELOG with clearer categories for changes.

- **Chores**
	- Updated version numbers for `andromeda-validator-staking` and `andromeda-vesting` packages to indicate stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->