### PR TITLE
feat: include buy_now_price in UpdateAuction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rates: Handle cross-chain recipients [(#671)](https://github.com/andromedaprotocol/andromeda-core/pull/671)
 - Permissions: Permissioned Actors in AndromedaQuery [(#717)](https://github.com/andromedaprotocol/andromeda-core/pull/717)
 - Added Schema and Form ADOs [(#591)](https://github.com/andromedaprotocol/andromeda-core/pull/591)
+- Auction ADO: Added buy_now_price option in Update Auction [(#730)](https://github.com/andromedaprotocol/andromeda-core/pull/730)
 
 ### Changed
 - Rates: Limit rates recipient to only one address [(#669)](https://github.com/andromedaprotocol/andromeda-core/pull/669)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.2.4-b.1"
+version = "2.2.5-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.2.4"
+version = "2.2.4-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.2.4-b.1"
+version = "2.2.5-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.2.4"
+version = "2.2.4-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -115,6 +115,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
             whitelist,
             min_bid,
             min_raise,
+            buy_now_price,
             recipient,
         } => execute_update_auction(
             ctx,
@@ -126,6 +127,7 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
             whitelist,
             min_bid,
             min_raise,
+            buy_now_price,
             recipient,
         ),
         ExecuteMsg::PlaceBid {
@@ -364,6 +366,7 @@ fn execute_update_auction(
     whitelist: Option<Vec<Addr>>,
     min_bid: Option<Uint128>,
     min_raise: Option<Uint128>,
+    buy_now_price: Option<Uint128>,
     recipient: Option<Recipient>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -418,6 +421,14 @@ fn execute_update_auction(
         ContractError::StartTimeAfterEndTime {}
     );
 
+    if let (Some(buy_now), Some(min)) = (buy_now_price, min_bid) {
+        if min >= buy_now {
+            return Err(ContractError::InvalidMinBid {
+                msg: Some("buy_now_price must be greater than the min_bid".to_string()),
+            });
+        }
+    }
+
     if let Some(ref whitelist) = whitelist {
         ADOContract::default()
             .permission_action(token_auction_state.auction_id.to_string(), deps.storage)?;
@@ -440,6 +451,7 @@ fn execute_update_auction(
     token_auction_state.uses_cw20 = uses_cw20;
     token_auction_state.min_bid = min_bid;
     token_auction_state.min_raise = min_raise;
+    token_auction_state.buy_now_price = buy_now_price;
     token_auction_state.whitelist = whitelist;
     token_auction_state.recipient = recipient;
     TOKEN_AUCTION_STATE.save(
@@ -457,6 +469,7 @@ fn execute_update_auction(
         attr("whitelist", format!("{:?}", whitelist_str)),
         attr("min_bid", format!("{:?}", &min_bid)),
         attr("min_raise", format!("{:?}", &min_raise)),
+        attr("buy_now_price", format!("{:?}", &buy_now_price)),
     ]))
 }
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -225,6 +225,7 @@ pub fn mock_update_auction(
     coin_denom: Asset,
     min_bid: Option<Uint128>,
     min_raise: Option<Uint128>,
+    buy_now_price: Option<Uint128>,
     whitelist: Option<Vec<Addr>>,
     recipient: Option<Recipient>,
 ) -> ExecuteMsg {
@@ -237,6 +238,7 @@ pub fn mock_update_auction(
         whitelist,
         min_bid,
         min_raise,
+        buy_now_price,
         recipient,
     }
 }

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -977,6 +977,7 @@ fn execute_update_auction_zero_start() {
         whitelist: None,
         min_bid: None,
         min_raise: None,
+        buy_now_price: None,
         recipient: None,
     };
     let mut env = mock_env();
@@ -1010,6 +1011,7 @@ fn execute_update_auction_zero_duration() {
         whitelist: None,
         min_bid: None,
         min_raise: None,
+        buy_now_price: None,
         recipient: None,
     };
     let mut env = mock_env();
@@ -1037,6 +1039,7 @@ fn execute_update_auction_unauthorized() {
         whitelist: Some(vec![Addr::unchecked("user")]),
         min_bid: None,
         min_raise: None,
+        buy_now_price: None,
         recipient: None,
     };
     let env = mock_env();
@@ -1062,6 +1065,7 @@ fn execute_update_auction_auction_started() {
         whitelist: Some(vec![Addr::unchecked("user")]),
         min_bid: None,
         min_raise: None,
+        buy_now_price: None,
         recipient: None,
     };
     let mut env = mock_env();
@@ -1089,6 +1093,7 @@ fn execute_update_auction() {
         whitelist: Some(vec![Addr::unchecked("user")]),
         min_bid: None,
         min_raise: None,
+        buy_now_price: Some(Uint128::from(100u128)),
         recipient: None,
     };
     let mut env = mock_env();
@@ -1104,7 +1109,7 @@ fn execute_update_auction() {
             high_bidder_addr: Addr::unchecked(""),
             high_bidder_amount: Uint128::zero(),
             coin_denom: "uusd".to_string(),
-            buy_now_price: None,
+            buy_now_price: Some(Uint128::from(100u128)),
             uses_cw20: false,
             auction_id: 1u128.into(),
             owner: MOCK_TOKEN_OWNER.to_string(),

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -47,6 +47,7 @@ pub enum ExecuteMsg {
         whitelist: Option<Vec<Addr>>,
         min_bid: Option<Uint128>,
         min_raise: Option<Uint128>,
+        buy_now_price: Option<Uint128>,
         recipient: Option<Recipient>,
     },
     CancelAuction {

--- a/tests-integration/tests/auction_app.rs
+++ b/tests-integration/tests/auction_app.rs
@@ -815,6 +815,7 @@ fn test_auction_app_cw20_restricted() {
         Asset::Cw20Token(AndrAddr::from_string(second_cw20.addr().to_string())),
         None,
         None,
+        None,
         Some(vec![buyer_one.clone(), buyer_two.clone()]),
         Some(Recipient::from_string(buyer_one)),
     );


### PR DESCRIPTION
# Motivation
Closes #728 

# Implementation
Added an optional `buy_now_price` in `UpdateAuction` alongside this line:
```rust
    token_auction_state.buy_now_price = buy_now_price;
```
and prior verification identical to the one where we start the auction. 
# Testing
`execute_update_auction` unit test has been modified to include a new `buy_now_price`

# Version Changes
`andromeda-auction`: `2.2.4` -> `2.2.5-b.1`

# Notes
We've modified an `ExecuteMsg` so it's a breaking change for the schema side I suppose. 

# Future work
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a `buy_now_price` option for auctions, allowing immediate purchase alongside traditional bidding.
	- Added support for CW20 tokens in auction functionalities.
	- Enhanced auction state management with new parameters and responses.

- **Bug Fixes**
	- Improved error handling for auction updates and bid placements, ensuring proper validation and permissions.

- **Documentation**
	- Updated `CHANGELOG.md` to reflect new features and changes.

- **Tests**
	- Expanded test coverage for auction functionalities, including new test cases for CW20 token handling and permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->