### PR TITLE
fix: rename references to development to main

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ defaults:
 pull_request_rules:
   - name: backport to v1.1.x branch
     conditions:
-      - base=development
+      - base=main
       - label=backport/v1.1.x
     actions:
       backport:
@@ -15,7 +15,7 @@ pull_request_rules:
           - v1.1.x
   - name: backport to release/3 branch
     conditions:
-      - base=development
+      - base=main
       - label=backport/release/3
     actions:
       backport:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build Contracts & Schemas
 on:
   pull_request:
-    branches: [main, development]
+    branches: [main]
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,6 @@ on:
     # as defined in the (optional) "skipLabels" property.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches:
-      - development
       - main
 jobs:
   changelog:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths: ["**.*"]
   pull_request:
-    branches: [main, development]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 <p>&nbsp;</p>
 <p align="center">
-<img src="https://github.com/andromedaprotocol/andromeda-core/blob/development/asset/core-logo.png" width=1000>
+<img src="https://github.com/andromedaprotocol/andromeda-core/blob/main/asset/core-logo.png" width=1000>
 </p>
 
-  AndromedaOS is a revolutionary software layer that provides a massively
-  abstracted environment and user experience for the next generation of
-  blockchain innovators to create, develop and get paid.
+AndromedaOS is a revolutionary software layer that provides a massively
+abstracted environment and user experience for the next generation of
+blockchain innovators to create, develop and get paid.
 
 # Introduction to AndromedaOS
 
 ### Mission
 
 **Andromeda** **Protocol** is a rapid development framework and a next-generation user interface that brings an Easier, Better, and Faster capability to Web 3.0, and the blockchain industry.
-
 
 #### What is a blockchain operating system? <a href="#what-is-a-blockchain-operating-system" id="what-is-a-blockchain-operating-system"></a>
 
@@ -22,11 +21,11 @@ AndromedaOS, or _aOS_ for short, is comprised of several interoperating systems 
 
 A quick description of each of the components that make up the aOS:
 
