### PR TITLE
fix: Change SubDir's Return Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: alterations to kernel for IBC [(#726)](https://github.com/andromedaprotocol/andromeda-core/pull/726)
 - Fixed handle_local amp message when a amp message is passed with custom config [(#729)](https://github.com/andromedaprotocol/andromeda-core/pull/729)
+- Fixed wrong return attribute for SubDir Query [(#756)](https://github.com/andromedaprotocol/andromeda-core/pull/756)
 
 ## Release 3
 

--- a/contracts/os/andromeda-vfs/src/query.rs
+++ b/contracts/os/andromeda-vfs/src/query.rs
@@ -1,10 +1,9 @@
-use andromeda_std::os::vfs::{validate_path_name, SubDirBound};
+use andromeda_std::os::vfs::{validate_path_name, PathInfo, SubDirBound};
 use andromeda_std::{amp::AndrAddr, error::ContractError};
 use cosmwasm_std::{Addr, Deps};
 
 use crate::state::{
-    get_paths, get_subdir, resolve_pathname, resolve_symlink, PathInfo, ADDRESS_LIBRARY,
-    ADDRESS_USERNAME,
+    get_paths, get_subdir, resolve_pathname, resolve_symlink, ADDRESS_LIBRARY, ADDRESS_USERNAME,
 };
 
 pub fn resolve_path(deps: Deps, path: AndrAddr) -> Result<Addr, ContractError> {

--- a/contracts/os/andromeda-vfs/src/state.rs
+++ b/contracts/os/andromeda-vfs/src/state.rs
@@ -1,19 +1,10 @@
 use andromeda_std::{
     amp::AndrAddr,
     error::ContractError,
-    os::vfs::{validate_path_name, SubDirBound},
+    os::vfs::{validate_path_name, PathInfo, SubDirBound},
 };
 use cosmwasm_std::{ensure, Addr, Api, Storage};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Map, MultiIndex};
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-pub struct PathInfo {
-    pub name: String,
-    pub address: Addr,
-    pub parent_address: Addr,
-    pub symlink: Option<AndrAddr>,
-}
 
 pub struct PathIndices<'a> {
     /// PK: parent_address + component_name

--- a/contracts/os/andromeda-vfs/src/testing/tests.rs
+++ b/contracts/os/andromeda-vfs/src/testing/tests.rs
@@ -1,13 +1,13 @@
 use crate::{
     contract::{execute, instantiate, query},
-    state::{add_pathname, resolve_pathname, PathInfo, ADDRESS_LIBRARY, ADDRESS_USERNAME, USERS},
+    state::{add_pathname, resolve_pathname, ADDRESS_LIBRARY, ADDRESS_USERNAME, USERS},
 };
 
 use andromeda_std::{
     amp::AndrAddr,
     os::{
         kernel::{ExecuteMsg as KernelExecuteMsg, InternalMsg},
-        vfs::{ExecuteMsg, InstantiateMsg},
+        vfs::{ExecuteMsg, InstantiateMsg, PathInfo},
     },
     testing::mock_querier::{
         mock_dependencies_custom, MOCK_APP_CONTRACT, MOCK_FAKE_KERNEL_CONTRACT,

--- a/packages/std/src/os/vfs.rs
+++ b/packages/std/src/os/vfs.rs
@@ -199,11 +199,19 @@ impl From<SubDirBound> for (Addr, String) {
 }
 
 #[cw_serde]
+pub struct PathInfo {
+    pub name: String,
+    pub address: Addr,
+    pub parent_address: Addr,
+    pub symlink: Option<AndrAddr>,
+}
+
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(Addr)]
     ResolvePath { path: AndrAddr },
-    #[returns(Vec<PathDetails>)]
+    #[returns(Vec<PathInfo>)]
     SubDir {
         path: AndrAddr,
         min: Option<SubDirBound>,


### PR DESCRIPTION
# Motivation
SubDir had the wrong attribute. `PathDetails` instead of `PathInfo`

# Implementation
Moved `PathInfo`'s definition to packages to avoid circular dependency.
Replaced `#[returns(Vec<PathDetails>)]` with `#[returns(Vec<PathInfo>)]`

# Testing
None

# Version Changes
None

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced path information structure with new `PathInfo` struct.
  - Improved subdirectory query to return more comprehensive path details.

- **Bug Fixes**
  - Corrected return attribute for the SubDir Query to improve accuracy.

- **Refactor**
  - Reorganized import statements for `PathInfo` across multiple modules.
  - Updated function signatures to utilize new `PathInfo` struct.

- **Documentation**
  - Updated changelog to reflect recent changes and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->