### PR TITLE
Trigger tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,91 +178,58 @@ jobs:
               echo "No changes to commit"
             fi
 
-        - name: Trigger Armor Workflow
-          uses: actions/github-script@v7
-          with:
-            github-token: ${{ secrets.CI_PAT }}
-            script: |
-              const kernelAddress = '${{ inputs.kernel_address }}';
-              const testnetKernels = '${{ vars.TESTNET_KERNELS }}';
-              const testnetStagingKernels = '${{ vars.TESTNET_STAGING_KERNELS }}';
-              
-              // Read the version map
-              const fs = require('fs');
-              const versionMap = fs.readFileSync('artifacts/version-map.json', 'utf8');
-              
-              let workflowFile;
-              if (kernelAddress === testnetKernels) {
-                workflowFile = 'develop.yml';
-              } else if (kernelAddress === testnetStagingKernels) {
-                workflowFile = 'staging.yml';
-              } else {
-                core.setFailed('Error: Kernel not found in known configurations');
-                return;
-              }
-              
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: 'andromedaprotocol',
-                  repo: 'andromeda-armor',
-                  workflow_id: workflowFile,
-                  ref: 'main',
-                  inputs: {
-                    version_map: versionMap
-                  }
-                });
-              } catch (error) {
-                core.setFailed(`Failed to trigger Armor workflow: ${error.message}`);
-              }
+  trigger-armour-workflow:      
+    needs: [build_contracts, build_schemas, build_deploy_script, deploy, trigger-schema-parser]
+    runs-on: ubuntu-latest
+    steps:       
+      - name: Download version-map
+        uses: actions/download-artifact@v4
+        with:
+          name: contracts
+          path: "artifacts"
 
-              - name: Download version-map
-              uses: actions/download-artifact@v4
-              with:
-                name: contracts
-                path: "artifacts"
+      - name: Extract version map
+        run: |
+          cd artifacts
+          ls -a
+          unzip -o contracts.zip
+          ls -a
+          cat version-map.json
+          cp version-map.json ../version-map.json  
+
+      - name: Trigger Armor Workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CI_PAT }}
+          script: |
+            const kernelAddress = '${{ inputs.kernel_address }}';
+            const testnetKernels = '${{ vars.TESTNET_KERNELS }}';
+            const testnetStagingKernels = '${{ vars.TESTNET_STAGING_KERNELS }}';
             
