### PR TITLE
feat: add attributes to add_child in vfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 1.5.8",

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -130,13 +130,22 @@ pub fn add_child(
     // Only add path method can override existing paths as its safe because only owner of the path can execute it
     match existing {
         None => {
-            add_pathname(deps.storage, parent_address, name, info.sender)?;
+            add_pathname(
+                deps.storage,
+                parent_address.clone(),
+                name.clone(),
+                info.sender,
+            )?;
         }
         Some(path) => {
             ensure!(path.address == info.sender, ContractError::Unauthorized {})
         }
     };
-    Ok(Response::default())
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "add_child"),
+        attr("name", name),
+        attr("parent", parent_address),
+    ]))
 }
 
 const MAX_USERNAME_LENGTH: u64 = 30;


### PR DESCRIPTION
# Motivation
The `add_child` function in the VFS didn't have any attributes in its response. 

# Implementation
Added the following attributes:
```rust
Ok(Response::default().add_attributes(vec![
        attr("action", "add_child"),
        attr("name", name),
        attr("parent", parent_address),
    ]))
```

# Testing
None

# Version Changes
`vfs`: `1.1.1` -> `1.1.2`

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced response structure for the `add_child` function, now includes action attributes.
- **Bug Fixes**
	- Improved clarity in parameter handling for the `add_child` function.
- **Chores**
	- Updated version of the `andromeda-vfs` package from 1.1.1 to 1.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->