### PR TITLE
feat: added a query for pending packets to kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Schema and Form ADOs [(#591)](https://github.com/andromedaprotocol/andromeda-core/pull/591)
 - Flat Rate denom can be a VFS path [(#727)](https://github.com/andromedaprotocol/andromeda-core/pull/727)
 - Auction ADO: Added buy_now_price option in Update Auction [(#730)](https://github.com/andromedaprotocol/andromeda-core/pull/730)
+- feat: added a query for pending packets to kernel [(#740)](https://github.com/andromedaprotocol/andromeda-core/pull/740)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,21 +4212,21 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.0-b.1"
+version = "1.2.0-b.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "osmosis-std",
  "osmosis-std-derive 0.15.3",
  "prost 0.11.9",
+ "rstest",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.0-b.2"
+version = "1.2.0-b.3"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,4 +69,4 @@ test-case = { version = "3.3.1" }
 cw-orch = "=0.24.1"
 jsonschema-valid = { version = "0.5.2" }
 serde_json = { version = "1.0.134" }
-rstest = "0.23.0"
+rstest = "0.24.0"

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.0-b.2"
+version = "1.2.0-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -46,4 +46,5 @@ cw-multi-test = { workspace = true, optional = true }
 cw-orch = { workspace = true }
 
 [dev-dependencies]
+rstest = "0.23.0"
 # andromeda-testing = { workspace = true, optional = true }

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.0-b.1"
+version = "1.2.0-b.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -46,6 +46,5 @@ cw-multi-test = { workspace = true, optional = true }
 cw-orch = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.23.0"
 # andromeda-testing = { workspace = true, optional = true }
 rstest = { workspace = true }

--- a/contracts/os/andromeda-kernel/src/contract.rs
+++ b/contracts/os/andromeda-kernel/src/contract.rs
@@ -175,5 +175,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::ChainNameByChannel { channel } => {
             encode_binary(&query::chain_name_by_channel(deps, channel)?)
         }
+        QueryMsg::PendingPackets { channel_id } => {
+            encode_binary(&query::pending_packets(deps, channel_id)?)
+        }
     }
 }

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -3,13 +3,14 @@ use andromeda_std::{
     error::ContractError,
     os::{
         aos_querier::AOSQuerier,
-        kernel::{ChainNameResponse, ChannelInfoResponse, VerifyAddressResponse},
+        kernel::{ChainNameResponse, ChannelInfoResponse, Ics20PacketInfo, VerifyAddressResponse},
     },
 };
-use cosmwasm_std::{Addr, Coin, Deps};
+use cosmwasm_std::{Addr, Coin, Deps, Order};
 
 use crate::state::{
-    CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CURR_CHAIN, IBC_FUND_RECOVERY, KERNEL_ADDRESSES,
+    CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CHANNEL_TO_EXECUTE_MSG, CURR_CHAIN, IBC_FUND_RECOVERY,
+    KERNEL_ADDRESSES,
 };
 
 pub fn key_address(deps: Deps, key: String) -> Result<Addr, ContractError> {
@@ -67,4 +68,25 @@ pub fn chain_name(deps: Deps) -> Result<ChainNameResponse, ContractError> {
     Ok(ChainNameResponse {
         chain_name: CURR_CHAIN.may_load(deps.storage)?.unwrap_or_default(),
     })
+}
+
+pub fn pending_packets(
+    deps: Deps,
+    channel_id: Option<String>,
+) -> Result<Vec<Ics20PacketInfo>, ContractError> {
+    let packets: Vec<Ics20PacketInfo> = if let Some(channel_id) = channel_id {
+        CHANNEL_TO_EXECUTE_MSG
+            .prefix(channel_id)
+            .range(deps.storage, None, None, Order::Ascending)
+            .filter_map(|item| item.ok())
+            .map(|(_, packet)| packet)
+            .collect()
+    } else {
+        CHANNEL_TO_EXECUTE_MSG
+            .range(deps.storage, None, None, Order::Ascending)
+            .filter_map(|item| item.ok())
+            .map(|(_, packet)| packet)
+            .collect()
+    };
+    Ok(packets)
 }

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -3,14 +3,17 @@ use andromeda_std::{
     error::ContractError,
     os::{
         aos_querier::AOSQuerier,
-        kernel::{ChainNameResponse, ChannelInfoResponse, Ics20PacketInfo, VerifyAddressResponse},
+        kernel::{
+            ChainNameResponse, ChannelInfoResponse, EnvResponse, Ics20PacketInfo,
+            VerifyAddressResponse,
+        },
     },
 };
 use cosmwasm_std::{Addr, Coin, Deps, Order};
 
 use crate::state::{
-    CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CHANNEL_TO_EXECUTE_MSG, CURR_CHAIN, IBC_FUND_RECOVERY,
-    KERNEL_ADDRESSES,
+    CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CHANNEL_TO_EXECUTE_MSG, CURR_CHAIN, ENV_VARIABLES,
+    IBC_FUND_RECOVERY, KERNEL_ADDRESSES,
 };
 
 pub fn key_address(deps: Deps, key: String) -> Result<Addr, ContractError> {

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -2,7 +2,8 @@ use crate::{
     contract::{execute, instantiate, query},
     ibc::PACKET_LIFETIME,
     state::{
-        ADO_OWNER, CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CURR_CHAIN, ENV_VARIABLES, KERNEL_ADDRESSES,
+        ADO_OWNER, CHAIN_TO_CHANNEL, CHANNEL_TO_CHAIN, CHANNEL_TO_EXECUTE_MSG, CURR_CHAIN,
+        ENV_VARIABLES, KERNEL_ADDRESSES,
     },
 };
 use andromeda_std::{

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -14,7 +14,7 @@ use andromeda_std::{
     error::ContractError,
     os::kernel::{
         ChannelInfo, ExecuteMsg, IbcExecuteMsg, Ics20PacketInfo, InstantiateMsg, InternalMsg,
-        QueryMsg,
+        PendingPacketResponse, QueryMsg,
     },
     testing::mock_querier::{
         mock_dependencies_custom, MOCK_ADODB_CONTRACT, MOCK_FAKE_KERNEL_CONTRACT,
@@ -591,13 +591,13 @@ fn test_query_pending_packets(
     )
     .unwrap();
 
-    let pending_packets: Vec<Ics20PacketInfo> = from_json(&res).unwrap();
-    assert_eq!(pending_packets.len(), expected_count);
+    let pending_packets: PendingPacketResponse = from_json(&res).unwrap();
+    assert_eq!(pending_packets.packets.len(), expected_count);
 
     // Verify packets are from the correct channel if channel_id is specified
     if let Some(channel) = channel_id {
-        for packet in pending_packets {
-            assert_eq!(packet.channel, channel);
+        for packet in pending_packets.packets {
+            assert_eq!(packet.packet_info.channel, channel);
         }
     }
 }

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -24,7 +24,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     coin, from_json,
     testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage},
-    to_json_binary, Addr, Binary, CosmosMsg, Env, IbcMsg, OwnedDeps, Uint128,
+    to_json_binary, Addr, Binary, CosmosMsg, Env, IbcMsg, OwnedDeps,
 };
 use rstest::*;
 

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -119,6 +119,7 @@ pub struct PendingPacketResponse {
     pub packets: Vec<Ics20PacketInfo>,
 }
 
+#[cw_serde]
 pub struct EnvResponse {
     pub value: Option<String>,
 }

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -116,7 +116,13 @@ pub struct ChainNameResponse {
 
 #[cw_serde]
 pub struct PendingPacketResponse {
-    pub packets: Vec<Ics20PacketInfo>,
+    pub packets: Vec<PacketInfoAndSequence>,
+}
+
+#[cw_serde]
+pub struct PacketInfoAndSequence {
+    pub packet_info: Ics20PacketInfo,
+    pub sequence: u64,
 }
 
 #[cw_serde]

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -103,6 +103,11 @@ pub struct ChainNameResponse {
 }
 
 #[cw_serde]
+pub struct PendingPacketResponse {
+    pub packets: Vec<Ics20PacketInfo>,
+}
+
+#[cw_serde]
 #[cfg_attr(not(target_arch = "wasm32"), derive(cw_orch::QueryFns))]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -126,6 +131,8 @@ pub enum QueryMsg {
     AdoType {},
     #[returns(crate::ado_base::ownership::ContractOwnerResponse)]
     Owner {},
+    #[returns(PendingPacketResponse)]
+    PendingPackets { channel_id: Option<String> },
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation

These changes add a query to the kernel for any pending IBC packets.

# Implementation

- Added a new `PendingPackets` query to Kernel

# Testing

Added unit tests for the new query

# Version Changes

`kernel`: `1.2.0-b.1` -> `1.2.0-b.2`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for querying pending IBC packets in the kernel.
  - Introduced support for CW20 in Splitter contracts and optional configuration for Send in Splitter contracts.
  - Added new ADOs including Matrix ADO and Distance ADO.

- **Changes**
  - Updated address validation and recipient handling for cross-chain interactions.
  - Limited rate recipients to a single address.

- **Bug Fixes**
  - Improved kernel handling for IBC and fixed issues with local amp messages.

- **Dependency Updates**
  - Upgraded `rstest` testing dependency to version 0.24.0.

- **Package Version**
  - Updated `andromeda-kernel` package version from "1.2.0-b.2" to "1.2.0-b.3".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->