-        - name: Extract version map
-          run: |
-            cd artifacts
-            ls -a
-            unzip -o contracts.zip
-            ls -a
-            cat version-map.json
-            cp version-map.json ../version-map.json  
-        
-        - name: Trigger Armor Workflow
-          uses: actions/github-script@v7
-          with:
-            github-token: ${{ secrets.CI_PAT }}
-            script: |
-              const kernelAddress = '${{ inputs.kernel_address }}';
-              const testnetKernels = '${{ vars.TESTNET_KERNELS }}';
-              const testnetStagingKernels = '${{ vars.TESTNET_STAGING_KERNELS }}';
-              
-              // Read the version map
-              const fs = require('fs');
-              const versionMap = fs.readFileSync('version-map.json', 'utf8');
-              
-              let workflowFile;
-              if (kernelAddress === testnetKernels) {
-                workflowFile = 'develop.yml';
-              } else if (kernelAddress === testnetStagingKernels) {
-                workflowFile = 'staging.yml';
-              } else {
-                core.setFailed('Error: Kernel not found in known configurations');
-                return;
-              }
-              
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: 'andromedaprotocol',
-                  repo: 'andromeda-armor',
-                  workflow_id: workflowFile,
-                  ref: 'main',
-                  inputs: {
-                    version_map: versionMap
-                  }
-                });
-              } catch (error) {
-                core.setFailed(`Failed to trigger Armor workflow: ${error.message}`);
-              }
+            // Read the version map
+            const fs = require('fs');
+            const versionMap = fs.readFileSync('version-map.json', 'utf8');
+            
+            let workflowFile;
+            if (kernelAddress === testnetKernels) {
+              workflowFile = 'develop.yml';
+            } else if (kernelAddress === testnetStagingKernels) {
+              workflowFile = 'staging.yml';
+            } else {
+              core.setFailed('Error: Kernel not found in known configurations');
+              return;
+            }
+            
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: 'andromedaprotocol',
+                repo: 'andromeda-armor',
+                workflow_id: workflowFile,
+                ref: 'main',
+                inputs: {
+                  version_map: versionMap
+                }
+              });
+            } catch (error) {
+              core.setFailed(`Failed to trigger Armor workflow: ${error.message}`);
+            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,14 @@ jobs:
               echo "Error: Kernel not found in known configurations"
               exit 1
             fi
+        - name: Download version-map
+          uses: actions/download-artifact@v4
+          with:
+            name: contracts
+            path: "artifacts"
+
+        - run: |
+            echo "version-map.json"
 
         - name: Checkout Schema Parser
           uses: actions/checkout@v4
@@ -177,3 +185,40 @@ jobs:
             else
               echo "No changes to commit"
             fi
+
+        - name: Trigger Armor Workflow
+          uses: actions/github-script@v7
+          with:
+            github-token: ${{ secrets.CI_PAT }}
+            script: |
+              const kernelAddress = '${{ inputs.kernel_address }}';
+              const testnetKernels = '${{ vars.TESTNET_KERNELS }}';
+              const testnetStagingKernels = '${{ vars.TESTNET_STAGING_KERNELS }}';
+              
+              // Read the version map
+              const fs = require('fs');
+              const versionMap = fs.readFileSync('artifacts/version-map.json', 'utf8');
+              
+              let workflowFile;
+              if (kernelAddress === testnetKernels) {
+                workflowFile = 'develop.yml';
+              } else if (kernelAddress === testnetStagingKernels) {
+                workflowFile = 'staging.yml';
+              } else {
+                core.setFailed('Error: Kernel not found in known configurations');
+                return;
+              }
+              
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: 'andromedaprotocol',
+                  repo: 'andromeda-armor',
+                  workflow_id: workflowFile,
+                  ref: 'main',
+                  inputs: {
+                    version_map: versionMap
+                  }
+                });
+              } catch (error) {
+                core.setFailed(`Failed to trigger Armor workflow: ${error.message}`);
+              }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,7 +220,7 @@ jobs:
             try {
               await github.rest.actions.createWorkflowDispatch({
                 owner: 'andromedaprotocol',
-                repo: 'andromeda-armor',
+                repo: 'andromeda-armour',
                 workflow_id: workflowFile,
                 ref: 'main',
                 inputs: {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,7 +181,13 @@ jobs:
   trigger-armour-workflow:      
     needs: [trigger-schema-parser]
     runs-on: ubuntu-latest
-    steps:       
+    steps:
+      - name: Wait for schema updates
+        run: |
+          echo "Waiting 6 minutes for schema updates to propagate..."
+          sleep 360
+          echo "Wait complete, proceeding with Armor workflow trigger"
+      
       - name: Download version-map
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,14 +129,6 @@ jobs:
               echo "Error: Kernel not found in known configurations"
               exit 1
             fi
-        - name: Download version-map
-          uses: actions/download-artifact@v4
-          with:
-            name: contracts
-            path: "artifacts"
-
-        - run: |
-            echo "version-map.json"
 
         - name: Checkout Schema Parser
           uses: actions/checkout@v4
@@ -198,6 +190,58 @@ jobs:
               // Read the version map
               const fs = require('fs');
               const versionMap = fs.readFileSync('artifacts/version-map.json', 'utf8');
+              
+              let workflowFile;
+              if (kernelAddress === testnetKernels) {
+                workflowFile = 'develop.yml';
+              } else if (kernelAddress === testnetStagingKernels) {
+                workflowFile = 'staging.yml';
+              } else {
+                core.setFailed('Error: Kernel not found in known configurations');
+                return;
+              }
+              
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: 'andromedaprotocol',
+                  repo: 'andromeda-armor',
+                  workflow_id: workflowFile,
+                  ref: 'main',
+                  inputs: {
+                    version_map: versionMap
+                  }
+                });
+              } catch (error) {
+                core.setFailed(`Failed to trigger Armor workflow: ${error.message}`);
+              }
+
+              - name: Download version-map
+              uses: actions/download-artifact@v4
+              with:
+                name: contracts
+                path: "artifacts"
+            
+        - name: Extract version map
+          run: |
+            cd artifacts
+            ls -a
+            unzip -o contracts.zip
+            ls -a
+            cat version-map.json
+            cp version-map.json ../version-map.json  
+        
+        - name: Trigger Armor Workflow
+          uses: actions/github-script@v7
+          with:
+            github-token: ${{ secrets.CI_PAT }}
+            script: |
+              const kernelAddress = '${{ inputs.kernel_address }}';
+              const testnetKernels = '${{ vars.TESTNET_KERNELS }}';
+              const testnetStagingKernels = '${{ vars.TESTNET_STAGING_KERNELS }}';
+              
+              // Read the version map
+              const fs = require('fs');
+              const versionMap = fs.readFileSync('version-map.json', 'utf8');
               
               let workflowFile;
               if (kernelAddress === testnetKernels) {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
           ./andromeda-deploy
 
   trigger-schema-parser:
-      needs: [deploy, build_schemas]
+      needs: [deploy]
       runs-on: ubuntu-latest
       steps:
         - name: Set Branch Based on Kernel
@@ -179,7 +179,7 @@ jobs:
             fi
 
   trigger-armour-workflow:      
-    needs: [build_contracts, build_schemas, build_deploy_script, deploy, trigger-schema-parser]
+    needs: [trigger-schema-parser]
     runs-on: ubuntu-latest
     steps:       
       - name: Download version-map
@@ -191,11 +191,8 @@ jobs:
       - name: Extract version map
         run: |
           cd artifacts
-          ls -a
-          unzip -o contracts.zip
-          ls -a
-          cat version-map.json
-          cp version-map.json ../version-map.json  
+          cat version_map.json
+          cp version_map.json ../version_map.json  
 
       - name: Trigger Armor Workflow
         uses: actions/github-script@v7
@@ -208,7 +205,7 @@ jobs:
             
             // Read the version map
             const fs = require('fs');
-            const versionMap = fs.readFileSync('version-map.json', 'utf8');
+            const versionMap = fs.readFileSync('version_map.json', 'utf8');
             
             let workflowFile;
             if (kernelAddress === testnetKernels) {


### PR DESCRIPTION
# Motivation

Added the final trigger for e2e tests:

Changes:

1. Download the version map
2. Read it and send it to andromeda-armour
3. Added wait time before triggering
4. Trigger e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for triggering subsequent processes based on schema updates.
- **Improvements**
	- Simplified job dependencies for better workflow control.
	- Enhanced error handling for improved reliability in workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->