### PR TITLE
feat: deploy devnet configs

### DIFF
--- a/packages/deploy/src/chains/devnets.rs
+++ b/packages/deploy/src/chains/devnets.rs
@@ -37,4 +37,21 @@ pub const WASM_DEVNET: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
 };
 
-pub const DEVNET_CHAINS: &[ChainInfo] = &[OSMOSIS_DEVNET, WASM_DEVNET];
+pub const ANDROMEDA_DEVNET_NETWORK: NetworkInfo = NetworkInfo {
+    chain_name: "andromeda-devnet",
+    pub_address_prefix: "andr",
+    coin_type: 118u32,
+};
+
+pub const ANDROMEDA_DEVNET: ChainInfo = ChainInfo {
+    chain_id: "localandromedaa-1",
+    gas_denom: "uandr",
+    fcd_url: None,
+    gas_price: 0.025,
+    grpc_urls: &["http://164.90.212.168:20311/"],
+    lcd_url: Some("http://164.90.212.168:20211/"),
+    network_info: ANDROMEDA_DEVNET_NETWORK,
+    kind: ChainKind::Testnet,
+};
+
+pub const DEVNET_CHAINS: &[ChainInfo] = &[OSMOSIS_DEVNET, WASM_DEVNET, ANDROMEDA_DEVNET];

--- a/packages/deploy/src/chains/devnets.rs
+++ b/packages/deploy/src/chains/devnets.rs
@@ -1,0 +1,40 @@
+use cw_orch::{
+    environment::{ChainKind, NetworkInfo},
+    prelude::ChainInfo,
+};
+
+pub const OSMOSIS_DEVNET_NETWORK: NetworkInfo = NetworkInfo {
+    chain_name: "osmosis-devnet",
+    pub_address_prefix: "osmo",
+    coin_type: 118u32,
+};
+
+pub const OSMOSIS_DEVNET: ChainInfo = ChainInfo {
+    chain_id: "localosmosisa-1",
+    gas_denom: "uosmo",
+    fcd_url: None,
+    gas_price: 0.025,
+    grpc_urls: &["http://164.90.212.168:20321/"],
+    lcd_url: Some("http://164.90.212.168:20221/"),
+    network_info: OSMOSIS_DEVNET_NETWORK,
+    kind: ChainKind::Testnet,
+};
+
+pub const WASM_DEVNET_NETWORK: NetworkInfo = NetworkInfo {
+    chain_name: "wasm-devnet",
+    pub_address_prefix: "wasm",
+    coin_type: 118u32,
+};
+
+pub const WASM_DEVNET: ChainInfo = ChainInfo {
+    chain_id: "localwasma-1",
+    gas_denom: "ustake",
+    fcd_url: None,
+    gas_price: 0.025,
+    grpc_urls: &["http://164.90.212.168:20341/"],
+    lcd_url: Some("http://164.90.212.168:20241/"),
+    network_info: WASM_DEVNET_NETWORK,
+    kind: ChainKind::Testnet,
+};
+
+pub const DEVNET_CHAINS: &[ChainInfo] = &[OSMOSIS_DEVNET, WASM_DEVNET];

--- a/packages/deploy/src/chains/mod.rs
+++ b/packages/deploy/src/chains/mod.rs
@@ -1,0 +1,15 @@
+pub mod devnets;
+pub mod testnets;
+
+use cw_orch::prelude::ChainInfo;
+use devnets::DEVNET_CHAINS;
+use testnets::TESTNET_CHAINS;
+
+pub fn get_chain(chain: String) -> ChainInfo {
+    [TESTNET_CHAINS, DEVNET_CHAINS]
+        .concat()
+        .iter()
+        .find(|c| c.chain_id == chain || c.network_info.chain_name == chain)
+        .unwrap()
+        .clone()
+}

--- a/packages/deploy/src/chains/testnets.rs
+++ b/packages/deploy/src/chains/testnets.rs
@@ -37,12 +37,4 @@ pub const STARGAZE_TESTNET: ChainInfo = ChainInfo {
     kind: ChainKind::Testnet,
 };
 
-pub const ALL_CHAINS: &[ChainInfo] = &[ANDROMEDA_TESTNET, STARGAZE_TESTNET];
-
-pub fn get_chain(chain: String) -> ChainInfo {
-    ALL_CHAINS
-        .iter()
-        .find(|c| c.chain_id == chain || c.network_info.chain_name == chain)
-        .unwrap()
-        .clone()
-}
+pub const TESTNET_CHAINS: &[ChainInfo] = &[ANDROMEDA_TESTNET, STARGAZE_TESTNET];


### PR DESCRIPTION
# Motivation
These changes add internet devnet configs to the deployment script for:
- Osmosis
- Wasmd
- Andromeda

# Implementation

Chain configs were moved to a directory and each config was divided in to the correct mod file.

# Testing

A deployment action was run on the Osmosis devnet successfully.
