### PR TITLE
feat: cross chain recipients no longer error in get_raw_address_from_vfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Rates: Limit rates recipient to only one address [(#669)](https://github.com/andromedaprotocol/andromeda-core/pull/669)
+- Address Validation: Cross-chain recipients don't need to be registered in VFS [(#725)](https://github.com/andromedaprotocol/andromeda-core/pull/725)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.0-b.1"
+version = "1.5.0-b.2"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema 1.5.8",

--- a/contracts/data-storage/andromeda-form/src/state.rs
+++ b/contracts/data-storage/andromeda-form/src/state.rs
@@ -26,7 +26,7 @@ pub struct SubmissionIndexes<'a> {
     pub wallet_address: MultiIndex<'a, Addr, SubmissionInfo, (u64, Addr)>,
 }
 
-impl<'a> IndexList<SubmissionInfo> for SubmissionIndexes<'a> {
+impl IndexList<SubmissionInfo> for SubmissionIndexes<'_> {
     fn get_indexes(
         &'_ self,
     ) -> Box<dyn Iterator<Item = &'_ dyn cw_storage_plus::Index<SubmissionInfo>> + '_> {

--- a/contracts/finance/andromeda-conditional-splitter/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/testing/mock_querier.rs
@@ -45,6 +45,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/finance/andromeda-cross-chain-swap/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-cross-chain-swap/src/testing/mock_querier.rs
@@ -45,6 +45,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/testing/mock_querier.rs
@@ -47,6 +47,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/finance/andromeda-set-amount-splitter/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-set-amount-splitter/src/testing/mock_querier.rs
@@ -45,6 +45,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/finance/andromeda-splitter/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/mock_querier.rs
@@ -45,6 +45,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/finance/andromeda-timelock/src/state.rs
+++ b/contracts/finance/andromeda-timelock/src/state.rs
@@ -11,7 +11,7 @@ pub struct EscrowIndexes<'a> {
     pub owner: MultiIndex<'a, String, Escrow, Vec<u8>>,
 }
 
-impl<'a> IndexList<Escrow> for EscrowIndexes<'a> {
+impl IndexList<Escrow> for EscrowIndexes<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Escrow>> + '_> {
         let v: Vec<&dyn Index<Escrow>> = vec![&self.owner];
         Box::new(v.into_iter())

--- a/contracts/finance/andromeda-timelock/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-timelock/src/testing/mock_querier.rs
@@ -44,6 +44,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/finance/andromeda-vesting/src/state.rs
+++ b/contracts/finance/andromeda-vesting/src/state.rs
@@ -38,7 +38,7 @@ pub struct BatchIndexes<'a> {
     pub claim_time: MultiIndex<'a, (u8, u64), Batch, u64>,
 }
 
-impl<'a> IndexList<Batch> for BatchIndexes<'a> {
+impl IndexList<Batch> for BatchIndexes<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Batch>> + '_> {
         let v: Vec<&dyn Index<Batch>> = vec![&self.claim_time];
         Box::new(v.into_iter())

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/mock_querier.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/mock_querier.rs
@@ -1,50 +1,14 @@
-use andromeda_std::ado_base::InstantiateMsg;
-use andromeda_std::ado_contract::ADOContract;
 use andromeda_std::testing::mock_querier::MockAndromedaQuerier;
-use cosmwasm_std::testing::mock_info;
-use cosmwasm_std::QuerierWrapper;
 use cosmwasm_std::{
-    from_json,
-    testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
-    Coin, OwnedDeps, Querier, QuerierResult, QueryRequest, SystemError, SystemResult, WasmQuery,
+    from_json, testing::MockQuerier, Querier, QuerierResult, QueryRequest, SystemError,
+    SystemResult, WasmQuery,
 };
-
-pub use andromeda_std::testing::mock_querier::MOCK_KERNEL_CONTRACT;
 
 /// Alternative to `cosmwasm_std::testing::mock_dependencies` that allows us to respond to custom queries.
 ///
 /// Automatically assigns a kernel address as MOCK_KERNEL_CONTRACT.
-pub fn mock_dependencies_custom(
-    contract_balance: &[Coin],
-) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
-    let custom_querier: WasmMockQuerier =
-        WasmMockQuerier::new(MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]));
-    let storage = MockStorage::default();
-    let mut deps = OwnedDeps {
-        storage,
-        api: MockApi::default(),
-        querier: custom_querier,
-        custom_query_type: std::marker::PhantomData,
-    };
-    ADOContract::default()
-        .instantiate(
-            &mut deps.storage,
-            mock_env(),
-            &deps.api,
-            &QuerierWrapper::new(&deps.querier),
-            mock_info("sender", &[]),
-            InstantiateMsg {
-                ado_type: "splitter".to_string(),
-                ado_version: "test".to_string(),
 
-                kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
-                owner: None,
-            },
-        )
-        .unwrap();
-    deps
-}
-
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,
@@ -78,14 +42,6 @@ impl WasmMockQuerier {
                 MockAndromedaQuerier::default().handle_query(&self.base, request)
             }
             _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
