### PR TITLE
feat: kernel environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rates: Handle cross-chain recipients [(#671)](https://github.com/andromedaprotocol/andromeda-core/pull/671)
 - Permissions: Permissioned Actors in AndromedaQuery [(#717)](https://github.com/andromedaprotocol/andromeda-core/pull/717)
 - Added Schema and Form ADOs [(#591)](https://github.com/andromedaprotocol/andromeda-core/pull/591)
+- feat: kernel environment variables [#738](https://github.com/andromedaprotocol/andromeda-core/pull/738)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.0-b.1"
+version = "1.2.0-b.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "osmosis-std",
  "osmosis-std-derive 0.15.3",
  "prost 0.11.9",
+ "rstest",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,6 @@ cw-multi-test = { version = "1.0.0", features = ["cosmwasm_1_2"] }
 serde = { version = "1.0.216" }
 test-case = { version = "3.3.1" }
 cw-orch = "=0.24.1"
-jsonschema-valid = { version = "0.5.2"}
+jsonschema-valid = { version = "0.5.2" }
 serde_json = { version = "1.0.134" }
+rstest = "0.23.0"

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -325,9 +325,15 @@ fn execute_claim(
     );
 
     let kernel_addr = ADOContract::default().get_kernel_address(deps.storage)?;
-    let curr_chain = AOSQuerier::get_current_chain(&deps.querier, &kernel_addr)?;
 
-    let withdraw_msg: CosmosMsg = if curr_chain == "andromeda" {
+    let is_andromeda_distribution = AOSQuerier::get_env_variable::<bool>(
+        &deps.querier,
+        &kernel_addr,
+        "andromeda_distribution",
+    )?
+    .unwrap_or(false);
+
+    let withdraw_msg: CosmosMsg = if is_andromeda_distribution {
         MsgWithdrawDelegatorReward {
             delegator_address: delegator.to_string(),
             validator_address: validator.to_string(),

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.0-b.1"
+version = "1.2.0-b.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -47,3 +47,4 @@ cw-orch = { workspace = true }
 
 [dev-dependencies]
 # andromeda-testing = { workspace = true, optional = true }
+rstest = { workspace = true }

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -176,5 +176,6 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::ChainNameByChannel { channel } => {
             encode_binary(&query::chain_name_by_channel(deps, channel)?)
         }
+        QueryMsg::GetEnv { variable } => encode_binary(&query::get_env(deps, variable)?),
     }
 }

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -127,8 +127,9 @@ pub fn execute(
         ExecuteMsg::UpdateChainName { chain_name } => {
             execute::update_chain_name(execute_env, chain_name)
         }
+        ExecuteMsg::SetEnv { variable, value } => execute::set_env(execute_env, variable, value),
+        ExecuteMsg::UnsetEnv { variable } => execute::unset_env(execute_env, variable),
         ExecuteMsg::Internal(msg) => execute::internal(execute_env, msg),
-        // Base message
         ExecuteMsg::Ownership(ownership_message) => ADOContract::default().execute_ownership(
             execute_env.deps,
             execute_env.env,

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -504,7 +504,11 @@ pub fn set_env(
         }
     );
 
-    ENV_VARIABLES.save(execute_ctx.deps.storage, &variable, &value)?;
+    ENV_VARIABLES.save(
+        execute_ctx.deps.storage,
+        &variable.to_ascii_uppercase(),
+        &value,
+    )?;
     Ok(Response::default()
         .add_attribute("action", "set_env")
         .add_attribute("variable", variable)
@@ -520,11 +524,11 @@ pub fn unset_env(execute_ctx: ExecuteContext, variable: String) -> Result<Respon
 
     ensure!(
         ENV_VARIABLES
-            .may_load(execute_ctx.deps.storage, &variable)?
+            .may_load(execute_ctx.deps.storage, &variable.to_ascii_uppercase())?
             .is_some(),
         ContractError::EnvironmentVariableNotFound { variable }
     );
-    ENV_VARIABLES.remove(execute_ctx.deps.storage, &variable);
+    ENV_VARIABLES.remove(execute_ctx.deps.storage, &variable.to_ascii_uppercase());
     Ok(Response::default()
         .add_attribute("action", "unset_env")
         .add_attribute("variable", variable))

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -492,11 +492,37 @@ pub fn set_env(
     );
 
     ensure!(
+        !variable.is_empty(),
+        ContractError::InvalidEnvironmentVariable {
+            msg: "Environment variable name cannot be empty".to_string()
+        }
+    );
+
+    ensure!(
+        variable
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        ContractError::InvalidEnvironmentVariable {
+            msg:
+                "Environment variable name can only contain alphanumeric characters and underscores"
+                    .to_string()
+        }
+    );
+
+    ensure!(
         variable.len() <= 100,
         ContractError::InvalidEnvironmentVariable {
             msg: "Environment variable name length exceeds the maximum allowed length of 100 characters".to_string()
         }
     );
+
+    ensure!(
+        !value.is_empty(),
+        ContractError::InvalidEnvironmentVariable {
+            msg: "Environment variable value cannot be empty".to_string()
+        }
+    );
+
     ensure!(
         value.len() <= 100,
         ContractError::InvalidEnvironmentVariable {

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -484,6 +484,19 @@ pub fn set_env(
         ContractError::Unauthorized {}
     );
 
+    ensure!(
+        variable.len() <= 100,
+        ContractError::InvalidEnvironmentVariable {
+            msg: "Environment variable name length exceeds the maximum allowed length of 100 characters".to_string()
+        }
+    );
+    ensure!(
+        value.len() <= 100,
+        ContractError::InvalidEnvironmentVariable {
+            msg: "Environment variable value length exceeds the maximum allowed length of 100 characters".to_string()
+        }
+    );
+
     ENV_VARIABLES.save(execute_ctx.deps.storage, &variable, &value)?;
     Ok(Response::default()
         .add_attribute("action", "set_env")
@@ -498,6 +511,12 @@ pub fn unset_env(execute_ctx: ExecuteContext, variable: String) -> Result<Respon
         ContractError::Unauthorized {}
     );
 
+    ensure!(
+        ENV_VARIABLES
+            .may_load(execute_ctx.deps.storage, &variable)?
+            .is_some(),
+        ContractError::EnvironmentVariableNotFound { variable }
+    );
     ENV_VARIABLES.remove(execute_ctx.deps.storage, &variable);
     Ok(Response::default()
         .add_attribute("action", "unset_env")

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -3,13 +3,14 @@ use andromeda_std::{
     error::ContractError,
     os::{
         aos_querier::AOSQuerier,
-        kernel::{ChainNameResponse, ChannelInfoResponse, VerifyAddressResponse},
+        kernel::{ChainNameResponse, ChannelInfoResponse, EnvResponse, VerifyAddressResponse},
     },
 };
 use cosmwasm_std::{Addr, Coin, Deps};
 
 use crate::state::{
-    CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CURR_CHAIN, IBC_FUND_RECOVERY, KERNEL_ADDRESSES,
+    CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CURR_CHAIN, ENV_VARIABLES, IBC_FUND_RECOVERY,
+    KERNEL_ADDRESSES,
 };
 
 pub fn key_address(deps: Deps, key: String) -> Result<Addr, ContractError> {
@@ -66,5 +67,11 @@ pub fn recoveries(deps: Deps, addr: Addr) -> Result<Vec<Coin>, ContractError> {
 pub fn chain_name(deps: Deps) -> Result<ChainNameResponse, ContractError> {
     Ok(ChainNameResponse {
         chain_name: CURR_CHAIN.may_load(deps.storage)?.unwrap_or_default(),
+    })
+}
+
+pub fn get_env(deps: Deps, variable: String) -> Result<EnvResponse, ContractError> {
+    Ok(EnvResponse {
+        value: ENV_VARIABLES.may_load(deps.storage, &variable)?,
     })
 }

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -72,6 +72,6 @@ pub fn chain_name(deps: Deps) -> Result<ChainNameResponse, ContractError> {
 
 pub fn get_env(deps: Deps, variable: String) -> Result<EnvResponse, ContractError> {
     Ok(EnvResponse {
-        value: ENV_VARIABLES.may_load(deps.storage, &variable)?,
+        value: ENV_VARIABLES.may_load(deps.storage, &variable.to_ascii_uppercase())?,
     })
 }

--- a/contracts/os/andromeda-kernel/src/state.rs
+++ b/contracts/os/andromeda-kernel/src/state.rs
@@ -19,7 +19,7 @@ pub struct OutgoingPacket {
 }
 
 pub const KERNEL_ADDRESSES: Map<&str, Addr> = Map::new("kernel_addresses");
-pub const _ENV_VARIABLES: Map<&str, String> = Map::new("kernel_env_variables");
+pub const ENV_VARIABLES: Map<&str, String> = Map::new("kernel_env_variables");
 pub const CURR_CHAIN: Item<String> = Item::new("kernel_curr_chain");
 
 //Temporary storage for creating a new ADO to assign a new owner

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -441,7 +441,9 @@ fn test_set_unset_env(
         }
 
         // Check if the variable is set
-        let stored_value = ENV_VARIABLES.load(&deps.storage, variable).unwrap();
+        let stored_value = ENV_VARIABLES
+            .load(&deps.storage, &variable.to_ascii_uppercase())
+            .unwrap();
         assert_eq!(stored_value, value);
     }
 
@@ -458,6 +460,8 @@ fn test_set_unset_env(
     }
 
     // Check if the variable is unset
-    let stored_value = ENV_VARIABLES.may_load(&deps.storage, variable).unwrap();
+    let stored_value = ENV_VARIABLES
+        .may_load(&deps.storage, &variable.to_ascii_uppercase())
+        .unwrap();
     assert!(stored_value.is_none());
 }

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -167,10 +167,12 @@ pub fn register_user(
     );
     let username = username.to_lowercase();
     let kernel = &ADOContract::default().get_kernel_address(env.deps.storage)?;
-    let curr_chain = AOSQuerier::get_current_chain(&env.deps.querier, kernel)?;
+    let is_registration_enabled =
+        AOSQuerier::get_env_variable::<bool>(&env.deps.querier, kernel, "username_registration")?
+            .unwrap_or(false);
     // Can only register username directly on Andromeda chain
     ensure!(
-        curr_chain == "andromeda" || env.info.sender == kernel,
+        is_registration_enabled || env.info.sender == kernel,
         ContractError::Unauthorized {}
     );
     // If address is provided sender must be Kernel

--- a/ibc-tests/Cargo.toml
+++ b/ibc-tests/Cargo.toml
@@ -16,7 +16,7 @@ serde.workspace = true
 tokio = "1.42.0"
 cw-orch = { workspace = true }
 cw-orch-daemon = "0.24.2"
-rstest = "0.23.0"
+rstest = { workspace = true }
 
 andromeda-testing-e2e = { workspace = true }
 
@@ -52,4 +52,3 @@ andromeda-non-fungible-tokens = { workspace = true }
 cosmwasm-std = { workspace = true, features = ["staking"] }
 cw20.workspace = true
 cw721.workspace = true
-

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -752,6 +752,12 @@ pub enum ContractError {
 
     #[error("Invalid tier for {operation} operation: {msg} ")]
     InvalidTier { operation: String, msg: String },
+
+    #[error("Environment variable not found: {variable}")]
+    EnvironmentVariableNotFound { variable: String },
+
+    #[error("Invalid environment variable length: {msg}")]
+    InvalidEnvironmentVariable { msg: String },
 }
 
 impl ContractError {

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -322,4 +322,14 @@ impl AOSQuerier {
         };
         Ok((new_denom_trace.get_ibc_denom(), new_denom_trace))
     }
+
+    pub fn get_env_variable(
+        querier: &QuerierWrapper,
+        kernel_addr: &Addr,
+        variable: &str,
+    ) -> Result<Option<String>, ContractError> {
+        let key = AOSQuerier::get_map_storage_key("kernel_env_variables", &[variable.as_bytes()])?;
+        let verify: Option<String> = AOSQuerier::query_storage(querier, kernel_addr, &key)?;
+        Ok(verify)
+    }
 }

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -323,13 +323,13 @@ impl AOSQuerier {
         Ok((new_denom_trace.get_ibc_denom(), new_denom_trace))
     }
 
-    pub fn get_env_variable(
+    pub fn get_env_variable<T: DeserializeOwned>(
         querier: &QuerierWrapper,
         kernel_addr: &Addr,
         variable: &str,
-    ) -> Result<Option<String>, ContractError> {
+    ) -> Result<Option<T>, ContractError> {
         let key = AOSQuerier::get_map_storage_key("kernel_env_variables", &[variable.as_bytes()])?;
-        let verify: Option<String> = AOSQuerier::query_storage(querier, kernel_addr, &key)?;
+        let verify: Option<T> = AOSQuerier::query_storage(querier, kernel_addr, &key)?;
         Ok(verify)
     }
 }

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -73,10 +73,15 @@ pub enum ExecuteMsg {
     UpdateChainName {
         chain_name: String,
     },
+    /// Sets an environment variable with the given name and value.
+    /// The variable name must be uppercase and can only contain letters, numbers, and underscores.
+    /// The value must be a valid UTF-8 string.
     SetEnv {
         variable: String,
         value: String,
     },
+    /// Removes an environment variable with the given name.
+    /// Returns success even if the variable doesn't exist.
     UnsetEnv {
         variable: String,
     },

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -73,6 +73,13 @@ pub enum ExecuteMsg {
     UpdateChainName {
         chain_name: String,
     },
+    SetEnv {
+        variable: String,
+        value: String,
+    },
+    UnsetEnv {
+        variable: String,
+    },
     // Only accessible to key contracts
     Internal(InternalMsg),
     // Base message

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -110,6 +110,11 @@ pub struct ChainNameResponse {
 }
 
 #[cw_serde]
+pub struct EnvResponse {
+    pub value: Option<String>,
+}
+
+#[cw_serde]
 #[cfg_attr(not(target_arch = "wasm32"), derive(cw_orch::QueryFns))]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -133,6 +138,8 @@ pub enum QueryMsg {
     AdoType {},
     #[returns(crate::ado_base::ownership::ContractOwnerResponse)]
     Owner {},
+    #[returns(EnvResponse)]
+    GetEnv { variable: String },
 }
 
 #[cw_serde]

--- a/packages/std/src/testing/mock_querier.rs
+++ b/packages/std/src/testing/mock_querier.rs
@@ -504,6 +504,22 @@ impl MockAndromedaQuerier {
                 "andromeda".to_string()
             };
             SystemResult::Ok(ContractResult::Ok(to_json_binary(&res).unwrap()))
+        } else if key_str.contains("kernel_env_variables") {
+            let split = key_str.split("kernel_env_variables");
+            let key = split.last();
+            if let Some(key) = key {
+                match key {
+                    "username_registration" => {
+                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&!fake).unwrap()))
+                    }
+                    "andromeda_distribution" => {
+                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&!fake).unwrap()))
+                    }
+                    _ => panic!("Invalid Kernel Address Key"),
+                }
+            } else {
+                panic!("Invalid Kernel Address Raw Query")
+            }
         } else if key_str.contains("channel") {
             SystemResult::Ok(ContractResult::Ok(
                 to_json_binary(&ChannelInfo {

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -165,7 +165,7 @@ name = "validator_staking"
 name = "shunting"
 
 [dependencies]
-rstest = "0.23.0"
+rstest = { workspace = true }
 
 # [[test]]
 # name = "cw20_staking_app"


### PR DESCRIPTION
# Motivation

These changes add environment variables to the Kernel. These have been employed in certain scenarios that toggling via an environment variable makes sense.

# Implementation

Added the following execute messages to the Kernel contract:
- `SetEnv`
- `UnsetEnv`

Added the following query messages to the Kernel contract:
- `GetEnv`

# Testing

Unit tests were added for the new execute messages and affected cases were updated accordingly.

# Version Changes

`andromeda-kernel`: `1.2.0-b.1` -> `1.2.0-b.2`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for setting and unsetting environment variables via new commands.
	- Introduced functionality to manage environment variables within the contract.
	- Enhanced user registration logic based on environment variable settings.
	- Added new error variants for better handling of environment variable issues.
	- Introduced a new method for querying environment variables.
	- Added a new testing function to validate environment variable operations.

- **Bug Fixes**
	- Improved error handling for environment variable operations.

- **Documentation**
	- Updated changelog to reflect new features and enhancements.

- **Chores**
	- Updated dependency management for the testing framework across multiple modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->