### PR TITLE
chore: bump all ADOs by minor for std update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.3.0"
+version = "1.3.0-beta"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.0"
+version = "2.1.0-beta"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.2.3-beta"
+version = "1.3.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cross-chain-swap"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.1.5-beta"
+version = "2.2.0-beta"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-curve"
-version = "0.1.0-b.2"
+version = "0.2.0-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.0.5"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-exchange"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-staking"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.0.5"
+version = "2.1.0"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-ibc-registry"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-ics20"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-lockdrop"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-marketplace"
-version = "2.2.4"
+version = "2.3.0"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-merkle-airdrop"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-primitive"
-version = "2.0.4"
+version = "2.1.0"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.3-beta"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vault"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "andromeda-ecosystem",
  "andromeda-std",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.0.4"
+version = "3.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-primitive"
-version = "2.0.4"
+version = "2.1.0"
 authors = [
   "Connor Barr <crnbarr@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/ecosystem/andromeda-vault/Cargo.toml
+++ b/contracts/ecosystem/andromeda-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vault"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.2.3-beta"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.3.0"
+version = "1.3.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
+++ b/contracts/finance/andromeda-cross-chain-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cross-chain-swap"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.0"
+version = "2.1.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.0.3-beta"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "2.0.3"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.0.4"
+version = "3.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-exchange"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-staking"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.0.5"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-ics20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-ics20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-ics20"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-lockdrop"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-merkle-airdrop"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/math/andromeda-curve/Cargo.toml
+++ b/contracts/math/andromeda-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-curve"
-version = "0.1.0-b.2"
+version = "0.2.0-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.0.3"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.1.5-beta"
+version = "2.2.0-beta"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.0.5"
+version = "2.1.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-marketplace"
-version = "2.2.4"
+version = "2.3.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-ibc-registry/Cargo.toml
+++ b/contracts/os/andromeda-ibc-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-ibc-registry"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.1.2"
+version = "1.2.0"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"


### PR DESCRIPTION
# Motivation

These changes bump the version of several ADOs that missed version bumps during development due to an STD package update.

# Implementation
The following ADOs had their versions bumped:
- app-contract
- primitive
- vault
- conditional-splitter
- x-chain-swap
- rate-limiting-withdrawals
- timelock
- validator-staking
- vesting
- cw20-exchange
- cw20
- cw20-staking
- ics20
- lockdrop
- merkle-airdrop
- curve
- address-list
- crowdfund
- cw721
- marketplace
- economics
- vfs
- ibc-registry


# Version Changes

Each contract above was bumped by a minor version

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
