### PR TITLE
feat: Allow Flat Rate to be a VFS Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rates: Handle cross-chain recipients [(#671)](https://github.com/andromedaprotocol/andromeda-core/pull/671)
 - Permissions: Permissioned Actors in AndromedaQuery [(#717)](https://github.com/andromedaprotocol/andromeda-core/pull/717)
 - Added Schema and Form ADOs [(#591)](https://github.com/andromedaprotocol/andromeda-core/pull/591)
+- Flat Rate denom can be a VFS path [(#727)](https://github.com/andromedaprotocol/andromeda-core/pull/727)
 
 ### Changed
 - Rates: Limit rates recipient to only one address [(#669)](https://github.com/andromedaprotocol/andromeda-core/pull/669)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rates"
-version = "2.0.3-b.1"
+version = "2.0.4-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rates"
-version = "2.0.3"
+version = "2.0.3-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.0-b.2"
+version = "1.5.0-b.3"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema 1.5.8",

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rates"
-version = "2.0.3"
+version = "2.0.3-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rates"
-version = "2.0.3-b.1"
+version = "2.0.4-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-rates/src/contract.rs
+++ b/contracts/modules/andromeda-rates/src/contract.rs
@@ -32,8 +32,6 @@ pub fn instantiate(
     let action = msg.action;
     let rate = msg.rate;
 
-    RATES.save(deps.storage, &action, &rate)?;
-
     let inst_resp = ADOContract::default().instantiate(
         deps.storage,
         env,
@@ -47,6 +45,9 @@ pub fn instantiate(
             owner: msg.owner,
         },
     )?;
+
+    let local_rate = rate.validate(deps.as_ref())?;
+    RATES.save(deps.storage, &action, &local_rate)?;
 
     Ok(inst_resp)
 }

--- a/contracts/modules/andromeda-rates/src/testing/tests.rs
+++ b/contracts/modules/andromeda-rates/src/testing/tests.rs
@@ -32,7 +32,7 @@ fn test_instantiate_query() {
             msg: None,
             ibc_recovery_address: None,
         },
-        value: LocalRateValue::Flat(coin(100_u128, "uandr")),
+        value: LocalRateValue::Flat(coin(100_u128, MOCK_UANDR)),
         description: None,
     };
     let msg = InstantiateMsg {

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.0-b.2"
+version = "1.5.0-b.3"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/ado_contract/rates.rs
+++ b/packages/std/src/ado_contract/rates.rs
@@ -46,8 +46,7 @@ impl ADOContract<'_> {
         );
         let action: String = action.into();
         // Validate rates
-        rate.validate_rate(ctx.deps.as_ref())?;
-
+        let rate = rate.validate_rate(ctx.deps.as_ref())?;
         self.set_rates(ctx.deps.storage, action, rate)?;
 
         Ok(Response::default().add_attributes(vec![("action", "set_rates")]))

--- a/tests-integration/tests/marketplace_app.rs
+++ b/tests-integration/tests/marketplace_app.rs
@@ -564,13 +564,13 @@ fn test_marketplace_app_cw20_restricted() {
         app.query_ado_by_component_name(&router, marketplace_component.name);
     let address_list: MockAddressList =
         app.query_ado_by_component_name(&router, address_list_component.name);
-    let cw20: MockCW20 = app.query_ado_by_component_name(&router, cw20_component.name);
+    let cw20: MockCW20 = app.query_ado_by_component_name(&router, cw20_component.name.clone());
 
     let local_rate = LocalRate {
         rate_type: LocalRateType::Additive,
         recipient: Recipient::from_string(rates_receiver.to_string()),
         // This is the cw20's address
-        value: LocalRateValue::Flat(coin(100, cw20.addr().to_string())),
+        value: LocalRateValue::Flat(coin(100, format!("./{}", cw20_component.name))),
         description: None,
     };
 


### PR DESCRIPTION
# Motivation
Closes #652 

# Implementation
Turn coin denom into an `AndrAddr`, allowing vfs paths to be set as denoms
```rust
                let denom_andr_addr = AndrAddr::from_string(&coin.denom);

                let is_valid_address = denom_andr_addr.get_raw_address(&deps);
```
The raw address will be eventually saved, not the path. To do that, the validation functions for rates now return the struct they're validating instead of `()`, to accommodate the VFS path denoms:
```rust
Ok(LocalRateValue::Flat(Coin {
                            denom: cw20_address.into_string(),
                            amount: coin.amount,
                        }))
```


# Testing
Modified the `test_marketplace_app_cw20_restricted` integration test to use vfs path as denom for its flat rate. 

# Version Changes
`andromeda-std`: `1.5.0-b.2` -> `1.5.0-b.3`
`andromeda-rates`: `2.0.3` -> `2.0.3-b.1`

# Notes
There was no validation of the Local Rate during the Rates contract instantiation. That has been fixed. 

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated version numbers for packages to reflect recent changes.
	- Enhanced validation processes for rates, ensuring only validated rates are stored.
	- Introduced a `splitter` component to facilitate fund distribution in the marketplace.
	- Added new ADOs and features, including CW20 support in Splitter contracts and the ability for Flat Rate denominations to be a VFS path.

- **Bug Fixes**
	- Improved error handling for CW20 token transactions, ensuring only authorized tokens can be used.

- **Tests**
	- Expanded test suite for the marketplace application, adding new tests and refining existing ones to improve transaction handling and validation. 
	- Standardized the use of constants for currency values in test cases.

- **Documentation**
	- Updated CHANGELOG.md to reflect various changes and additions across the Andromeda project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->