-* ​[Andromeda Digital Objects](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/introduction-to-ados) - the building blocks of the system
-* [​Andromeda Apps](https://docs.andromedaprotocol.io/andromeda/andromeda-apps/introduction-to-apps) - advanced functionality built with ADOs
-* ​[aOS Kernel](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/kernel) - the system for enforcing and coordinating the different systems
-* ​[aOS File System](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/virtual-file-system) - common namespace for referencing ADOs, services, network, etc
-* ​[aOS Economics](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/economics-engine) - developer and creator incentives
+- ​[Andromeda Digital Objects](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/introduction-to-ados) - the building blocks of the system
+- [​Andromeda Apps](https://docs.andromedaprotocol.io/andromeda/andromeda-apps/introduction-to-apps) - advanced functionality built with ADOs
+- ​[aOS Kernel](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/kernel) - the system for enforcing and coordinating the different systems
+- ​[aOS File System](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/virtual-file-system) - common namespace for referencing ADOs, services, network, etc
+- ​[aOS Economics](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/economics-engine) - developer and creator incentives
 
 It's important to note that each of these systems exist 100% on-chain. All logic, interactions, objects, economics, etc. are deployed on-chain.
 
@@ -55,11 +54,11 @@ For example, a user can build an NFT collection on Stargaze selling the NFTs usi
 
 ### What is the benefit of using aOS
 
-* **For Projects:**
+- **For Projects:**
 
-Before **Andromeda**, projects would need to hire a full development teams in order to  build their projects and custom smart contracts. Andromeda eliminates this need by providing a very large amount of custom smart contracts that upcoming projects can pick and chose from to achieve their desired utility. These projects can then use our **No-Code-Builder** to build their projects in a matter of minutes on any of the chains that Andromeda is deployed on.
+Before **Andromeda**, projects would need to hire a full development teams in order to build their projects and custom smart contracts. Andromeda eliminates this need by providing a very large amount of custom smart contracts that upcoming projects can pick and chose from to achieve their desired utility. These projects can then use our **No-Code-Builder** to build their projects in a matter of minutes on any of the chains that Andromeda is deployed on.
 
-* **For Developers:**
+- **For Developers:**
 
 Developers can use our **Andromeda Logic Library** (ALL) which contains all our contracts to build from. Similar to how [**cw-plus**](https://github.com/CosmWasm/cw-plus) contracts are used as a base for production quality builds, the ALL will act as a base for all developers to create their own ADOs that use the superior interoperable system.&#x20;
 
@@ -67,7 +66,7 @@ As it stands, the ALL contains around 25 ADOs which is the tip of the iceberg. M
 
 Furthermore, developers are incentivized for their contributions and the ADOs they create. This incentive system operates through our[ economic engine](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/economics-engine), enabling developers to set custom fees on their ADOs when it is published. Users utilizing these ADOs pay these fees, which are then returned to the developer responsible for their creation.
 
-* **For Chains:**
+- **For Chains:**
 
 &#x20;AndromedaOS provides a whole suite of tooling that can be quickly installed on any chain in the Cosmos ecosystem. Installing the aOS would instantly give a chain and its users access to the following:&#x20;
 
@@ -81,54 +80,54 @@ Furthermore, developers are incentivized for their contributions and the ADOs th
 
 A monorepository containing all the contracts and packages related to Andromeda Protocol. Full documentation for all the contracts can be found [here](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/introduction).
 
-## ADO Categories 
+## ADO Categories
 
 The contracts are classified based on their functionality. Currently we have 7 different contract categories.
 
-| Category| Description |                                                                                                                                 
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [app](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/app)| Contracts used for building Andromeda apps. |  
-| [ecosystem](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/ecosystem) | Contracts that are allow interaction with different ecosystem protocols.|                      
-| [finance](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/finance)       |  Contracts used by fungible tokens to perform defi operations.|                                                                                      
-| [fungible tokens](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/fungible-tokens)       | Contracts that integrate with fungible tokens (CW-20 tokens).|
-| [non-fungible-tokens](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/non-fungible-tokens)         | Contacts that integrate with non-funible toknes (NFTs). Includes a standard CW721 contract with some custom features.|
-| [os](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os)      | Contacts that make up the aOS architecture |
-
+| Category                                                                                                           | Description                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| [app](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/app)                                 | Contracts used for building Andromeda apps.                                                                           |
+| [ecosystem](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/ecosystem)                     | Contracts that are allow interaction with different ecosystem protocols.                                              |
+| [finance](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/finance)                         | Contracts used by fungible tokens to perform defi operations.                                                         |
+| [fungible tokens](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/fungible-tokens)         | Contracts that integrate with fungible tokens (CW-20 tokens).                                                         |
+| [non-fungible-tokens](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/non-fungible-tokens) | Contacts that integrate with non-funible toknes (NFTs). Includes a standard CW721 contract with some custom features. |
+| [os](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os)                               | Contacts that make up the aOS architecture                                                                            |
 
 ## Audited ADOs
+
 The list of ADOs that have been audited and are available on our web-application.
 
-| Contract | Category | Description | Documentation |
-| ---------------------------|------------------------|-------------------------------------------|----------------------------------------------------- |
-| [andromeda-app-contract](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/app/andromeda-app-contract)| app | Contract used to create Andromeda Apps. | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/andromeda-apps/app)|      
-| [andromeda-rate-limiting-withdrawals](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/finance/andromeda-rate-limiting-withdrawals)    | finance | Contract that puts restrictions on the withdrawal of funds by users.  | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/finance/rate-limiting-withdrawals)|
-| [andromeda-splitter](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/finance/andromeda-splitter)   | finance| Contract used to split any sent funds amongst defined addresses.  | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/finance/andromeda-splitter)|
-| [andromeda-timelock](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/finance/andromeda-timelock) | finance| Contract used to store funds until a condition has been satisfied before being released, similar to Escrow.|[Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/finance/timelock)|                                                      
-| [andromeda-cw20](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/fungible-tokens/andromeda-cw20) | fungible tokens |Contract to create standard CW20 tokens. | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/cw20-token)
-| [andromeda-cw20-staking](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/fungible-tokens/andromeda-cw20-staking)       | fungible tokens | Contract that allows the staking of CW20 tokens for rewards.    | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/cw20-staking)|
-| [andromeda-cw20-exchange](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/fungible-tokens/andromeda-cw20-exchange)       | fungible tokens | Contract that allows the exchanging native tokens for a specified CW20    | [Gitbook](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw20-exchange)|
-| [andromeda-lockdrop](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/fungible-tokens/andromeda-lockdrop) | fungible tokens| Contract that allows users to deposit a netive token in exchange for the project's cw-20 token   |[Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/lockdrop)|
-| [andromeda-merkle-airdrop](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/fungible-tokens/andromeda-merkle-airdrop)       | fungible tokens| Contract used to perform a merkle airdrop on cw20-tokens| [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/merkle-airdrop)|                        
-| [andromeda-auction](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/non-fungible-tokens/andromeda-auction)|non-fungible-tokens| Contract that can receive an NFT and run an auction on it.| [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/non-fungible-tokens/auction)|
-| [andromeda-marketplace](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/non-fungible-tokens/andromeda-marketplace)|non-fungible-tokens| Contract that can receive an NFT and run an a sale on it.| [Gitbook](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/marketplace)|
-| [andromeda-crowdfund](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/non-fungible-tokens/andromeda-crowdfund)|non-fungible-tokens| Contracts used to perform a crowdfund by selling NFTs.|[Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/non-fungible-tokens/crowdfund)|
-| [andromeda-cw721](https://github.com/andromedaprotocol/andromeda-core/tree/development/contracts/non-fungible-tokens/andromeda-cw721)| non-fungible-tokens| Contract used to create CW721 standard NFTs. Has a custom message that allows selling the NFTs.| [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/non-fungible-tokens/andromeda-digital-object)|
-| [andromeda-adodb](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-adodb)| os| The ADO database responsible for publishing new ADOs into the aOS| [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/andromeda-factory)|
-| [andromeda-economics](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-economics)| os | The contract responsible for handling ADO fees| [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/economics-engine)|
-| [andromeda-kernel](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-kernel)| os | The contract responsible for handling communication between ADOs| [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/kernel)|
-| [andromeda-vfs](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-vfs)| os| The contract responsible for managing the usernames and paths of ADOs and users in the aOs | [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/virtual-file-system)|
+| Contract                                                                                                                                                   | Category            | Description                                                                                                 | Documentation                                                                                                                  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [andromeda-app-contract](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/app/andromeda-app-contract)                               | app                 | Contract used to create Andromeda Apps.                                                                     | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/andromeda-apps/app)                                      |
+| [andromeda-rate-limiting-withdrawals](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/finance/andromeda-rate-limiting-withdrawals) | finance             | Contract that puts restrictions on the withdrawal of funds by users.                                        | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/finance/rate-limiting-withdrawals)                       |
+| [andromeda-splitter](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/finance/andromeda-splitter)                                   | finance             | Contract used to split any sent funds amongst defined addresses.                                            | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/finance/andromeda-splitter)                              |
+| [andromeda-timelock](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/finance/andromeda-timelock)                                   | finance             | Contract used to store funds until a condition has been satisfied before being released, similar to Escrow. | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/finance/timelock)                                        |
+| [andromeda-cw20](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/fungible-tokens/andromeda-cw20)                                   | fungible tokens     | Contract to create standard CW20 tokens.                                                                    | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/cw20-token)                              |
+| [andromeda-cw20-staking](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/fungible-tokens/andromeda-cw20-staking)                   | fungible tokens     | Contract that allows the staking of CW20 tokens for rewards.                                                | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/cw20-staking)                            |
+| [andromeda-cw20-exchange](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/fungible-tokens/andromeda-cw20-exchange)                 | fungible tokens     | Contract that allows the exchanging native tokens for a specified CW20                                      | [Gitbook](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw20-exchange)                                 |
+| [andromeda-lockdrop](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/fungible-tokens/andromeda-lockdrop)                           | fungible tokens     | Contract that allows users to deposit a netive token in exchange for the project's cw-20 token              | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/lockdrop)                                |
+| [andromeda-merkle-airdrop](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/fungible-tokens/andromeda-merkle-airdrop)               | fungible tokens     | Contract used to perform a merkle airdrop on cw20-tokens                                                    | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/fungible-tokens/merkle-airdrop)                          |
+| [andromeda-auction](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/non-fungible-tokens/andromeda-auction)                         | non-fungible-tokens | Contract that can receive an NFT and run an auction on it.                                                  | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/non-fungible-tokens/auction)                             |
+| [andromeda-marketplace](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/non-fungible-tokens/andromeda-marketplace)                 | non-fungible-tokens | Contract that can receive an NFT and run an a sale on it.                                                   | [Gitbook](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/marketplace)                                   |
+| [andromeda-crowdfund](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/non-fungible-tokens/andromeda-crowdfund)                     | non-fungible-tokens | Contracts used to perform a crowdfund by selling NFTs.                                                      | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/non-fungible-tokens/crowdfund)                           |
+| [andromeda-cw721](https://github.com/andromedaprotocol/andromeda-core/tree/main/contracts/non-fungible-tokens/andromeda-cw721)                             | non-fungible-tokens | Contract used to create CW721 standard NFTs. Has a custom message that allows selling the NFTs.             | [Gitbook](https://docs.andromedaprotocol.io/andromeda/smart-contracts/non-fungible-tokens/andromeda-digital-object)            |
+| [andromeda-adodb](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-adodb)                                          | os                  | The ADO database responsible for publishing new ADOs into the aOS                                           | [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/andromeda-factory)   |
+| [andromeda-economics](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-economics)                                  | os                  | The contract responsible for handling ADO fees                                                              | [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/economics-engine)    |
+| [andromeda-kernel](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-kernel)                                        | os                  | The contract responsible for handling communication between ADOs                                            | [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/kernel)              |
+| [andromeda-vfs](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/contracts/os/andromeda-vfs)                                              | os                  | The contract responsible for managing the usernames and paths of ADOs and users in the aOs                  | [Gitbook](https://docs.andromedaprotocol.io/andromeda/platform-and-framework/andromeda-messaging-protocol/virtual-file-system) |
 
 **Note**: Other ADOs can be found in our repo, but they have not gone through the auditing process yet.
 
 ## Packages
 
-| Contract                                                                                                             | Description                                                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [andromeda_protocol](https://github.com/andromedaprotocol/andromeda-core/tree/development/packages) | Package used to define message types and various utility methods used by Andromeda ADO Contracts.|
+| Contract                                                                                     | Description                                                                                       |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [andromeda_protocol](https://github.com/andromedaprotocol/andromeda-core/tree/main/packages) | Package used to define message types and various utility methods used by Andromeda ADO Contracts. |
 
 ### ADO Base
 
-The packages also includes the [ado_base](https://github.com/andromedaprotocol/andromeda-core/tree/development/packages/ado-base). Since all our ADOs are built using the same architecture, redundency was inevitable. So we decided to bundle up all the functions/messages/structures that are used by all ADOs into the ado_base which can be referenced by any new ADOs. 
+The packages also includes the [ado_base](https://github.com/andromedaprotocol/andromeda-core/tree/main/packages/ado-base). Since all our ADOs are built using the same architecture, redundency was inevitable. So we decided to bundle up all the functions/messages/structures that are used by all ADOs into the ado_base which can be referenced by any new ADOs.
 
 ## Development
 
@@ -138,6 +137,7 @@ A starting template for ADO development can be found [here](https://github.com/a
 The andromeda-std crate can be found [here](https://crates.io/crates/andromeda-std).
 
 ### Integration Tests
+
 Check out our cw-multi-test based testing [library](https://github.com/andromedaprotocol/andromeda-core/tree/1.0.rc-1/packages/andromeda-testing) to setup custom ADO integration tests.
 
 ### Testing
@@ -157,9 +157,7 @@ This will build all contract `.wasm` files in to the `artifacts` directory at th
 To build a single contract, you need to have [wasm-opt](https://command-not-found.com/wasm-opt)
 Then run:
 
-`./build.sh [contract name]` or `./build.sh [catogory name]` 
-
-
+`./build.sh [contract name]` or `./build.sh [catogory name]`
 
 Examples:
 
@@ -202,13 +200,15 @@ rustup toolchain install nightly
 ```sh
 cargo clippy --all --all-targets -- -D warnings
 ```
+
 ### Creating and Interacting with ADOs
 
 Andromeda is deployed on many of the Cosmos chains. Usually this will require you to set up an environment for each chain. Luckily, Andromeda has built the Andromeda CLI, an all in one tool to build, interact, and manage ADOs and wallets for any of the chains. The CLI documentation can be found [here](https://docs.andromedaprotocol.io/andromeda/andromeda-cli/introduction).
 
-### Andromeda JS 
+### Andromeda JS
+
 [Andromeda.js](https://github.com/andromedaprotocol/andromeda.js) is a JavaScript SDK for writing applications that interact with ADOs on any of the blockchains that Andromeda is deployed on. More on the AndromedaJS can be found [here](https://docs.andromedaprotocol.io/andromeda.js/).
 
 ## Licensing
 
-[Terms and Conditions](https://github.com/andromedaprotocol/andromeda-core/blob/development/LICENSE/LICENSE.md)
+[Terms and Conditions](https://github.com/andromedaprotocol/andromeda-core/blob/main/LICENSE/LICENSE.md)


### PR DESCRIPTION
# Motivation

The `development` branch has been renamed to main. These changes are to support this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workflows to trigger only on the `main` branch for pull requests.
	- Improved clarity and formatting in the README.md, including updated image sources and links.

- **Bug Fixes**
	- Corrected image and link references in the README.md to point to the `main` branch.

- **Documentation**
	- Enhanced README.md with formatting adjustments and clearer section organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->