-        }
-    }
-
-    pub fn new(base: MockQuerier) -> Self {
-        WasmMockQuerier {
-            base,
-            contract_address: mock_env().contract.address.to_string(),
-            tokens_left_to_burn: 2,
         }
     }
 }

--- a/contracts/fungible-tokens/andromeda-cw20/src/testing/mock_querier.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/testing/mock_querier.rs
@@ -43,6 +43,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/fungible-tokens/andromeda-ics20/src/testing/mock_querier.rs
+++ b/contracts/fungible-tokens/andromeda-ics20/src/testing/mock_querier.rs
@@ -43,6 +43,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/testing/mock_querier.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/testing/mock_querier.rs
@@ -57,6 +57,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/math/andromeda-matrix/src/testing/tests.rs
+++ b/contracts/math/andromeda-matrix/src/testing/tests.rs
@@ -138,7 +138,7 @@ fn test_authorization() {
 
     // Store as external user
     // This should error
-    let err = store_matrix(deps.as_mut(), &key, &data, &UNAUTHORIZED_OPERATOR).unwrap_err();
+    let err = store_matrix(deps.as_mut(), &key, &data, UNAUTHORIZED_OPERATOR).unwrap_err();
     assert_eq!(err, ContractError::Unauthorized {});
 }
 

