### PR TITLE
Splitter config lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: alterations to kernel for IBC [(#726)](https://github.com/andromedaprotocol/andromeda-core/pull/726)
 - Fixed handle_local amp message when a amp message is passed with custom config [(#729)](https://github.com/andromedaprotocol/andromeda-core/pull/729)
+- fix: Bypass splitter lock using config [(#757)](https://github.com/andromedaprotocol/andromeda-core/pull/757)
 
 ## Release 3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.0-b.1"
+version = "1.2.0-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.3.0-b.2"
+version = "2.3.0-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0-b.2"
+version = "2.1.0-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "cw20",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
+ "rstest",
  "schemars",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20",
+ "rstest",
 ]
 
 [[package]]
@@ -883,6 +884,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20",
+ "rstest",
 ]
 
 [[package]]
@@ -1070,6 +1072,7 @@ dependencies = [
  "cw-orch",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
+ "rstest",
 ]
 
 [[package]]

--- a/contracts/finance/andromeda-conditional-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/contract.rs
@@ -197,8 +197,8 @@ fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
             amount: remainder_funds,
         })));
     }
-    let kernel_address = ADOContract::default().get_kernel_address(deps.as_ref().storage)?;
     if !pkt.messages.is_empty() {
+        let kernel_address = ADOContract::default().get_kernel_address(deps.as_ref().storage)?;
         let distro_msg = pkt.to_sub_msg(kernel_address, Some(amp_funds), 1)?;
         msgs.push(distro_msg);
     }

