### PR TITLE
ref: expose query_permissioned_actors in AndromedaQuery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema 1.5.8",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_base/mod.rs
+++ b/packages/std/src/ado_base/mod.rs
@@ -11,6 +11,7 @@ pub mod version;
 
 pub mod withdraw;
 use crate::amp::{messages::AMPPkt, AndrAddr};
+use crate::common::OrderBy;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
 
@@ -74,6 +75,13 @@ pub enum AndromedaQuery {
     },
     #[returns(Vec<self::permissioning::PermissionedActionsResponse>)]
     PermissionedActions {},
+    #[returns(Vec<self::permissioning::PermissionedActorsResponse>)]
+    PermissionedActors {
+        action: String,
+        limit: Option<u32>,
+        start_after: Option<String>,
+        order_by: Option<OrderBy>,
+    },
 
     #[cfg(feature = "rates")]
     #[returns(Option<self::rates::Rate>)]

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -40,6 +40,11 @@ pub struct PermissionedActionsResponse {
     pub actions: Vec<String>,
 }
 
+#[cw_serde]
+pub struct PermissionedActorsResponse {
+    pub actors: Vec<String>,
+}
+
 /// An enum to represent a user's permission for an action
 ///
 /// - **Blacklisted** - The user cannot perform the action until after the provided expiration

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -1178,6 +1178,7 @@ mod tests {
         contract.owner.save(ctx.deps.storage, &info.sender).unwrap();
 
         let actor = "actor";
+        let actor2 = "actor2";
         let action = "action";
         ADOContract::default()
             .execute_permission_action(ctx, action)
@@ -1190,11 +1191,19 @@ mod tests {
             Permission::Local(LocalPermission::default()),
         )
         .unwrap();
+        ADOContract::set_permission(
+            deps.as_mut().storage,
+            action,
+            actor2,
+            Permission::Local(LocalPermission::default()),
+        )
+        .unwrap();
         let actors = ADOContract::default()
             .query_permissioned_actors(deps.as_ref(), action, None, None, None)
             .unwrap();
 
-        assert_eq!(actors.len(), 1);
+        assert_eq!(actors.len(), 2);
         assert_eq!(actors[0], actor);
+        assert_eq!(actors[1], actor2);
     }
 }

--- a/packages/std/src/ado_contract/query.rs
+++ b/packages/std/src/ado_contract/query.rs
@@ -55,6 +55,18 @@ impl<'a> ADOContract<'a> {
                 AndromedaQuery::PermissionedActions {} => {
                     encode_binary(&self.query_permissioned_actions(deps)?)
                 }
+                AndromedaQuery::PermissionedActors {
+                    action,
+                    start_after,
+                    limit,
+                    order_by,
+                } => encode_binary(&self.query_permissioned_actors(
+                    deps,
+                    action,
+                    start_after,
+                    limit,
+                    order_by,
+                )?),
                 #[cfg(feature = "rates")]
                 AndromedaQuery::Rates { action } => encode_binary(&self.get_rates(deps, action)?),
 


### PR DESCRIPTION
# Motivation
Closes #679 

# Implementation
```rust
AndromedaQuery::PermissionedActors {
                    action,
                    start_after,
                    limit,
                    order_by,
                } => encode_binary(&self.query_permissioned_actors(
                    deps,
                    action,
                    start_after,
                    limit,
                    order_by,
                )?),
```

# Testing
Slight adjustment to the `test_query_permissioned_actors` unit test

# Version Changes
`andromeda-std`: `1.5.0` -> `1.6.0`

# Notes
None

# Future work
None
