### PR TITLE
ci: backport tags for release 4

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,3 +21,11 @@ pull_request_rules:
       backport:
         branches:
           - release/3
+  - name: backport to release/4 branch
+    conditions:
+      - base=main
+      - label=backport/release/4
+    actions:
+      backport:
+        branches:
+          - release/4


### PR DESCRIPTION
# Motivation

Adds mergify handler for backport tags for release 4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced automated backporting workflow by adding support for backporting changes to the `release/4` branch
	- Improved release management configuration in GitHub merge rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->