--- a/contracts/finance/andromeda-conditional-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/contract.rs
@@ -229,7 +229,7 @@ fn execute_update_thresholds(
     // Can't call this function while the lock isn't expired
     ensure!(
         conditional_splitter.lock_time.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     let updated_conditional_splitter = ConditionalSplitter {
@@ -261,7 +261,7 @@ fn execute_update_lock(ctx: ExecuteContext, lock_time: Expiry) -> Result<Respons
     // Can't call this function while the lock isn't expired
     ensure!(
         conditional_splitter.lock_time.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     let new_lock_time_expiration = lock_time.get_time(&env.block);

--- a/contracts/finance/andromeda-conditional-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/testing/tests.rs
@@ -220,7 +220,7 @@ fn test_execute_update_lock() {
     };
     let info = mock_info(OWNER, &[]);
     let err = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
-    assert_eq!(err, ContractError::ContractLocked {});
+    assert_eq!(err, ContractError::ContractLocked { msg: None });
 }
 
 #[test]

--- a/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.0-b.1"
+version = "1.2.0-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
@@ -32,3 +32,4 @@ cw-orch = { workspace = true }
 
 [dev-dependencies]
 andromeda-app = { workspace = true }
+rstest = { workspace = true }

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
@@ -164,6 +164,12 @@ fn execute_send_cw20(
     let splitter = SPLITTER.load(deps.storage)?;
 
     let splitter_recipients = if let Some(config) = config {
+        ensure!(
+            splitter.lock.is_expired(&ctx.env.block),
+            ContractError::ContractLocked {
+                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+            }
+        );
         validate_recipient_list(deps.as_ref(), config.clone())?;
         config
     } else {

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
@@ -241,7 +241,7 @@ fn execute_update_default_recipient(
     // Can't call this function while the lock isn't expired
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     if let Some(ref recipient) = recipient {
@@ -294,6 +294,12 @@ fn execute_send(
     }
     let splitter = SPLITTER.load(deps.storage)?;
     let splitter_recipients = if let Some(config) = config {
+        ensure!(
+            splitter.lock.is_expired(&ctx.env.block),
+            ContractError::ContractLocked {
+                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+            }
+        );
         validate_recipient_list(deps.as_ref(), config.clone())?;
         config
     } else {
@@ -384,7 +390,7 @@ fn execute_update_recipients(
 
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
     // Max 100 recipients
     ensure!(
@@ -415,7 +421,7 @@ fn execute_update_lock(ctx: ExecuteContext, lock_time: Expiry) -> Result<Respons
     // Can't call this function while the lock isn't expired
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     let new_expiration = validate_expiry_duration(&lock_time, &env.block)?;

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
@@ -167,7 +167,7 @@ fn execute_send_cw20(
         ensure!(
             splitter.lock.is_expired(&ctx.env.block),
             ContractError::ContractLocked {
-                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+                msg: Some("Config isn't allowed while the splitter is locked".to_string())
             }
         );
         validate_recipient_list(deps.as_ref(), config.clone())?;
@@ -303,7 +303,7 @@ fn execute_send(
         ensure!(
             splitter.lock.is_expired(&ctx.env.block),
             ContractError::ContractLocked {
-                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+                msg: Some("Config isn't allowed while the splitter is locked".to_string())
             }
         );
         validate_recipient_list(deps.as_ref(), config.clone())?;

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/testing/tests.rs
@@ -559,3 +559,121 @@ fn test_update_app_contract_invalid_recipient() {
     // );
     assert!(res.is_err())
 }
+
+use rstest::*;
+
+#[fixture]
+fn locked_splitter() -> (DepsMut<'static>, Splitter) {
+    let deps = Box::leak(Box::new(mock_dependencies_custom(&[])));
+    let lock_time = mock_env().block.time.plus_seconds(86400);
+    let splitter = Splitter {
+        recipients: vec![
+            AddressAmount {
+                recipient: Recipient::from_string("addr1".to_string()),
+                coins: coins(40_u128, "uluna"),
+            },
+            AddressAmount {
+                recipient: Recipient::from_string("addr2".to_string()),
+                coins: coins(60_u128, "uluna"),
+            },
+        ],
+        lock: Milliseconds::from_seconds(lock_time.seconds()),
+        default_recipient: None,
+    };
+    SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    (deps.as_mut(), splitter)
+}
+
+#[fixture]
+fn unlocked_splitter() -> (DepsMut<'static>, Splitter) {
+    let deps = Box::leak(Box::new(mock_dependencies_custom(&[])));
+    let splitter = Splitter {
+        recipients: vec![
+            AddressAmount {
+                recipient: Recipient::from_string("addr1".to_string()),
+                coins: coins(40_u128, "uluna"),
+            },
+            AddressAmount {
+                recipient: Recipient::from_string("addr2".to_string()),
+                coins: coins(60_u128, "uluna"),
+            },
+        ],
+        lock: Milliseconds::default(),
+        default_recipient: None,
+    };
+    SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    (deps.as_mut(), splitter)
+}
+
+#[rstest]
+fn test_send_with_config_locked(locked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = locked_splitter;
+
+    let config = vec![AddressAmount {
+        recipient: Recipient::from_string("new_addr".to_string()),
+        coins: coins(100_u128, "uluna"),
+    }];
+
+    let msg = ExecuteMsg::Send {
+        config: Some(config),
+    };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::ContractLocked {
+            msg: Some("Config isn't allowed while the splitter is locked".to_string())
+        },
+        res.unwrap_err()
+    );
+}
+
+#[rstest]
+fn test_send_with_config_unlocked(unlocked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = unlocked_splitter;
+
+    let config = vec![AddressAmount {
+        recipient: Recipient::from_string("new_addr".to_string()),
+        coins: coins(100_u128, "uluna"),
+    }];
+
+    let msg = ExecuteMsg::Send {
+        config: Some(config),
+    };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages and refund
+    assert_eq!(3, res.messages.len()); // 1 for refund, 1 for transfer, 1 for economics
+    assert!(res.attributes.contains(&attr("action", "send")));
+}
+
+#[rstest]
+fn test_send_without_config_locked(locked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = locked_splitter;
+
+    let msg = ExecuteMsg::Send { config: None };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages and refund
+    assert_eq!(3, res.messages.len()); // 1 for refund, 1 for transfers, 1 for economics
+    assert!(res.attributes.contains(&attr("action", "send")));
+}
+
+#[rstest]
+fn test_send_without_config_unlocked(unlocked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = unlocked_splitter;
+
+    let msg = ExecuteMsg::Send { config: None };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages and refund
+    assert_eq!(3, res.messages.len()); // 1 for refund, 1 for transfers, 1 for economics
+    assert!(res.attributes.contains(&attr("action", "send")));
+}

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -32,3 +32,4 @@ andromeda-testing = { workspace = true, optional = true }
 
 [dev-dependencies]
 andromeda-app = { workspace = true }
+rstest = { workspace = true }

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.3.0-b.2"
+version = "2.3.0-b.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -254,6 +254,12 @@ fn execute_send_cw20(
     let splitter = SPLITTER.load(deps.storage)?;
 
     let splitter_recipients = if let Some(config) = config {
+        ensure!(
+            splitter.lock.is_expired(&ctx.env.block),
+            ContractError::ContractLocked {
+                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+            }
+        );
         validate_recipient_list(deps.as_ref(), config.clone())?;
         config
     } else {
@@ -329,7 +335,7 @@ fn execute_update_recipients(
 
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
     // Max 100 recipients
     ensure!(
@@ -360,7 +366,7 @@ fn execute_update_lock(ctx: ExecuteContext, lock_time: Expiry) -> Result<Respons
     // Can't call this function while the lock isn't expired
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     let new_lock_time_expiration = validate_expiry_duration(&lock_time, &env.block)?;
@@ -395,7 +401,7 @@ fn execute_update_default_recipient(
     // Can't call this function while the lock isn't expired
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     if let Some(ref recipient) = recipient {

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -257,7 +257,7 @@ fn execute_send_cw20(
         ensure!(
             splitter.lock.is_expired(&ctx.env.block),
             ContractError::ContractLocked {
-                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+                msg: Some("Config isn't allowed while the splitter is locked".to_string())
             }
         );
         validate_recipient_list(deps.as_ref(), config.clone())?;

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -176,6 +176,12 @@ fn execute_send(
     let splitter = SPLITTER.load(deps.storage)?;
 
     let splitter_recipients = if let Some(config) = config {
+        ensure!(
+            splitter.lock.is_expired(&ctx.env.block),
+            ContractError::ContractLocked {
+                msg: Some("Config isn't allowed while the splitter is locked".to_string())
+            }
+        );
         validate_recipient_list(deps.as_ref(), config.clone())?;
         config
     } else {

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -682,3 +682,119 @@ fn test_update_app_contract_invalid_recipient() {
     // );
     assert!(res.is_err())
 }
+
+use rstest::*;
+
+#[fixture]
+fn locked_splitter() -> (DepsMut<'static>, Splitter) {
+    let deps = Box::leak(Box::new(mock_dependencies_custom(&[])));
+    let lock_time = mock_env().block.time.plus_seconds(86400);
+    let splitter = Splitter {
+        recipients: vec![
+            AddressPercent {
+                recipient: Recipient::from_string("addr1".to_string()),
+                percent: Decimal::percent(40),
+            },
+            AddressPercent {
+                recipient: Recipient::from_string("addr2".to_string()),
+                percent: Decimal::percent(60),
+            },
+        ],
+        lock: Milliseconds::from_seconds(lock_time.seconds()),
+        default_recipient: None,
+    };
+    SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    (deps.as_mut(), splitter)
+}
+
+#[fixture]
+fn unlocked_splitter() -> (DepsMut<'static>, Splitter) {
+    let deps = Box::leak(Box::new(mock_dependencies_custom(&[])));
+    let splitter = Splitter {
+        recipients: vec![
+            AddressPercent {
+                recipient: Recipient::from_string("addr1".to_string()),
+                percent: Decimal::percent(40),
+            },
+            AddressPercent {
+                recipient: Recipient::from_string("addr2".to_string()),
+                percent: Decimal::percent(60),
+            },
+        ],
+        lock: Milliseconds::default(),
+        default_recipient: None,
+    };
+    SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    (deps.as_mut(), splitter)
+}
+
+#[rstest]
+fn test_send_with_config_locked(locked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = locked_splitter;
+
+    let config = vec![AddressPercent {
+        recipient: Recipient::from_string("new_addr".to_string()),
+        percent: Decimal::percent(100),
+    }];
+
+    let msg = ExecuteMsg::Send {
+        config: Some(config),
+    };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::ContractLocked {
+            msg: Some("Config isn't allowed while the splitter is locked".to_string())
+        },
+        res.unwrap_err()
+    );
+}
+
+#[rstest]
+fn test_send_with_config_unlocked(unlocked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = unlocked_splitter;
+
+    let config = vec![AddressPercent {
+        recipient: Recipient::from_string("new_addr".to_string()),
+        percent: Decimal::percent(100),
+    }];
+
+    let msg = ExecuteMsg::Send {
+        config: Some(config),
+    };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages
+    assert_eq!(2, res.messages.len());
+    assert!(res.attributes.contains(&attr("action", "send")));
+}
+
+#[rstest]
+fn test_send_without_config_locked(locked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = locked_splitter;
+
+    let msg = ExecuteMsg::Send { config: None };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages
+    assert!(res.attributes.contains(&attr("action", "send")));
+}
+
+#[rstest]
+fn test_send_without_config_unlocked(unlocked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = unlocked_splitter;
+
+    let msg = ExecuteMsg::Send { config: None };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages
+    assert!(res.attributes.contains(&attr("action", "send")));
+}

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -30,3 +30,4 @@ cw-orch = { workspace = true }
 
 [dev-dependencies]
 andromeda-app = { workspace = true }
+rstest = { workspace = true }

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0-b.2"
+version = "2.1.0-b.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -279,7 +279,7 @@ fn execute_send(
         ensure!(
             splitter.lock.is_expired(&ctx.env.block),
             ContractError::ContractLocked {
-                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+                msg: Some("Config isn't allowed while the splitter is locked".to_string())
             }
         );
         // Max 100 recipients

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/contract.rs
@@ -134,7 +134,7 @@ pub fn execute_update_recipient_weight(
 
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     // Recipients are stored in a vector, we search for the desired recipient's index in the vector
@@ -176,7 +176,7 @@ fn execute_update_default_recipient(
     // Can't call this function while the lock isn't expired
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     if let Some(ref recipient) = recipient {
@@ -222,7 +222,7 @@ pub fn execute_add_recipient(
 
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     // Can't set weight to 0
@@ -276,6 +276,12 @@ fn execute_send(
     );
     let splitter = SPLITTER.load(deps.storage)?;
     let splitter_recipients = if let Some(config) = config {
+        ensure!(
+            splitter.lock.is_expired(&ctx.env.block),
+            ContractError::ContractLocked {
+                msg: Some("Config isn't allowed if the splitter is locked".to_string())
+            }
+        );
         // Max 100 recipients
         ensure!(config.len() <= 100, ContractError::ReachedRecipientLimit {});
         config
@@ -380,7 +386,7 @@ fn execute_update_recipients(
     // Can't update recipients while lock isn't expired
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     // Maximum number of recipients is 100
@@ -418,7 +424,7 @@ fn execute_remove_recipient(
 
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     // Find and remove recipient in one pass
@@ -455,7 +461,7 @@ fn execute_update_lock(ctx: ExecuteContext, lock_time: Expiry) -> Result<Respons
 
     ensure!(
         splitter.lock.is_expired(&env.block),
-        ContractError::ContractLocked {}
+        ContractError::ContractLocked { msg: None }
     );
 
     let new_lock_time_expiration = validate_expiry_duration(&lock_time, &env.block)?;

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -327,7 +327,7 @@ fn test_execute_update_lock_already_locked() {
 
     let info = mock_info(owner, &[]);
     let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(ContractError::ContractLocked {}, res);
+    assert_eq!(ContractError::ContractLocked { msg: None }, res);
 }
 
 #[test]
@@ -601,7 +601,7 @@ fn test_execute_remove_recipient_contract_locked() {
     };
 
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::ContractLocked {});
+    assert_eq!(err, ContractError::ContractLocked { msg: None });
 }
 
 #[test]
@@ -824,7 +824,7 @@ fn test_update_recipient_weight_locked_contract() {
         },
     };
     let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(err, ContractError::ContractLocked {});
+    assert_eq!(err, ContractError::ContractLocked { msg: None });
 }
 
 #[test]
@@ -1277,7 +1277,10 @@ fn test_execute_add_recipient_locked_contract() {
 
     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
     let res = execute(deps.as_mut(), env, info, msg);
-    assert_eq!(ContractError::ContractLocked {}, res.unwrap_err());
+    assert_eq!(
+        ContractError::ContractLocked { msg: None },
+        res.unwrap_err()
+    );
 }
 
 #[test]
@@ -1492,7 +1495,7 @@ fn test_execute_update_recipients_contract_locked() {
 
     let info = mock_info(owner, &[]);
     let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
-    assert_eq!(res, ContractError::ContractLocked {});
+    assert_eq!(res, ContractError::ContractLocked { msg: None });
 }
 
 #[test]

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -1651,122 +1651,138 @@ fn test_execute_send() {
 
     assert_eq!(res, expected_res);
 }
+use rstest::*;
 
-// #[test]
-// fn test_query_splitter() {
-//     let mut deps = mock_dependencies_custom(&[]);
-//     let env = mock_env();
-//     let splitter = Splitter {
-//         recipients: vec![],
-//         lock: Milliseconds::default(),
-//     };
+#[fixture]
+fn locked_splitter() -> (DepsMut<'static>, Splitter) {
+    let deps = Box::leak(Box::new(mock_dependencies_custom(&[])));
+    let lock_time = mock_env().block.time.plus_seconds(86400);
 
-//     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    // Call instantiate with the recipients
+    let msg = InstantiateMsg {
+        recipients: vec![
+            AddressWeight {
+                recipient: Recipient::from_string("addr1".to_string()),
+                weight: Uint128::new(40), // 40% weight
+            },
+            AddressWeight {
+                recipient: Recipient::from_string("addr2".to_string()),
+                weight: Uint128::new(60), // 60% weight
+            },
+        ],
+        lock_time: Some(Expiry::AtTime(Milliseconds::from_seconds(
+            lock_time.seconds(),
+        ))),
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        owner: None,
+        default_recipient: None,
+    };
 
-//     let query_msg = QueryMsg::GetSplitterConfig {};
-//     let res = query(deps.as_ref(), env, query_msg).unwrap();
-//     let val: GetSplitterConfigResponse = from_json(&res).unwrap();
+    let info = mock_info("owner", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-//     assert_eq!(val.config, splitter);
-// }
+    let splitter = SPLITTER.load(deps.as_ref().storage).unwrap();
+    (deps.as_mut(), splitter)
+}
 
-// #[test]
-// fn test_query_user_weight() {
-//     let mut deps = mock_dependencies_custom(&[]);
-//     let env = mock_env();
-//     let user1 = AddressWeight {
-//         recipient: Recipient::Addr("first".to_string()),
-//         weight: Uint128::new(5),
-//     };
-//     let user2 = AddressWeight {
-//         recipient: Recipient::Addr("second".to_string()),
-//         weight: Uint128::new(10),
-//     };
-//     let splitter = Splitter {
-//         recipients: vec![user1, user2],
-//         lock: Milliseconds::default(),
-//     };
+#[fixture]
+fn unlocked_splitter() -> (DepsMut<'static>, Splitter) {
+    let deps = Box::leak(Box::new(mock_dependencies_custom(&[])));
 
-//     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    // Call instantiate with the recipients
+    let msg = InstantiateMsg {
+        recipients: vec![
+            AddressWeight {
+                recipient: Recipient::from_string("addr1".to_string()),
+                weight: Uint128::new(40), // 40% weight
+            },
+            AddressWeight {
+                recipient: Recipient::from_string("addr2".to_string()),
+                weight: Uint128::new(60), // 60% weight
+            },
+        ],
+        lock_time: None,
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        owner: None,
+        default_recipient: None,
+    };
 
-//     let query_msg = QueryMsg::GetUserWeight {
-//         user: Recipient::Addr("second".to_string()),
-//     };
-//     let res = query(deps.as_ref(), env, query_msg).unwrap();
-//     let val: GetUserWeightResponse = from_json(&res).unwrap();
+    let info = mock_info("owner", &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-//     assert_eq!(val.weight, Uint128::new(10));
-//     assert_eq!(val.total_weight, Uint128::new(15));
-// }
+    let splitter = SPLITTER.load(deps.as_ref().storage).unwrap();
+    (deps.as_mut(), splitter)
+}
 
-// #[test]
-// fn test_execute_send_error() {
-//     // Send more than 5 coins
-//     let mut deps = mock_dependencies_custom(&[]);
-//     let env = mock_env();
+#[rstest]
+fn test_send_with_config_locked(locked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = locked_splitter;
 
-//     let sender_funds_amount = 10000u128;
-//     let owner = "creator";
+    let config = vec![AddressWeight {
+        recipient: Recipient::from_string("new_addr".to_string()),
+        weight: Uint128::new(100), // 100% weight
+    }];
 
-//     let recip_address1 = "address1".to_string();
-//     let recip_weight1 = Uint128::new(10); // Weight of 10
+    let msg = ExecuteMsg::Send {
+        config: Some(config),
+    };
 
-//     let recip_address2 = "address2".to_string();
-//     let recip_weight2 = Uint128::new(20); // Weight of 20
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg);
 
-//     let recipient = vec![
-//         AddressWeight {
-//             recipient: Recipient::Addr(recip_address1),
-//             weight: recip_weight1,
-//         },
-//         AddressWeight {
-//             recipient: Recipient::Addr(recip_address2),
-//             weight: recip_weight2,
-//         },
-//     ];
-//     let msg = ExecuteMsg::Send {
-//         reply_gas_exit: None,
-//         packet: None,
-//     };
+    assert_eq!(
+        ContractError::ContractLocked {
+            msg: Some("Config isn't allowed while the splitter is locked".to_string())
+        },
+        res.unwrap_err()
+    );
+}
 
-//     let info = mock_info(
-//         owner,
-//         &vec![
-//             Coin::new(sender_funds_amount, "uluna"),
-//             Coin::new(sender_funds_amount, "uluna"),
-//             Coin::new(sender_funds_amount, "uluna"),
-//             Coin::new(sender_funds_amount, "uluna"),
-//             Coin::new(sender_funds_amount, "uluna"),
-//             Coin::new(sender_funds_amount, "uluna"),
-//         ],
-//     );
-//     let splitter = Splitter {
-//         recipients: recipient.clone(),
-//         lock: Milliseconds::default(),
-//     };
+#[rstest]
+fn test_send_with_config_unlocked(unlocked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = unlocked_splitter;
 
-//     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    let config = vec![AddressWeight {
+        recipient: Recipient::from_string("new_addr".to_string()),
+        weight: Uint128::new(100), // 100% weight
+    }];
 
-//     let res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap_err();
+    let msg = ExecuteMsg::Send {
+        config: Some(config),
+    };
 
-//     let expected_res = ContractError::ExceedsMaxAllowedCoins {};
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
 
-//     assert_eq!(res, expected_res);
+    // Verify response contains expected submessages and refund
+    assert_eq!(1, res.messages.len());
+    assert!(res.attributes.contains(&attr("action", "send")));
+}
 
-//     // Send 0 coins
-//     let info = mock_info(owner, &[]);
-//     let splitter = Splitter {
-//         recipients: recipient,
-//         lock: Milliseconds::default(),
-//     };
+#[rstest]
+fn test_send_without_config_locked(locked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = locked_splitter;
 
-//     SPLITTER.save(deps.as_mut().storage, &splitter).unwrap();
+    let msg = ExecuteMsg::Send { config: None };
 
-//     let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
 
-//     let expected_res = ContractError::InvalidFunds {
-//         msg: "ensure! at least one coin to be sent".to_string(),
-//     };
+    // Verify response contains expected submessages
+    assert_eq!(2, res.messages.len());
+    assert!(res.attributes.contains(&attr("action", "send")));
+}
 
-//     assert_eq!(res, expected_res);
-// }
+#[rstest]
+fn test_send_without_config_unlocked(unlocked_splitter: (DepsMut<'static>, Splitter)) {
+    let (deps, _) = unlocked_splitter;
+
+    let msg = ExecuteMsg::Send { config: None };
+
+    let info = mock_info("owner", &[Coin::new(10000, "uluna")]);
+    let res = execute(deps, mock_env(), info, msg).unwrap();
+
+    // Verify response contains expected submessages
+    assert_eq!(2, res.messages.len());
+    assert!(res.attributes.contains(&attr("action", "send")));
+}

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -4,8 +4,8 @@ use andromeda_std::amp::addresses::AndrAddr;
 use andromeda_std::amp::messages::{AMPCtx, AMPMsg, AMPPkt};
 use andromeda_std::amp::{ADO_DB_KEY, VFS_KEY};
 use andromeda_std::common::context::ExecuteContext;
+use andromeda_std::common::has_coins_merged;
 use andromeda_std::common::reply::ReplyId;
-use andromeda_std::common::{has_coins_merged, merge_coins};
 use andromeda_std::error::ContractError;
 use andromeda_std::os::aos_querier::AOSQuerier;
 #[cfg(not(target_arch = "wasm32"))]

--- a/contracts/os/andromeda-kernel/src/query.rs
+++ b/contracts/os/andromeda-kernel/src/query.rs
@@ -4,8 +4,8 @@ use andromeda_std::{
     os::{
         aos_querier::AOSQuerier,
         kernel::{
-            ChainNameResponse, ChannelInfoResponse, EnvResponse, Ics20PacketInfo,
-            PacketInfoAndSequence, PendingPacketResponse, VerifyAddressResponse,
+            ChainNameResponse, ChannelInfoResponse, EnvResponse, PacketInfoAndSequence,
+            PendingPacketResponse, VerifyAddressResponse,
         },
     },
 };

--- a/packages/andromeda-finance/Cargo.toml
+++ b/packages/andromeda-finance/Cargo.toml
@@ -28,3 +28,6 @@ andromeda-std = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-orch = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -43,8 +43,8 @@ pub enum ContractError {
     #[error("UnpublishedVersion")]
     UnpublishedVersion {},
 
-    #[error("ContractLocked")]
-    ContractLocked {},
+    #[error("ContractLocked: {msg:?}")]
+    ContractLocked { msg: Option<String> },
 
     #[error("UnidentifiedMsgID")]
     UnidentifiedMsgID {},

--- a/tests-integration/tests/conditional_splitter.rs
+++ b/tests-integration/tests/conditional_splitter.rs
@@ -174,3 +174,100 @@ fn test_conditional_splitter() {
     assert_eq!(uusd_balance_1.amount, Uint128::from(20u128));
     assert_eq!(uusd_balance_2.amount, Uint128::from(80u128));
 }
+
+#[test]
+fn test_conditional_splitter_with_multiple_thresholds() {
+    let mut router = mock_app(None);
+    let andr = MockAndromedaBuilder::new(&mut router, "admin")
+        .with_wallets(vec![("owner", vec![coin(100_000, "uandr")])])
+        .with_contracts(vec![
+            ("app-contract", mock_andromeda_app()),
+            (
+                "conditional-splitter",
+                mock_andromeda_conditional_splitter(),
+            ),
+        ])
+        .build(&mut router);
+    let owner = andr.get_wallet("owner");
+
+    let recipient_a = "andr12lm0kfn2g3gn39ulzvqnadwksss5ez8rc7rwq7";
+    let recipient_b = "andr10dx5rcshf3fwpyw8jjrh5m25kv038xkqvngnls";
+
+    let threshold_recipients_5 = vec![
+        AddressPercent {
+            recipient: Recipient::from_string(recipient_b.to_string()),
+            percent: Decimal::from_str("0.3").unwrap(),
+        },
+        AddressPercent {
+            recipient: Recipient::from_string(recipient_a.to_string()),
+            percent: Decimal::from_str("0.7").unwrap(),
+        },
+    ];
+
+    let threshold_recipients_10 = vec![
+        AddressPercent {
+            recipient: Recipient::from_string(recipient_a.to_string()),
+            percent: Decimal::from_str("0.5").unwrap(),
+        },
+        AddressPercent {
+            recipient: Recipient::from_string(recipient_b.to_string()),
+            percent: Decimal::from_str("0.5").unwrap(),
+        },
+    ];
+
+    let thresholds = vec![
+        Threshold::new(Uint128::new(5), threshold_recipients_5),
+        Threshold::new(Uint128::new(10), threshold_recipients_10),
+    ];
+
+    let app_code_id = andr.get_code_id(&mut router, "app-contract");
+    let splitter_init_msg = mock_conditional_splitter_instantiate_msg(
+        thresholds,
+        andr.kernel.addr().clone(),
+        None,
+        None,
+    );
+    let splitter_app_component = AppComponent {
+        name: "conditional-splitter".to_string(),
+        component_type: ComponentType::new(splitter_init_msg),
+        ado_type: "conditional-splitter".to_string(),
+    };
+
+    let app_components = vec![splitter_app_component.clone()];
+    let app = MockAppContract::instantiate(
+        app_code_id,
+        owner,
+        &mut router,
+        "Conditional Splitter App",
+        app_components,
+        andr.kernel.addr(),
+        None,
+    );
+
+    let splitter: MockConditionalSplitter =
+        app.query_ado_by_component_name(&router, splitter_app_component.name);
+
+    // Test amount between 5 and 10 (should use 30/70 split)
+    let token_1 = coin(6, "uandr");
+    splitter
+        .execute_send(&mut router, owner.clone(), &[token_1])
+        .unwrap();
+
+    let balance_a = router.wrap().query_balance(recipient_a, "uandr").unwrap();
+    let balance_b = router.wrap().query_balance(recipient_b, "uandr").unwrap();
+
+    assert_eq!(balance_a.amount, Uint128::from(4u128)); // 70% of 6
+    assert_eq!(balance_b.amount, Uint128::from(1u128)); // 30% of 6
+
+    // Test amount above 10 (should use 50/50 split)
+    let token_2 = coin(15, "uandr");
+    splitter
+        .execute_send(&mut router, owner.clone(), &[token_2])
+        .unwrap();
+
+    let balance_a = router.wrap().query_balance(recipient_a, "uandr").unwrap();
+    let balance_b = router.wrap().query_balance(recipient_b, "uandr").unwrap();
+
+    assert_eq!(balance_a.amount, Uint128::from(11u128)); // 4 from previous + 50% of 15
+    assert_eq!(balance_b.amount, Uint128::from(8u128)); // 1 from previous + 50% of 15
+}


### PR DESCRIPTION
# Motivation
The splitter contracts' locks could be bypassed by providing a config during `Send`. 

# Implementation
Added this check whenever a config is provided:
```rust
ensure!(
            splitter.lock.is_expired(&ctx.env.block),
            ContractError::ContractLocked {
                msg: Some("Config isn't allowed while the splitter is locked".to_string())
            }
        );
```

# Testing
Added `test_get_threshold` for the `get_threshold` function

# Version Changes
`splitter`: `2.3.0-b.2` -> `2.3.0-b.3`
`fixed-amount-splitter`: `1.2.0-b.1` -> `1.2.0-b.2`
`weighted-distribution-splitter`: `2.1.0-b.2` -> `2.1.0-b.3`

# Notes
None

# Future work
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for contract lock states across multiple finance-related contracts.
  - Standardized `ContractLocked` error to include optional message field.
  - Prevented bypassing splitter lock via configuration.

- **Chores**
  - Version updates for several splitter contracts:
    - Fixed Amount Splitter: `1.2.0-b.1` → `1.2.0-b.2`
    - Splitter: `2.3.0-b.2` → `2.3.0-b.3`
    - Weighted Distribution Splitter: `2.1.0-b.2` → `2.1.0-b.3`

- **Refactor**
  - Improved validation checks for contract lock expiration.
  - Updated error handling mechanisms in contract execution functions.

- **Tests**
  - Added new test cases to enhance coverage for the `Send` functionality in splitter contracts, validating behavior under locked and unlocked states.
  - Introduced parameterized testing for the `get_threshold` function in the conditional splitter module.
  - Added a new test for handling multiple thresholds in the conditional splitter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->