### PR TITLE
Removed Rates module from Point ADO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Weighted Splitter: Replace Recipient with AndrAddr in RemoveRecipient and GetUserWeight [(#739)](https://github.com/andromedaprotocol/andromeda-core/pull/739)
 - feat: IBC packet tracking adjustments [#748](https://github.com/andromedaprotocol/andromeda-core/pull/748)
 - ref: Rename Set Amount Splitter to Fixed Amount Splitter [(#754)](https://github.com/andromedaprotocol/andromeda-core/pull/754)
+- Point ADO: remove Rates module from the contract[(#761)](https://github.com/andromedaprotocol/andromeda-core/pull/761)
 
 ### Fixed
 

--- a/contracts/math/andromeda-point/Cargo.toml
+++ b/contracts/math/andromeda-point/Cargo.toml
@@ -29,7 +29,7 @@ cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 
-andromeda-std = { workspace = true, features = ["rates"] }
+andromeda-std = { workspace = true }
 andromeda-math = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/contracts/math/andromeda-point/src/execute.rs
+++ b/contracts/math/andromeda-point/src/execute.rs
@@ -1,13 +1,10 @@
 use andromeda_math::point::{ExecuteMsg, PointCoordinate, PointRestriction};
 use andromeda_std::{
-    ado_base::rates::{Rate, RatesMessage},
     ado_contract::ADOContract,
-    common::{actions::call_action, context::ExecuteContext, rates::get_tax_amount, Funds},
+    common::{actions::call_action, context::ExecuteContext},
     error::ContractError,
 };
-use cosmwasm_std::{
-    coin, ensure, BankMsg, Coin, CosmosMsg, Deps, MessageInfo, Response, SubMsg, Uint128,
-};
+use cosmwasm_std::{ensure, Response};
 use cw_utils::nonpayable;
 
 use crate::{
@@ -16,8 +13,7 @@ use crate::{
 };
 
 pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
-    let action = msg.as_ref().to_string();
-    call_action(
+    let action_response = call_action(
         &mut ctx.deps,
         &ctx.info,
         &ctx.env,
@@ -25,23 +21,17 @@ pub fn handle_execute(mut ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Respon
         msg.as_ref(),
     )?;
 
-    match msg.clone() {
+    let res = match msg.clone() {
         ExecuteMsg::UpdateRestriction { restriction } => update_restriction(ctx, restriction),
-        ExecuteMsg::SetPoint { point } => set_point(ctx, point, action),
+        ExecuteMsg::SetPoint { point } => set_point(ctx, point),
         ExecuteMsg::DeletePoint {} => delete_point(ctx),
-        ExecuteMsg::Rates(rates_message) => match rates_message {
-            RatesMessage::SetRate { rate, .. } => match rate {
-                Rate::Local(local_rate) => {
-                    // Percent rates aren't applicable in this case, so we enforce Flat rates
-                    ensure!(local_rate.value.is_flat(), ContractError::InvalidRate {});
-                    ADOContract::default().execute(ctx, msg)
-                }
-                Rate::Contract(_) => ADOContract::default().execute(ctx, msg),
-            },
-            RatesMessage::RemoveRate { .. } => ADOContract::default().execute(ctx, msg),
-        },
         _ => ADOContract::default().execute(ctx, msg),
-    }
+    }?;
+
+    Ok(res
+        .add_submessages(action_response.messages)
+        .add_attributes(action_response.attributes)
+        .add_events(action_response.events))
 }
 
 pub fn update_restriction(
@@ -60,39 +50,22 @@ pub fn update_restriction(
         .add_attribute("sender", sender))
 }
 
-pub fn set_point(
-    ctx: ExecuteContext,
-    point: PointCoordinate,
-    action: String,
-) -> Result<Response, ContractError> {
+pub fn set_point(ctx: ExecuteContext, point: PointCoordinate) -> Result<Response, ContractError> {
     let sender = ctx.info.sender.clone();
     ensure!(
         has_permission(ctx.deps.storage, &sender)?,
         ContractError::Unauthorized {}
     );
 
-    let tax_response = tax_set_value(ctx.deps.as_ref(), &ctx.info, action)?;
-
     point.validate()?;
 
     DATA.save(ctx.deps.storage, &point.clone())?;
     DATA_OWNER.save(ctx.deps.storage, &sender)?;
 
-    let mut response = Response::new()
+    let response = Response::new()
         .add_attribute("method", "set_point")
         .add_attribute("sender", sender)
         .add_attribute("point", format!("{point:?}"));
-
-    if let Some(tax_response) = tax_response {
-        response = response.add_submessages(tax_response.1);
-        let refund = tax_response.0.try_get_coin()?;
-        if !refund.amount.is_zero() {
-            return Ok(response.add_message(CosmosMsg::Bank(BankMsg::Send {
-                to_address: ctx.info.sender.into_string(),
-                amount: vec![refund],
-            })));
-        }
-    }
 
     Ok(response)
 }
@@ -109,45 +82,4 @@ pub fn delete_point(ctx: ExecuteContext) -> Result<Response, ContractError> {
     Ok(Response::new()
         .add_attribute("method", "delete_point")
         .add_attribute("sender", sender))
-}
-
-fn tax_set_value(
-    deps: Deps,
-    info: &MessageInfo,
-    action: String,
-) -> Result<Option<(Funds, Vec<SubMsg>)>, ContractError> {
-    let default_coin = coin(0_u128, "uandr".to_string());
-    let sent_funds = info.funds.first().unwrap_or(&default_coin);
-
-    let transfer_response = ADOContract::default().query_deducted_funds(
-        deps,
-        action,
-        Funds::Native(sent_funds.clone()),
-    )?;
-
-    if let Some(transfer_response) = transfer_response {
-        let remaining_funds = transfer_response.leftover_funds.try_get_coin()?;
-        let tax_amount = get_tax_amount(
-            &transfer_response.msgs,
-            remaining_funds.amount,
-            remaining_funds.amount,
-        );
-
-        let refund = if sent_funds.amount > tax_amount {
-            sent_funds.amount.checked_sub(tax_amount)?
-        } else {
-            Uint128::zero()
-        };
-
-        let after_tax_payment = Coin {
-            denom: remaining_funds.denom,
-            amount: refund,
-        };
-        Ok(Some((
-            Funds::Native(after_tax_payment),
-            transfer_response.msgs,
-        )))
-    } else {
-        Ok(None)
-    }
 }

--- a/contracts/math/andromeda-point/src/mock.rs
+++ b/contracts/math/andromeda-point/src/mock.rs
@@ -3,7 +3,6 @@ use crate::contract::{execute, instantiate, query};
 use andromeda_math::point::{
     ExecuteMsg, GetDataOwnerResponse, InstantiateMsg, PointCoordinate, PointRestriction, QueryMsg,
 };
-use andromeda_std::ado_base::rates::{Rate, RatesMessage};
 use andromeda_testing::mock::MockApp;
 use andromeda_testing::{
     mock_ado,
@@ -53,16 +52,6 @@ impl MockPoint {
         }
     }
 
-    pub fn execute_add_rate(
-        &self,
-        app: &mut MockApp,
-        sender: Addr,
-        action: String,
-        rate: Rate,
-    ) -> ExecuteResult {
-        self.execute(app, &mock_set_rate_msg(action, rate), sender, &[])
-    }
-
     pub fn query_point(&self, app: &mut MockApp) -> PointCoordinate {
         let msg = mock_point_get_point();
         let res: PointCoordinate = self.query(app, msg);
@@ -96,10 +85,6 @@ pub fn mock_point_instantiate_msg(
 /// Used to generate a message to set point
 pub fn mock_point_set_point_msg(point: PointCoordinate) -> ExecuteMsg {
     ExecuteMsg::SetPoint { point }
-}
-
-pub fn mock_set_rate_msg(action: String, rate: Rate) -> ExecuteMsg {
-    ExecuteMsg::Rates(RatesMessage::SetRate { action, rate })
 }
 
 pub fn mock_point_get_point() -> QueryMsg {

--- a/contracts/math/andromeda-point/src/testing/mock.rs
+++ b/contracts/math/andromeda-point/src/testing/mock.rs
@@ -8,7 +8,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    Coin, Deps, DepsMut, MessageInfo, OwnedDeps, Response,
+    Deps, DepsMut, MessageInfo, OwnedDeps, Response,
 };
 
 use crate::contract::{execute, instantiate, query};
@@ -45,19 +45,6 @@ pub fn set_point(
         point: point.clone(),
     };
     let info = mock_info(sender, &[]);
-    execute(deps, mock_env(), info, msg)
-}
-
-pub fn set_point_with_funds(
-    deps: DepsMut<'_>,
-    point: &PointCoordinate,
-    sender: &str,
-    coin: Coin,
-) -> Result<Response, ContractError> {
-    let msg = ExecuteMsg::SetPoint {
-        point: point.clone(),
-    };
-    let info = mock_info(sender, &[coin]);
     execute(deps, mock_env(), info, msg)
 }
 

--- a/contracts/os/andromeda-adodb/src/tests.rs
+++ b/contracts/os/andromeda-adodb/src/tests.rs
@@ -718,9 +718,11 @@ fn test_all_ado_types() {
 
     let mut code_id = 1;
 
-    let ados = [ADOVersion::from_string("ado_type_1@0.1.0".to_string()),
+    let ados = [
+        ADOVersion::from_string("ado_type_1@0.1.0".to_string()),
         ADOVersion::from_string("ado_type_1@0.1.1".to_string()),
-        ADOVersion::from_string("ado_type_2@0.1.0".to_string())];
+        ADOVersion::from_string("ado_type_2@0.1.0".to_string()),
+    ];
 
     ados.iter().for_each(|ado_version| {
         let msg = ExecuteMsg::Publish {

--- a/contracts/os/andromeda-kernel/src/testing/test_handler.rs
+++ b/contracts/os/andromeda-kernel/src/testing/test_handler.rs
@@ -12,7 +12,9 @@ use andromeda_std::{
     },
 };
 use cosmwasm_std::{
-    coin, testing::{mock_env, mock_info}, to_json_binary, Addr, BankMsg, Binary, ReplyOn, SubMsg
+    coin,
+    testing::{mock_env, mock_info},
+    to_json_binary, Addr, BankMsg, Binary, ReplyOn, SubMsg,
 };
 
 struct TestHandleLocalCase {
@@ -26,12 +28,11 @@ struct TestHandleLocalCase {
 
 #[test]
 fn test_handle_local() {
-
     fn create_test_msg_with_config(config: AMPMsgConfig) -> AMPMsg {
         let base_msg = AMPMsg::new(MOCK_APP_CONTRACT, to_json_binary(&true).unwrap(), None);
         base_msg.with_config(config)
     }
-    
+
     // Then in tests:
     let config = AMPMsgConfig {
         reply_on: ReplyOn::Error,
@@ -40,7 +41,6 @@ fn test_handle_local() {
         direct: false,
         ibc_config: None,
     };
-
 
     let test_cases = vec![
         TestHandleLocalCase {
@@ -223,7 +223,7 @@ fn test_handle_local() {
             .to_sub_msg(MOCK_APP_CONTRACT, None, ReplyId::AMPMsg.repr())
             .unwrap(),
             expected_error: None,
-        }
+        },
     ];
 
     for test in test_cases {


### PR DESCRIPTION
The Rates module is not needed, so I removed that from the contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified point management functionality by removing tax and rate-related logic.
	- Streamlined `set_point` method signature.
	- Removed complex tax and fund transfer calculations.

- **Tests**
	- Updated test suite to remove tax-related test cases.
	- Enhanced test coverage by adding a new ADO version in the ADO contract tests.

- **Chores**
	- Cleaned up mock and testing implementations.
	- Removed unnecessary functions and imports related to rates and tax handling.
	- Updated dependency configuration for `andromeda-std`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->