### PR TITLE
ref: remove recipient now uses AndrAddr instead Recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rates: Limit rates recipient to only one address [(#669)](https://github.com/andromedaprotocol/andromeda-core/pull/669)
 - Address Validation: Cross-chain recipients don't need to be registered in VFS [(#725)](https://github.com/andromedaprotocol/andromeda-core/pull/725)
+- Weighted Splitter: Replace Recipient with AndrAddr in RemoveRecipient and GetUserWeight [(#739)](https://github.com/andromedaprotocol/andromeda-core/pull/739)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0-beta"
+version = "2.1.0-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0-beta"
+version = "2.1.0-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -1,3 +1,4 @@
+use andromeda_std::amp::AndrAddr;
 use andromeda_std::common::expiration::Expiry;
 use andromeda_std::common::Milliseconds;
 use andromeda_std::testing::mock_querier::{mock_dependencies_custom, MOCK_KERNEL_CONTRACT};
@@ -430,7 +431,7 @@ fn test_execute_remove_recipient() {
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
     let msg = ExecuteMsg::RemoveRecipient {
-        recipient: Recipient::from_string(String::from("addr1")),
+        recipient: AndrAddr::from_string("addr1"),
     };
     // Try removing a user that isn't in the list
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
@@ -525,7 +526,7 @@ fn test_execute_remove_recipient_not_on_list() {
 
     // Try removing a user that isn't in the list
     let msg = ExecuteMsg::RemoveRecipient {
-        recipient: Recipient::from_string(String::from("addr10")),
+        recipient: AndrAddr::from_string("addr10"),
     };
 
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
@@ -596,7 +597,7 @@ fn test_execute_remove_recipient_contract_locked() {
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
 
     let msg = ExecuteMsg::RemoveRecipient {
-        recipient: Recipient::from_string(String::from("addr1")),
+        recipient: AndrAddr::from_string("addr1"),
     };
 
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -1,5 +1,5 @@
 use andromeda_std::{
-    amp::recipient::Recipient,
+    amp::{recipient::Recipient, AndrAddr},
     andr_exec, andr_instantiate, andr_query,
     common::{expiration::Expiry, MillisecondsExpiration},
 };
@@ -45,7 +45,7 @@ pub enum ExecuteMsg {
     /// Add a single recipient to the recipient list. Only executable by the contract owner when the contract is not locked.
     AddRecipient { recipient: AddressWeight },
     /// Remove a single recipient from the recipient list. Only executable by the contract owner when the contract is not locked.
-    RemoveRecipient { recipient: Recipient },
+    RemoveRecipient { recipient: AndrAddr },
     /// Used to lock/unlock the contract allowing the config to be updated.
     UpdateLock { lock_time: Expiry },
     /// Divides any attached funds to the message amongst the recipients list.

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -61,7 +61,7 @@ pub enum QueryMsg {
     GetSplitterConfig {},
     /// Gets user's allocated weight
     #[returns(GetUserWeightResponse)]
-    GetUserWeight { user: Recipient },
+    GetUserWeight { user: AndrAddr },
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation
`RemoveRecipient` and `GetUserWeight` were taking `Recipient` as input but this has been replaced with `AndrAddr`. 

# Implementation
Replace `Recipient` with `AndrAddr`

# Testing
Minor adjustments

# Version Changes
`andromeda-weighted-splitter`: `2.1.0-beta` -> `2.1.0-b.2`

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated package version for `andromeda-weighted-distribution-splitter`.
	- Enhanced handling of recipient addresses with the introduction of `AndrAddr`.
	- Added optional configuration for Send in Splitter contracts and CW20 support.

- **Bug Fixes**
	- Improved error handling for removing non-existent recipients.

- **Tests**
	- Added new tests for adding recipients and managing recipient weights.
	- Updated existing tests to reflect changes in recipient address handling.

- **Changelog Updates**
	- Notable changes documented, including updates to the Weighted Splitter functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->