### PR TITLE
ci: add nightly release schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,29 @@
+name: Nightly Deployment
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: "0 0 * * *"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Deploy Workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CI_PAT }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              workflow_id: 'deploy.yml',
+              ref: 'development',
+              inputs: {
+                network: 'galileo-4',
+                kernel_address: 'andr1536hsxv4706s0wwmswcc7j7t7newvfu8tqx7fnm8hfvdznlc0dnsal669q',
+                deploy_os: 'true',
+              }
+            });

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,14 +16,18 @@ jobs:
         with:
           github-token: ${{ secrets.CI_PAT }}
           script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.name,
-              workflow_id: 'deploy.yml',
-              ref: 'main',
-              inputs: {
-                network: 'galileo-4',
-                kernel_address: 'andr1536hsxv4706s0wwmswcc7j7t7newvfu8tqx7fnm8hfvdznlc0dnsal669q',
-                deploy_os: 'true',
-              }
-            });
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.name,
+                workflow_id: 'deploy.yml',
+                ref: 'main',
+                inputs: {
+                  network: 'galileo-4',
+                  kernel_address: 'andr1536hsxv4706s0wwmswcc7j7t7newvfu8tqx7fnm8hfvdznlc0dnsal669q',
+                  deploy_os: 'true',
+                }
+              });
+            } catch (error) {
+              console.error('Error triggering deploy workflow:', error);
+            }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.name,
               workflow_id: 'deploy.yml',
-              ref: 'development',
+              ref: 'main',
               inputs: {
                 network: 'galileo-4',
                 kernel_address: 'andr1536hsxv4706s0wwmswcc7j7t7newvfu8tqx7fnm8hfvdznlc0dnsal669q',

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Deployment
+name: Nightly Testnet Staging Deployment
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
# Motivation

These changes add a scheduled automatic release to the Andromeda testnet every night at 00:00 UTC using the current `development` branch.

# Implementation

Added `nightly.yml` which uses the `deploy.yml` action to release nightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new nightly deployment workflow for automated testnet staging deployments.
	- Workflow can be triggered manually or scheduled to run daily at midnight UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->