--- a/contracts/modules/andromeda-address-list/src/testing/mock_querier.rs
+++ b/contracts/modules/andromeda-address-list/src/testing/mock_querier.rs
@@ -44,6 +44,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/modules/andromeda-rates/src/testing/mock_querier.rs
+++ b/contracts/modules/andromeda-rates/src/testing/mock_querier.rs
@@ -49,6 +49,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -436,7 +436,7 @@ fn execute_update_auction(
 
     token_auction_state.start_time = start_expiration;
     token_auction_state.end_time = end_expiration;
-    token_auction_state.coin_denom = coin_denom.clone();
+    token_auction_state.coin_denom.clone_from(&coin_denom);
     token_auction_state.uses_cw20 = uses_cw20;
     token_auction_state.min_bid = min_bid;
     token_auction_state.min_raise = min_raise;
@@ -1182,8 +1182,8 @@ fn get_and_increment_next_auction_id(
     let mut auction_info = auction_infos().load(storage, &key).unwrap_or_default();
     auction_info.push(next_auction_id);
     if auction_info.token_address.is_empty() {
-        auction_info.token_address = token_address.to_owned();
-        auction_info.token_id = token_id.to_owned();
+        token_address.clone_into(&mut auction_info.token_address);
+        token_id.clone_into(&mut auction_info.token_id);
     }
     auction_infos().save(storage, &key, &auction_info)?;
     Ok(next_auction_id)

--- a/contracts/non-fungible-tokens/andromeda-auction/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/state.rs
@@ -21,7 +21,7 @@ pub struct AuctionIdIndices<'a> {
     pub token: MultiIndex<'a, String, AuctionInfo, String>,
 }
 
-impl<'a> IndexList<AuctionInfo> for AuctionIdIndices<'a> {
+impl IndexList<AuctionInfo> for AuctionIdIndices<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<AuctionInfo>> + '_> {
         let v: Vec<&dyn Index<AuctionInfo>> = vec![&self.token];
         Box::new(v.into_iter())

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/mock_querier.rs
@@ -61,6 +61,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -311,7 +311,7 @@ fn execute_update_sale(
     ensure!(price > Uint128::zero(), ContractError::InvalidZeroAmount {});
 
     token_sale_state.price = price;
-    token_sale_state.coin_denom = coin_denom.clone();
+    token_sale_state.coin_denom.clone_from(&coin_denom);
     token_sale_state.uses_cw20 = uses_cw20;
     token_sale_state.recipient = recipient;
     TOKEN_SALE_STATE.save(
@@ -779,8 +779,8 @@ fn get_and_increment_next_sale_id(
     let mut sale_info = sale_infos().load(storage, &key).unwrap_or_default();
     sale_info.push(next_sale_id);
     if sale_info.token_address.is_empty() {
-        sale_info.token_address = token_address.to_owned();
-        sale_info.token_id = token_id.to_owned();
+        token_address.clone_into(&mut sale_info.token_address);
+        token_id.clone_into(&mut sale_info.token_id);
     }
     sale_infos().save(storage, &key, &sale_info)?;
     Ok(next_sale_id)

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/state.rs
@@ -78,7 +78,7 @@ pub struct SaleIdIndices<'a> {
     pub token: MultiIndex<'a, String, SaleInfo, String>,
 }
 
-impl<'a> IndexList<SaleInfo> for SaleIdIndices<'a> {
+impl IndexList<SaleInfo> for SaleIdIndices<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<SaleInfo>> + '_> {
         let v: Vec<&dyn Index<SaleInfo>> = vec![&self.token];
         Box::new(v.into_iter())

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/mock_querier.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/mock_querier.rs
@@ -54,6 +54,7 @@ pub fn mock_dependencies_custom(
     deps
 }
 
+#[allow(dead_code)]
 pub struct WasmMockQuerier {
     pub base: MockQuerier,
     pub contract_address: String,

--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -718,11 +718,9 @@ fn test_all_ado_types() {
 
     let mut code_id = 1;
 
-    let ados = vec![
-        ADOVersion::from_string("ado_type_1@0.1.0".to_string()),
+    let ados = [ADOVersion::from_string("ado_type_1@0.1.0".to_string()),
         ADOVersion::from_string("ado_type_1@0.1.1".to_string()),
-        ADOVersion::from_string("ado_type_2@0.1.0".to_string()),
-    ];
+        ADOVersion::from_string("ado_type_2@0.1.0".to_string())];
 
     ados.iter().for_each(|ado_version| {
         let msg = ExecuteMsg::Publish {

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -25,7 +25,7 @@ pub struct PathIndices<'a> {
     pub parent: MultiIndex<'a, Addr, PathInfo, (Addr, String)>,
 }
 
-impl<'a> IndexList<PathInfo> for PathIndices<'a> {
+impl IndexList<PathInfo> for PathIndices<'_> {
     fn get_indexes(
         &'_ self,
     ) -> Box<dyn Iterator<Item = &'_ dyn cw_storage_plus::Index<PathInfo>> + '_> {

--- a/packages/andromeda-data-storage/src/string_storage.rs
+++ b/packages/andromeda-data-storage/src/string_storage.rs
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_from_string() {
-        let cases = vec![(
+        let cases = [(
             StringStorage::String("String".to_string()),
             "String".to_string(),
         )];

--- a/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
+++ b/packages/andromeda-non-fungible-tokens/src/crowdfund.rs
@@ -122,15 +122,14 @@ pub enum CampaignStage {
     DISCARDED,
 }
 
-impl ToString for CampaignStage {
-    #[inline]
-    fn to_string(&self) -> String {
+impl std::fmt::Display for CampaignStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::READY => "READY".to_string(),
-            Self::ONGOING => "ONGOING".to_string(),
-            Self::SUCCESS => "SUCCESS".to_string(),
-            Self::FAILED => "FAILED".to_string(),
-            Self::DISCARDED => "DISCARDED".to_string(),
+            Self::READY => write!(f, "READY"),
+            Self::ONGOING => write!(f, "ONGOING"),
+            Self::SUCCESS => write!(f, "SUCCESS"),
+            Self::FAILED => write!(f, "FAILED"),
+            Self::DISCARDED => write!(f, "DISCARDED"),
         }
     }
 }

--- a/packages/deploy/src/os.rs
+++ b/packages/deploy/src/os.rs
@@ -151,7 +151,7 @@ impl OperatingSystemDeployment {
         let deployable = os_contracts();
         for (name, contract) in uploaded_contracts {
             let (_, version, _) = deployable.iter().find(|(n, _, _)| n == name).unwrap();
-            let versions = self.adodb.ado_versions(&name.to_string(), None, None)?;
+            let versions = self.adodb.ado_versions(name.to_string(), None, None)?;
             if versions.contains(&format!("{}@{}", name, version)) {
                 log::info!(
                     "Skipping publishing {} {} - already published",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.0-b.1"
+version = "1.5.0-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_base/rates.rs
+++ b/packages/std/src/ado_base/rates.rs
@@ -51,9 +51,9 @@ pub struct PaymentAttribute {
     pub receiver: String,
 }
 
-impl ToString for PaymentAttribute {
-    fn to_string(&self) -> String {
-        format!("{}<{}", self.receiver, self.amount)
+impl std::fmt::Display for PaymentAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}<{}", self.receiver, self.amount)
     }
 }
 
@@ -222,19 +222,17 @@ impl LocalRate {
                 msg: to_json_binary(&kernel_msg)?,
                 funds: vec![fee.clone()],
             })
+        } else if is_native {
+            self.recipient
+                .generate_direct_msg(&deps, vec![fee.clone()])?
         } else {
-            if is_native {
-                self.recipient
-                    .generate_direct_msg(&deps, vec![fee.clone()])?
-            } else {
-                self.recipient.generate_msg_cw20(
-                    &deps,
-                    Cw20Coin {
-                        amount: fee.amount,
-                        address: fee.denom.to_string(),
-                    },
-                )?
-            }
+            self.recipient.generate_msg_cw20(
+                &deps,
+                Cw20Coin {
+                    amount: fee.amount,
+                    address: fee.denom.to_string(),
+                },
+            )?
         };
 
         msgs.push(msg);

--- a/packages/std/src/ado_contract/app.rs
+++ b/packages/std/src/ado_contract/app.rs
@@ -11,7 +11,7 @@ enum AppQueryMsg {
     GetAddress { name: String },
 }
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     #[inline]
     pub fn get_app_contract(&self, storage: &dyn Storage) -> Result<Option<Addr>, ContractError> {
         Ok(self.app_contract.may_load(storage)?)

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 
 type ExecuteContextFunction<M, E> = fn(ExecuteContext, M) -> Result<Response, E>;
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     pub fn instantiate(
         &self,
         storage: &mut dyn Storage,

--- a/packages/std/src/ado_contract/ownership.rs
+++ b/packages/std/src/ado_contract/ownership.rs
@@ -12,7 +12,7 @@ const POTENTIAL_OWNER: Item<Addr> = Item::new("andr_potential_owner");
 const POTENTIAL_OWNER_EXPIRATION: Item<MillisecondsExpiration> =
     Item::new("andr_potential_owner_expiration");
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     pub fn execute_ownership(
         &self,
         deps: DepsMut,

--- a/packages/std/src/ado_contract/permissioning.rs
+++ b/packages/std/src/ado_contract/permissioning.rs
@@ -22,7 +22,7 @@ pub struct PermissionsIndices<'a> {
     pub action: MultiIndex<'a, String, PermissionInfo, String>,
 }
 
-impl<'a> IndexList<PermissionInfo> for PermissionsIndices<'a> {
+impl IndexList<PermissionInfo> for PermissionsIndices<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<PermissionInfo>> + '_> {
         let v: Vec<&dyn Index<PermissionInfo>> = vec![&self.action, &self.actor];
         Box::new(v.into_iter())
@@ -44,7 +44,7 @@ pub fn permissions<'a>() -> IndexedMap<'a, &'a str, PermissionInfo, PermissionsI
     IndexedMap::new("andr_permissions", indexes)
 }
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     pub fn execute_permissioning(
         &self,
         ctx: ExecuteContext,

--- a/packages/std/src/ado_contract/query.rs
+++ b/packages/std/src/ado_contract/query.rs
@@ -16,7 +16,7 @@ use cosmwasm_std::{from_json, to_json_binary, Binary, Deps, Env};
 use cw2::get_contract_version;
 use serde::Serialize;
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     #[allow(unreachable_patterns)]
     pub fn query(
         &self,
@@ -80,7 +80,7 @@ impl<'a> ADOContract<'a> {
     }
 }
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     #[inline]
     pub fn query_contract_owner(&self, deps: Deps) -> Result<ContractOwnerResponse, ContractError> {
         let owner = self.owner.load(deps.storage)?;

--- a/packages/std/src/ado_contract/rates.rs
+++ b/packages/std/src/ado_contract/rates.rs
@@ -12,7 +12,7 @@ pub fn rates<'a>() -> Map<'a, &'a str, Rate> {
     Map::new("rates")
 }
 
-impl<'a> ADOContract<'a> {
+impl ADOContract<'_> {
     /// Sets rates
     pub fn set_rates(
         &self,

--- a/packages/std/src/ado_contract/state.rs
+++ b/packages/std/src/ado_contract/state.rs
@@ -16,7 +16,7 @@ pub struct ADOContract<'a> {
     pub rates: Map<'a, &'a str, Rate>,
 }
 
-impl<'a> Default for ADOContract<'a> {
+impl Default for ADOContract<'_> {
     fn default() -> Self {
         ADOContract {
             owner: Item::new("owner"),

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -121,13 +121,6 @@ impl AndrAddr {
                         }
                     }
                 }
-                // .ok()
-                // .ok_or(ContractError::InvalidPathname {
-                //     error: Some(format!(
-                //         "{:?} does not exist in the file system",
-                //         valid_vfs_path.0
-                //     )),
-                // })
             }
         }
     }

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -108,7 +108,7 @@ impl AndrAddr {
                 match vfs_resolve_path(valid_vfs_path.clone(), vfs_addr, &deps.querier) {
                     Ok(addr) => Ok(addr),
                     Err(_) => {
-                        // If the path is a cross chain path then we return the path as is
+                        // If the path is cross-chain then we return it as is
                         if valid_vfs_path.get_protocol().is_some() {
                             Ok(Addr::unchecked(valid_vfs_path.into_string()))
                         } else {

--- a/packages/std/src/amp/addresses.rs
+++ b/packages/std/src/amp/addresses.rs
@@ -105,14 +105,29 @@ impl AndrAddr {
                 let valid_vfs_path =
                     self.local_path_to_vfs_path(deps.storage, &deps.querier, vfs_contract.clone())?;
                 let vfs_addr = Addr::unchecked(vfs_contract);
-                vfs_resolve_path(valid_vfs_path.clone(), vfs_addr, &deps.querier)
-                    .ok()
-                    .ok_or(ContractError::InvalidPathname {
-                        error: Some(format!(
-                            "{:?} does not exist in the file system",
-                            valid_vfs_path.0
-                        )),
-                    })
+                match vfs_resolve_path(valid_vfs_path.clone(), vfs_addr, &deps.querier) {
+                    Ok(addr) => Ok(addr),
+                    Err(_) => {
+                        // If the path is a cross chain path then we return the path as is
+                        if valid_vfs_path.get_protocol().is_some() {
+                            Ok(Addr::unchecked(valid_vfs_path.into_string()))
+                        } else {
+                            Err(ContractError::InvalidPathname {
+                                error: Some(format!(
+                                    "{:?} does not exist in the file system",
+                                    valid_vfs_path.0
+                                )),
+                            })
+                        }
+                    }
+                }
+                // .ok()
+                // .ok_or(ContractError::InvalidPathname {
+                //     error: Some(format!(
+                //         "{:?} does not exist in the file system",
+                //         valid_vfs_path.0
+                //     )),
+                // })
             }
         }
     }

--- a/packages/std/src/amp/recipient.rs
+++ b/packages/std/src/amp/recipient.rs
@@ -60,10 +60,7 @@ impl Recipient {
 
     pub fn is_cross_chain(&self) -> bool {
         let protocol = self.address.get_protocol();
-        match protocol {
-            Some("ibc") => true,
-            _ => false,
-        }
+        matches!(protocol, Some("ibc"))
     }
 
     /// Generates a direct sub message for the given recipient.

--- a/packages/std/src/common/context.rs
+++ b/packages/std/src/common/context.rs
@@ -8,7 +8,7 @@ pub struct ExecuteContext<'a> {
     pub amp_ctx: Option<AMPPkt>,
 }
 
-impl<'a> ExecuteContext<'a> {
+impl ExecuteContext<'_> {
     #[inline]
     pub fn new(deps: DepsMut, info: MessageInfo, env: Env) -> ExecuteContext {
         ExecuteContext {

--- a/tests-integration/tests/kernel_orch.rs
+++ b/tests-integration/tests/kernel_orch.rs
@@ -729,19 +729,6 @@ fn test_kernel_ibc_funds_only() {
         )
         .unwrap();
 
-    adodb_juno
-        .execute(
-            &os::adodb::ExecuteMsg::Publish {
-                code_id: 4,
-                ado_type: "economics".to_string(),
-                action_fees: None,
-                version: "1.1.1".to_string(),
-                publisher: None,
-            },
-            None,
-        )
-        .unwrap();
-
     economics_juno
         .instantiate(
             &os::economics::InstantiateMsg {
@@ -770,32 +757,6 @@ fn test_kernel_ibc_funds_only() {
                 owner: None,
             },
             None,
-            None,
-        )
-        .unwrap();
-
-    adodb_osmosis
-        .execute(
-            &os::adodb::ExecuteMsg::Publish {
-                code_id: 2,
-                ado_type: "counter".to_string(),
-                action_fees: None,
-                version: "1.0.2".to_string(),
-                publisher: None,
-            },
-            None,
-        )
-        .unwrap();
-
-    adodb_osmosis
-        .execute(
-            &os::adodb::ExecuteMsg::Publish {
-                code_id: 6,
-                ado_type: "economics".to_string(),
-                action_fees: None,
-                version: "1.1.1".to_string(),
-                publisher: None,
-            },
             None,
         )
         .unwrap();
@@ -1275,19 +1236,6 @@ fn test_kernel_ibc_funds_only_multi_hop() {
         )
         .unwrap();
 
-    adodb_osmosis
-        .execute(
-            &os::adodb::ExecuteMsg::Publish {
-                code_id: 2,
-                ado_type: "counter".to_string(),
-                action_fees: None,
-                version: "1.0.2".to_string(),
-                publisher: None,
-            },
-            None,
-        )
-        .unwrap();
-
     kernel_juno
         .execute(
             &ExecuteMsg::UpsertKeyAddress {
@@ -1662,19 +1610,6 @@ fn test_kernel_ibc_funds_and_execute_msg() {
                 ado_type: "splitter".to_string(),
                 action_fees: None,
                 version: "1.0.0".to_string(),
-                publisher: None,
-            },
-            None,
-        )
-        .unwrap();
-
-    adodb_osmosis
-        .execute(
-            &os::adodb::ExecuteMsg::Publish {
-                code_id: 2,
-                ado_type: "counter".to_string(),
-                action_fees: None,
-                version: "1.0.2".to_string(),
                 publisher: None,
             },
             None,

--- a/tests-integration/tests/rates_orch.rs
+++ b/tests-integration/tests/rates_orch.rs
@@ -126,7 +126,7 @@ fn test_marketplace_migration() {
         kernel_address: kernel_juno.address().unwrap().into_string(),
         owner: Some(sender.clone().into_string().clone()),
     };
-    rates_juno.instantiate(&rates_init_msg, None, None).unwrap();
+    rates_juno.instantiate(rates_init_msg, None, None).unwrap();
 
     kernel_juno
         .execute(

--- a/tests-integration/tests/splitter.rs
+++ b/tests-integration/tests/splitter.rs
@@ -2,16 +2,29 @@ use andromeda_app::app::AppComponent;
 use andromeda_app_contract::mock::{mock_andromeda_app, MockAppContract};
 
 use andromeda_cw20::mock::{mock_andromeda_cw20, mock_cw20_instantiate_msg, mock_minter, MockCW20};
+use andromeda_kernel::KernelContract;
 use andromeda_testing::{
     mock::{mock_app, MockApp},
     mock_builder::MockAndromedaBuilder,
     MockAndromeda, MockContract,
 };
 
-use andromeda_std::amp::Recipient;
-use cosmwasm_std::{coin, to_json_binary, Coin, Decimal, Empty, Uint128};
+use andromeda_std::{
+    amp::{AndrAddr, Recipient},
+    os::{
+        self,
+        kernel::{AcknowledgementMsg, ExecuteMsg, InstantiateMsg, SendMessageWithFundsResponse},
+    },
+};
+use cosmwasm_std::{
+    coin, to_json_binary, Binary, Coin, Decimal, Empty, IbcAcknowledgement, IbcEndpoint, IbcPacket,
+    IbcPacketAckMsg, IbcTimeout, Timestamp, Uint128,
+};
 
-use andromeda_finance::splitter::{AddressPercent, Cw20HookMsg};
+use andromeda_finance::splitter::{
+    AddressPercent, Cw20HookMsg, ExecuteMsg as SplitterExecuteMsg,
+    InstantiateMsg as SplitterInstantiateMsg,
+};
 use andromeda_splitter::mock::{
     mock_andromeda_splitter, mock_splitter_instantiate_msg, MockSplitter,
 };
@@ -71,6 +84,10 @@ fn setup(
             recipient: Recipient::from_string(recipient_2.to_string()),
             percent: Decimal::from_ratio(Uint128::from(8u128), Uint128::from(10u128)),
         },
+        // AddressPercent {
+        //     recipient: Recipient::from_string("ibc://osmosis/recipient3".to_string()),
+        //     percent: Decimal::from_ratio(Uint128::from(8u128), Uint128::from(10u128)),
+        // },
     ];
     let splitter_init_msg = mock_splitter_instantiate_msg(
         splitter_recipients,
@@ -299,4 +316,421 @@ fn test_successful_set_amount_splitter_cw20_with_remainder(setup: TestCase) {
     assert_eq!(cw20_balance, Uint128::from(100u128));
     let cw20_balance = cw20.query_balance(&router, owner);
     assert_eq!(cw20_balance, Uint128::from(1_000_000u128 - 200u128));
+}
+
+// Cross chain test
+use andromeda_adodb::ADODBContract;
+use andromeda_economics::EconomicsContract;
+use andromeda_splitter::SplitterContract;
+use andromeda_vfs::VFSContract;
+use cw_orch::prelude::*;
+use cw_orch_interchain::{prelude::*, types::IbcPacketOutcome, InterchainEnv};
+use ibc_relayer_types::core::ics24_host::identifier::PortId;
+#[test]
+fn test_splitter_cross_chain_recipient() {
+    // Here `juno-1` is the chain-id and `juno` is the address prefix for this chain
+    let sender = Addr::unchecked("sender_for_all_chains").into_string();
+    let buyer = Addr::unchecked("buyer").into_string();
+
+    let interchain = MockInterchainEnv::new(vec![
+        ("juno", &sender),
+        ("osmosis", &sender),
+        // Dummy chain to create unequal ports to test counterparty denom properly
+        ("cosmoshub", &sender),
+    ]);
+
+    let juno = interchain.get_chain("juno").unwrap();
+    let osmosis = interchain.get_chain("osmosis").unwrap();
+    juno.set_balance(sender.clone(), vec![Coin::new(100000000000000, "juno")])
+        .unwrap();
+    juno.set_balance(buyer.clone(), vec![Coin::new(100000000000000, "juno")])
+        .unwrap();
+
+    let kernel_juno = KernelContract::new(juno.clone());
+    let vfs_juno = VFSContract::new(juno.clone());
+    let adodb_juno = ADODBContract::new(juno.clone());
+    let economics_juno = EconomicsContract::new(juno.clone());
+    let splitter_juno = SplitterContract::new(juno.clone());
+
+    let kernel_osmosis = KernelContract::new(osmosis.clone());
+    let vfs_osmosis = VFSContract::new(osmosis.clone());
+    let adodb_osmosis = ADODBContract::new(osmosis.clone());
+
+    kernel_juno.upload().unwrap();
+    vfs_juno.upload().unwrap();
+    adodb_juno.upload().unwrap();
+    economics_juno.upload().unwrap();
+    splitter_juno.upload().unwrap();
+
+    kernel_osmosis.upload().unwrap();
+    vfs_osmosis.upload().unwrap();
+    adodb_osmosis.upload().unwrap();
+
+    let init_msg_juno = &InstantiateMsg {
+        owner: None,
+        chain_name: "juno".to_string(),
+    };
+    let init_msg_osmosis = &InstantiateMsg {
+        owner: None,
+        chain_name: "osmosis".to_string(),
+    };
+
+    kernel_juno.instantiate(init_msg_juno, None, None).unwrap();
+    kernel_osmosis
+        .instantiate(init_msg_osmosis, None, None)
+        .unwrap();
+
+    // Set up channel from juno to osmosis
+    let channel_receipt = interchain
+        .create_contract_channel(&kernel_juno, &kernel_osmosis, "andr-kernel-1", None)
+        .unwrap();
+
+    // After channel creation is complete, we get the channel id, which is necessary for ICA remote execution
+    let juno_channel = channel_receipt
+        .interchain_channel
+        .get_chain("juno")
+        .unwrap()
+        .channel
+        .unwrap();
+
+    // Set up channel from osmosis to cosmoshub for ICS20 transfers so that channel-0 is used on osmosis
+    // Later when we create channel with juno, channel-1 will be used on osmosis
+    let _channel_receipt = interchain
+        .create_channel(
+            "osmosis",
+            "cosmoshub",
+            &PortId::transfer(),
+            &PortId::transfer(),
+            "ics20-1",
+            None,
+        )
+        .unwrap();
+
+    // Set up channel from juno to osmosis for ICS20 transfers
+    let channel_receipt = interchain
+        .create_channel(
+            "juno",
+            "osmosis",
+            &PortId::transfer(),
+            &PortId::transfer(),
+            "ics20-1",
+            None,
+        )
+        .unwrap();
+
+    let channel = channel_receipt
+        .interchain_channel
+        .get_ordered_ports_from("juno")
+        .unwrap();
+
+    // After channel creation is complete, we get the channel id, which is necessary for ICA remote execution
+    let _juno_channel_ics20 = channel_receipt
+        .interchain_channel
+        .get_chain("juno")
+        .unwrap()
+        .channel
+        .unwrap();
+
+    vfs_juno
+        .instantiate(
+            &os::vfs::InstantiateMsg {
+                kernel_address: kernel_juno.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    vfs_osmosis
+        .instantiate(
+            &os::vfs::InstantiateMsg {
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    adodb_juno
+        .instantiate(
+            &os::adodb::InstantiateMsg {
+                kernel_address: kernel_juno.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    adodb_juno
+        .execute(
+            &os::adodb::ExecuteMsg::Publish {
+                code_id: 4,
+                ado_type: "economics".to_string(),
+                action_fees: None,
+                version: "1.1.1".to_string(),
+                publisher: None,
+            },
+            None,
+        )
+        .unwrap();
+
+    adodb_juno
+        .execute(
+            &os::adodb::ExecuteMsg::Publish {
+                code_id: splitter_juno.code_id().unwrap(),
+                ado_type: "splitter".to_string(),
+                action_fees: None,
+                version: "2.3.0-b.1".to_string(),
+                publisher: None,
+            },
+            None,
+        )
+        .unwrap();
+
+    economics_juno
+        .instantiate(
+            &os::economics::InstantiateMsg {
+                kernel_address: kernel_juno.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    kernel_juno
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "economics".to_string(),
+                value: economics_juno.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    adodb_osmosis
+        .instantiate(
+            &os::adodb::InstantiateMsg {
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+                owner: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    adodb_osmosis
+        .execute(
+            &os::adodb::ExecuteMsg::Publish {
+                code_id: 2,
+                ado_type: "counter".to_string(),
+                action_fees: None,
+                version: "1.0.2".to_string(),
+                publisher: None,
+            },
+            None,
+        )
+        .unwrap();
+
+    adodb_osmosis
+        .execute(
+            &os::adodb::ExecuteMsg::Publish {
+                code_id: 6,
+                ado_type: "economics".to_string(),
+                action_fees: None,
+                version: "1.1.1".to_string(),
+                publisher: None,
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_juno
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "vfs".to_string(),
+                value: vfs_juno.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_juno
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "adodb".to_string(),
+                value: adodb_juno.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_osmosis
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "vfs".to_string(),
+                value: vfs_osmosis.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_osmosis
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "adodb".to_string(),
+                value: adodb_osmosis.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_juno
+        .execute(
+            &ExecuteMsg::AssignChannels {
+                ics20_channel_id: Some(channel.clone().0.channel.unwrap().to_string()),
+                direct_channel_id: Some(juno_channel.to_string()),
+                chain: "osmosis".to_string(),
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    kernel_osmosis
+        .execute(
+            &ExecuteMsg::AssignChannels {
+                ics20_channel_id: Some(channel.0.channel.unwrap().to_string()),
+                direct_channel_id: Some(juno_channel.to_string()),
+                chain: "juno".to_string(),
+                kernel_address: kernel_juno.address().unwrap().into_string(),
+            },
+            None,
+        )
+        .unwrap();
+
+    let recipient = "osmo1qzskhrca90qy2yjjxqzq4yajy842x7c50xq33d";
+    println!(
+        "osmosis kernel address: {}",
+        kernel_osmosis.address().unwrap()
+    );
+
+    splitter_juno
+        .instantiate(
+            &SplitterInstantiateMsg {
+                recipients: vec![AddressPercent {
+                    recipient: Recipient {
+                        address: AndrAddr::from_string(format!("ibc://osmosis/{}", recipient)),
+                        msg: None,
+                        ibc_recovery_address: None,
+                    },
+                    percent: Decimal::one(),
+                }],
+                lock_time: None,
+                kernel_address: kernel_osmosis.address().unwrap().into_string(),
+                owner: None,
+                default_recipient: None,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+
+    // Send funds to splitter
+    let splitter_juno_send_request = splitter_juno
+        .execute(
+            &SplitterExecuteMsg::Send { config: None },
+            Some(&[Coin {
+                denom: "juno".to_string(),
+                amount: Uint128::new(100),
+            }]),
+        )
+        .unwrap();
+
+    let packet_lifetime = interchain
+        .await_packets("juno", splitter_juno_send_request)
+        .unwrap();
+
+    let ibc_denom = format!("ibc/{}/{}", channel.1.channel.unwrap().as_str(), "juno");
+
+    // For testing a successful outcome of the first packet sent out in the tx, you can use:
+    if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
+        // Packet has been successfully acknowledged and decoded, the transaction has gone through correctly
+        // Check recipient balance
+        let balances = osmosis
+            .query_all_balances(kernel_osmosis.address().unwrap())
+            .unwrap();
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[0].denom, ibc_denom);
+        assert_eq!(balances[0].amount.u128(), 100);
+    } else {
+        panic!("packet timed out");
+        // There was a decode error or the packet timed out
+        // Else the packet timed-out, you may have a relayer error or something is wrong in your application
+    };
+
+    // Register trigger address
+    kernel_juno
+        .execute(
+            &ExecuteMsg::UpsertKeyAddress {
+                key: "trigger_key".to_string(),
+                value: sender.clone(),
+            },
+            None,
+        )
+        .unwrap();
+
+    // Construct an Execute msg from the kernel on juno inteded for the splitter on osmosis
+    let kernel_juno_trigger_request = kernel_juno
+        .execute(
+            &ExecuteMsg::TriggerRelay {
+                packet_sequence: "1".to_string(),
+                packet_ack_msg: IbcPacketAckMsg::new(
+                    IbcAcknowledgement::new(
+                        to_json_binary(&AcknowledgementMsg::<SendMessageWithFundsResponse>::Ok(
+                            SendMessageWithFundsResponse {},
+                        ))
+                        .unwrap(),
+                    ),
+                    IbcPacket::new(
+                        Binary::default(),
+                        IbcEndpoint {
+                            port_id: "port_id".to_string(),
+                            channel_id: "channel_id".to_string(),
+                        },
+                        IbcEndpoint {
+                            port_id: "port_id".to_string(),
+                            channel_id: "channel_id".to_string(),
+                        },
+                        1,
+                        IbcTimeout::with_timestamp(Timestamp::from_seconds(1)),
+                    ),
+                    Addr::unchecked("relayer"),
+                ),
+            },
+            None,
+        )
+        .unwrap();
+
+    let packet_lifetime = interchain
+        .await_packets("juno", kernel_juno_trigger_request)
+        .unwrap();
+
+    // For testing a successful outcome of the first packet sent out in the tx, you can use:
+    if let IbcPacketOutcome::Success { .. } = &packet_lifetime.packets[0].outcome {
+        // Packet has been successfully acknowledged and decoded, the transaction has gone through correctly
+
+        // Check recipient balance after trigger execute msg
+        let balances = osmosis.query_all_balances(recipient).unwrap();
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[0].denom, ibc_denom);
+        assert_eq!(balances[0].amount.u128(), 100);
+    } else {
+        panic!("packet timed out");
+        // There was a decode error or the packet timed out
+        // Else the packet timed-out, you may have a relayer error or something is wrong in your application
+    };
 }

--- a/tests-integration/tests/splitter.rs
+++ b/tests-integration/tests/splitter.rs
@@ -84,10 +84,6 @@ fn setup(
             recipient: Recipient::from_string(recipient_2.to_string()),
             percent: Decimal::from_ratio(Uint128::from(8u128), Uint128::from(10u128)),
         },
-        // AddressPercent {
-        //     recipient: Recipient::from_string("ibc://osmosis/recipient3".to_string()),
-        //     percent: Decimal::from_ratio(Uint128::from(8u128), Uint128::from(10u128)),
-        // },
     ];
     let splitter_init_msg = mock_splitter_instantiate_msg(
         splitter_recipients,


### PR DESCRIPTION
# Motivation
Closes #724 

# Implementation
```rust
match vfs_resolve_path(valid_vfs_path.clone(), vfs_addr, &deps.querier) {
                    Ok(addr) => Ok(addr),
                    Err(_) => {
                        // If the path is a cross chain path then we return the path as is
                        if valid_vfs_path.get_protocol().is_some() {
                            Ok(Addr::unchecked(valid_vfs_path.into_string()))
                        } else {
                            Err(ContractError::InvalidPathname {
                                error: Some(format!(
                                    "{:?} does not exist in the file system",
                                    valid_vfs_path.0
                                )),
                            })
                        }
                    }
                }
```

# Testing
`test_splitter_cross_chain_recipient` integration test using cw-orch.

# Version Changes
`andromeda-std`: `1.5.0-b.1` -> `1.5.0-b.2`

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for address resolution in cross-chain operations.
	- Introduced a new test for cross-chain transactions involving multiple chains.
	- Added support for optional configuration in Splitter contracts and CW20 support.
	- Implemented a new struct for improved mock querying capabilities across various contracts.
	- Updated the `CampaignStage` enum for better string formatting.
	- Simplified lifetime handling in various contract implementations.

- **Bug Fixes**
	- Improved validation and refund logic in error scenarios for interchain communication tests.

- **Documentation**
	- Updated CHANGELOG to reflect new features and changes in functionality.

- **Chores**
	- Cleaned up unnecessary contract interactions in test setups.
	- Updated package version in Cargo.toml.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->