### PR TITLE
Mdjakovic/update curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed wrong return attribute for SubDir Query [(#756)](https://github.com/andromedaprotocol/andromeda-core/pull/756)
 - fix: Prevent bypassing splitter lock via config [(#757)](https://github.com/andromedaprotocol/andromeda-core/pull/757)
 - Fixed Curve ADO to be able to update curve config after reset [(#762)](https://github.com/andromedaprotocol/andromeda-core/pull/762)
+- Fixed Curve ADO's query error caused by Float data type [(#767)](https://github.com/andromedaprotocol/andromeda-core/pull/767)
 
 ## Release 3
 

--- a/contracts/math/andromeda-curve/src/contract.rs
+++ b/contracts/math/andromeda-curve/src/contract.rs
@@ -198,10 +198,15 @@ pub fn query_plot_y_from_x(
                 .map_err(|_| ContractError::Overflow {})?
                 .atomics();
 
-            let exponent_u32 =
+            let exponent_u32 = if exponent_value.u128() > u128::from(u32::MAX) {
+                return Err(ContractError::CustomError {
+                    msg: "Exponent value exceeds u32::MAX.".to_string(),
+                });
+            } else {
                 u32::try_from(exponent_value.u128()).map_err(|_| ContractError::CustomError {
                     msg: "Failed to convert exponent to u32.".to_string(),
-                })?;
+                })?
+            };
 
             // The argument of the checked_pow() must be u32, can not be other types
             let res = constant_value_decimal

--- a/contracts/math/andromeda-curve/src/contract.rs
+++ b/contracts/math/andromeda-curve/src/contract.rs
@@ -171,7 +171,7 @@ pub fn query_curve_config(storage: &dyn Storage) -> Result<GetCurveConfigRespons
 
 pub fn query_plot_y_from_x(
     storage: &dyn Storage,
-    x_value: Decimal,
+    x_value: u64,
 ) -> Result<GetPlotYFromXResponse, ContractError> {
     let curve_config = CURVE_CONFIG.load(storage)?;
 
@@ -190,7 +190,11 @@ pub fn query_plot_y_from_x(
             );
 
             let exponent_value = multiple_variable_value_decimal
-                .checked_mul(x_value)
+                .checked_mul(Decimal::from_atomics(x_value, 18).map_err(|e| {
+                    ContractError::CustomError {
+                        msg: format!("Failed to create decimal for the exponent_value: {:?}", e),
+                    }
+                })?)
                 .map_err(|_| ContractError::Overflow {})?
                 .atomics();
 

--- a/contracts/math/andromeda-curve/src/contract.rs
+++ b/contracts/math/andromeda-curve/src/contract.rs
@@ -15,7 +15,8 @@ use andromeda_std::{
 };
 
 use cosmwasm_std::{
-    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, Storage,
+    entry_point, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    Storage,
 };
 
 use cw_utils::nonpayable;
@@ -170,7 +171,7 @@ pub fn query_curve_config(storage: &dyn Storage) -> Result<GetCurveConfigRespons
 
 pub fn query_plot_y_from_x(
     storage: &dyn Storage,
-    x_value: f64,
+    x_value: u64,
 ) -> Result<GetPlotYFromXResponse, ContractError> {
     let curve_config = CURVE_CONFIG.load(storage)?;
 
@@ -181,18 +182,44 @@ pub fn query_plot_y_from_x(
             multiple_variable_value,
             constant_value,
         } => {
-            let curve_id_f64 = match curve_type {
-                CurveType::Growth => 1_f64,
-                CurveType::Decay => -1_f64,
-            };
-            let base_value_f64 = base_value as f64;
-            let constant_value_f64 = constant_value.unwrap_or(DEFAULT_CONSTANT_VALUE) as f64;
-            let multiple_variable_value_f64 =
-                multiple_variable_value.unwrap_or(DEFAULT_MULTIPLE_VARIABLE_VALUE) as f64;
+            let base_value_decimal = Decimal::percent(base_value * 100);
+            let constant_value_decimal =
+                Decimal::percent(constant_value.unwrap_or(DEFAULT_CONSTANT_VALUE) * 100);
+            let multiple_variable_value_decimal = Decimal::percent(
+                multiple_variable_value.unwrap_or(DEFAULT_MULTIPLE_VARIABLE_VALUE) * 100,
+            );
 
-            (constant_value_f64
-                * base_value_f64.powf(curve_id_f64 * multiple_variable_value_f64 * x_value))
-            .to_string()
+            let exponent_value = multiple_variable_value_decimal
+                .checked_mul(Decimal::from_atomics(x_value, 18).map_err(|e| {
+                    ContractError::CustomError {
+                        msg: format!("Failed to create decimal for the exponent_value: {:?}", e),
+                    }
+                })?)
+                .map_err(|_| ContractError::Overflow {})?
+                .atomics();
+
+            let exponent_u32 =
+                u32::try_from(exponent_value.u128()).map_err(|_| ContractError::CustomError {
+                    msg: "Failed to convert exponent to u32.".to_string(),
+                })?;
+
+            // The argument of the checked_pow() must be u32, can not be other types
+            let res = constant_value_decimal
+                .checked_mul(
+                    base_value_decimal
+                        .checked_pow(exponent_u32)
+                        .map_err(|_| ContractError::Overflow {})?,
+                )
+                .map_err(|_| ContractError::Overflow {})?;
+
+            let res_by_curve_type = match curve_type {
+                CurveType::Growth => res,
+                CurveType::Decay => Decimal::one()
+                    .checked_div(res)
+                    .map_err(|_| ContractError::Underflow {})?,
+            };
+
+            res_by_curve_type.to_string()
         }
     };
 

--- a/contracts/math/andromeda-curve/src/contract.rs
+++ b/contracts/math/andromeda-curve/src/contract.rs
@@ -171,7 +171,7 @@ pub fn query_curve_config(storage: &dyn Storage) -> Result<GetCurveConfigRespons
 
 pub fn query_plot_y_from_x(
     storage: &dyn Storage,
-    x_value: u64,
+    x_value: Decimal,
 ) -> Result<GetPlotYFromXResponse, ContractError> {
     let curve_config = CURVE_CONFIG.load(storage)?;
 
@@ -190,11 +190,7 @@ pub fn query_plot_y_from_x(
             );
 
             let exponent_value = multiple_variable_value_decimal
-                .checked_mul(Decimal::from_atomics(x_value, 18).map_err(|e| {
-                    ContractError::CustomError {
-                        msg: format!("Failed to create decimal for the exponent_value: {:?}", e),
-                    }
-                })?)
+                .checked_mul(x_value)
                 .map_err(|_| ContractError::Overflow {})?
                 .atomics();
 

--- a/contracts/math/andromeda-curve/src/mock.rs
+++ b/contracts/math/andromeda-curve/src/mock.rs
@@ -80,7 +80,7 @@ impl MockCurve {
         res
     }
 
-    pub fn query_plot_y_from_x(&self, app: &mut MockApp, x_value: f64) -> GetPlotYFromXResponse {
+    pub fn query_plot_y_from_x(&self, app: &mut MockApp, x_value: u64) -> GetPlotYFromXResponse {
         let msg = QueryMsg::GetPlotYFromX { x_value };
         let res: GetPlotYFromXResponse = self.query(app, msg);
         res

--- a/contracts/math/andromeda-curve/src/testing/mock.rs
+++ b/contracts/math/andromeda-curve/src/testing/mock.rs
@@ -78,7 +78,7 @@ pub fn query_curve_config(deps: Deps) -> Result<GetCurveConfigResponse, Contract
 
 pub fn query_plot_y_from_x(
     deps: Deps,
-    x_value: f64,
+    x_value: u64,
 ) -> Result<GetPlotYFromXResponse, ContractError> {
     let res = query(deps, mock_env(), QueryMsg::GetPlotYFromX { x_value });
     match res {

--- a/contracts/math/andromeda-curve/src/testing/mock.rs
+++ b/contracts/math/andromeda-curve/src/testing/mock.rs
@@ -10,7 +10,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    Deps, DepsMut, MessageInfo, OwnedDeps, Response,
+    Decimal, Deps, DepsMut, MessageInfo, OwnedDeps, Response,
 };
 
 use crate::contract::{execute, instantiate, query};
@@ -78,7 +78,7 @@ pub fn query_curve_config(deps: Deps) -> Result<GetCurveConfigResponse, Contract
 
 pub fn query_plot_y_from_x(
     deps: Deps,
-    x_value: u64,
+    x_value: Decimal,
 ) -> Result<GetPlotYFromXResponse, ContractError> {
     let res = query(deps, mock_env(), QueryMsg::GetPlotYFromX { x_value });
     match res {

--- a/contracts/math/andromeda-curve/src/testing/mock.rs
+++ b/contracts/math/andromeda-curve/src/testing/mock.rs
@@ -10,7 +10,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    Decimal, Deps, DepsMut, MessageInfo, OwnedDeps, Response,
+    Deps, DepsMut, MessageInfo, OwnedDeps, Response,
 };
 
 use crate::contract::{execute, instantiate, query};
@@ -78,7 +78,7 @@ pub fn query_curve_config(deps: Deps) -> Result<GetCurveConfigResponse, Contract
 
 pub fn query_plot_y_from_x(
     deps: Deps,
-    x_value: Decimal,
+    x_value: u64,
 ) -> Result<GetPlotYFromXResponse, ContractError> {
     let res = query(deps, mock_env(), QueryMsg::GetPlotYFromX { x_value });
     match res {

--- a/contracts/math/andromeda-curve/src/testing/tests.rs
+++ b/contracts/math/andromeda-curve/src/testing/tests.rs
@@ -4,7 +4,7 @@ use super::mock::{
 };
 use andromeda_math::curve::{CurveConfig, CurveType};
 use andromeda_std::{amp::AndrAddr, error::ContractError};
-use cosmwasm_std::{Decimal, StdError};
+use cosmwasm_std::StdError;
 use test_case::test_case;
 
 #[test]
@@ -158,7 +158,6 @@ fn test_query_curve_config_base_is_0() {
 #[test_case(3, "8".to_string() ; "exp(2, 3)")]
 #[test_case(4, "16".to_string() ; "exp(2, 4)")]
 fn test_query_plot_y_from_x_base_2_growth(input_x: u64, expected_y: String) {
-    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -177,7 +176,6 @@ fn test_query_plot_y_from_x_base_2_growth(input_x: u64, expected_y: String) {
 #[test_case(3, "27".to_string() ; "exp(3, 3)")]
 #[test_case(4, "81".to_string() ; "exp(3, 4)")]
 fn test_query_plot_y_from_x_base_3_growth(input_x: u64, expected_y: String) {
-    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -196,7 +194,6 @@ fn test_query_plot_y_from_x_base_3_growth(input_x: u64, expected_y: String) {
 #[test_case(3, "128".to_string() ; "exp(4, 3)")]
 #[test_case(4, "512".to_string() ; "exp(4, 4)")]
 fn test_query_plot_y_from_x_base_4_growth_constant_2(input_x: u64, expected_y: String) {
-    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -215,7 +212,6 @@ fn test_query_plot_y_from_x_base_4_growth_constant_2(input_x: u64, expected_y: S
 #[test_case(3, "0.125".to_string() ; "exp(1/2, 3)")]
 #[test_case(4, "0.0625".to_string() ; "exp(1/2, 4)")]
 fn test_query_plot_y_from_x_base_2_decay(input_x: u64, expected_y: String) {
-    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Decay,

--- a/contracts/math/andromeda-curve/src/testing/tests.rs
+++ b/contracts/math/andromeda-curve/src/testing/tests.rs
@@ -4,7 +4,7 @@ use super::mock::{
 };
 use andromeda_math::curve::{CurveConfig, CurveType};
 use andromeda_std::{amp::AndrAddr, error::ContractError};
-use cosmwasm_std::StdError;
+use cosmwasm_std::{Decimal, StdError};
 use test_case::test_case;
 
 #[test]
@@ -158,6 +158,7 @@ fn test_query_curve_config_base_is_0() {
 #[test_case(3, "8".to_string() ; "exp(2, 3)")]
 #[test_case(4, "16".to_string() ; "exp(2, 4)")]
 fn test_query_plot_y_from_x_base_2_growth(input_x: u64, expected_y: String) {
+    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -176,6 +177,7 @@ fn test_query_plot_y_from_x_base_2_growth(input_x: u64, expected_y: String) {
 #[test_case(3, "27".to_string() ; "exp(3, 3)")]
 #[test_case(4, "81".to_string() ; "exp(3, 4)")]
 fn test_query_plot_y_from_x_base_3_growth(input_x: u64, expected_y: String) {
+    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -194,6 +196,7 @@ fn test_query_plot_y_from_x_base_3_growth(input_x: u64, expected_y: String) {
 #[test_case(3, "128".to_string() ; "exp(4, 3)")]
 #[test_case(4, "512".to_string() ; "exp(4, 4)")]
 fn test_query_plot_y_from_x_base_4_growth_constant_2(input_x: u64, expected_y: String) {
+    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -212,6 +215,7 @@ fn test_query_plot_y_from_x_base_4_growth_constant_2(input_x: u64, expected_y: S
 #[test_case(3, "0.125".to_string() ; "exp(1/2, 3)")]
 #[test_case(4, "0.0625".to_string() ; "exp(1/2, 4)")]
 fn test_query_plot_y_from_x_base_2_decay(input_x: u64, expected_y: String) {
+    let input_x = Decimal::from_atomics(input_x, 18).unwrap();
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Decay,

--- a/contracts/math/andromeda-curve/src/testing/tests.rs
+++ b/contracts/math/andromeda-curve/src/testing/tests.rs
@@ -154,10 +154,10 @@ fn test_query_curve_config_base_is_0() {
     );
 }
 
-#[test_case(2_f64, "4".to_string() ; "exp(2, 2)")]
-#[test_case(3_f64, "8".to_string() ; "exp(2, 3)")]
-#[test_case(4_f64, "16".to_string() ; "exp(2, 4)")]
-fn test_query_plot_y_from_x_base_2_growth(input_x: f64, expected_y: String) {
+#[test_case(2, "4".to_string() ; "exp(2, 2)")]
+#[test_case(3, "8".to_string() ; "exp(2, 3)")]
+#[test_case(4, "16".to_string() ; "exp(2, 4)")]
+fn test_query_plot_y_from_x_base_2_growth(input_x: u64, expected_y: String) {
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -169,13 +169,13 @@ fn test_query_plot_y_from_x_base_2_growth(input_x: f64, expected_y: String) {
     );
 
     let res = query_plot_y_from_x(deps.as_ref(), input_x).unwrap().y_value;
-    assert_eq!(res, expected_y);
+    assert_eq!(res.to_string(), expected_y);
 }
 
-#[test_case(2_f64, "9".to_string() ; "exp(3, 2)")]
-#[test_case(3_f64, "27".to_string() ; "exp(3, 3)")]
-#[test_case(4_f64, "81".to_string() ; "exp(3, 4)")]
-fn test_query_plot_y_from_x_base_3_growth(input_x: f64, expected_y: String) {
+#[test_case(2, "9".to_string() ; "exp(3, 2)")]
+#[test_case(3, "27".to_string() ; "exp(3, 3)")]
+#[test_case(4, "81".to_string() ; "exp(3, 4)")]
+fn test_query_plot_y_from_x_base_3_growth(input_x: u64, expected_y: String) {
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Growth,
@@ -187,13 +187,31 @@ fn test_query_plot_y_from_x_base_3_growth(input_x: f64, expected_y: String) {
     );
 
     let res = query_plot_y_from_x(deps.as_ref(), input_x).unwrap().y_value;
-    assert_eq!(res, expected_y);
+    assert_eq!(res.to_string(), expected_y);
 }
 
-#[test_case(2_f64, "0.25".to_string() ; "exp(1/2, 2)")]
-#[test_case(3_f64, "0.125".to_string() ; "exp(1/2, 3)")]
-#[test_case(4_f64, "0.0625".to_string() ; "exp(1/2, 4)")]
-fn test_query_plot_y_from_x_base_2_decay(input_x: f64, expected_y: String) {
+#[test_case(2, "32".to_string() ; "exp(4, 2)")]
+#[test_case(3, "128".to_string() ; "exp(4, 3)")]
+#[test_case(4, "512".to_string() ; "exp(4, 4)")]
+fn test_query_plot_y_from_x_base_4_growth_constant_2(input_x: u64, expected_y: String) {
+    let (deps, _info) = proper_initialization(
+        CurveConfig::ExpConfig {
+            curve_type: CurveType::Growth,
+            base_value: 4,
+            multiple_variable_value: None,
+            constant_value: Some(2),
+        },
+        None,
+    );
+
+    let res = query_plot_y_from_x(deps.as_ref(), input_x).unwrap().y_value;
+    assert_eq!(res.to_string(), expected_y);
+}
+
+#[test_case(2, "0.25".to_string() ; "exp(1/2, 2)")]
+#[test_case(3, "0.125".to_string() ; "exp(1/2, 3)")]
+#[test_case(4, "0.0625".to_string() ; "exp(1/2, 4)")]
+fn test_query_plot_y_from_x_base_2_decay(input_x: u64, expected_y: String) {
     let (deps, _info) = proper_initialization(
         CurveConfig::ExpConfig {
             curve_type: CurveType::Decay,
@@ -205,5 +223,5 @@ fn test_query_plot_y_from_x_base_2_decay(input_x: f64, expected_y: String) {
     );
 
     let res = query_plot_y_from_x(deps.as_ref(), input_x).unwrap().y_value;
-    assert_eq!(res, expected_y);
+    assert_eq!(res.to_string(), expected_y);
 }

--- a/packages/andromeda-math/src/curve.rs
+++ b/packages/andromeda-math/src/curve.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{amp::AndrAddr, andr_exec, andr_instantiate, andr_query, error::ContractError};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::ensure;
+use cosmwasm_std::{ensure, Decimal};
 
 #[andr_instantiate]
 #[cw_serde]
@@ -60,7 +60,7 @@ pub enum QueryMsg {
     #[returns(GetCurveConfigResponse)]
     GetCurveConfig {},
     #[returns(GetPlotYFromXResponse)]
-    GetPlotYFromX { x_value: u64 },
+    GetPlotYFromX { x_value: Decimal },
 }
 
 #[cw_serde]

--- a/packages/andromeda-math/src/curve.rs
+++ b/packages/andromeda-math/src/curve.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{amp::AndrAddr, andr_exec, andr_instantiate, andr_query, error::ContractError};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{ensure, Decimal};
+use cosmwasm_std::ensure;
 
 #[andr_instantiate]
 #[cw_serde]
@@ -60,7 +60,7 @@ pub enum QueryMsg {
     #[returns(GetCurveConfigResponse)]
     GetCurveConfig {},
     #[returns(GetPlotYFromXResponse)]
-    GetPlotYFromX { x_value: Decimal },
+    GetPlotYFromX { x_value: u64 },
 }
 
 #[cw_serde]

--- a/packages/andromeda-math/src/curve.rs
+++ b/packages/andromeda-math/src/curve.rs
@@ -60,7 +60,7 @@ pub enum QueryMsg {
     #[returns(GetCurveConfigResponse)]
     GetCurveConfig {},
     #[returns(GetPlotYFromXResponse)]
-    GetPlotYFromX { x_value: f64 },
+    GetPlotYFromX { x_value: u64 },
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation

We have to resolve the query error caused by `float` data type.
The chain does not support that type.

![image](https://github.com/user-attachments/assets/dfd08829-4086-46d7-8e24-fcb6caf21461)

# Implementation

To resolve this issue, I used `u64` instead of `float64` as the input type, and implemented the `Decimal` as the calculation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
  - Fixed a query error in the Curve ADO related to Float data type handling.

- **Improvements**
  - Enhanced type safety for curve calculations by changing input types from `f64` to `u64`.
  - Improved mathematical precision using `Decimal` type for curve computations.

- **Testing**
  - Added new test case for growth curve with base 4.
  - Updated existing test cases to align with new type requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->