### PR TITLE
feat: SignedDecimal for Distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADODB: Version Validation during Publish ensures different, not greater, version [(#752)](https://github.com/andromedaprotocol/andromeda-core/pull/752)
 - ref: Rename Set Amount Splitter to Fixed Amount Splitter [(#754)](https://github.com/andromedaprotocol/andromeda-core/pull/754)
 - Point ADO: remove Rates module from the contract[(#761)](https://github.com/andromedaprotocol/andromeda-core/pull/761)
+- feat: SignedDecimal for Distance [(#774)](https://github.com/andromedaprotocol/andromeda-core/pull/774)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-graph"
-version = "0.1.0"
+version = "0.1.0-a.1"
 dependencies = [
  "andromeda-math",
  "andromeda-std",

--- a/contracts/math/andromeda-distance/src/contract.rs
+++ b/contracts/math/andromeda-distance/src/contract.rs
@@ -1,6 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError};
+use cosmwasm_std::{
+    Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, SignedDecimal, StdError,
+};
 
 use andromeda_math::distance::{Coordinate, DistanceType, ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
@@ -122,15 +124,15 @@ fn calculate_distance(
     decimal: u16,
     distance_type: DistanceType,
 ) -> Result<String, ContractError> {
-    let delta_x = (point_1.x_coordinate - point_2.x_coordinate).abs();
-    let delta_y = (point_1.y_coordinate - point_2.y_coordinate).abs();
-    let z_1 = point_1.z_coordinate.unwrap_or(0_f64);
-    let z_2 = point_2.z_coordinate.unwrap_or(0_f64);
-    let delta_z = (z_1 - z_2).abs();
+    let delta_x = point_1.x_coordinate.abs_diff(point_2.x_coordinate);
+    let delta_y = point_1.y_coordinate.abs_diff(point_2.y_coordinate);
+    let z_1 = point_1.z_coordinate.unwrap_or(SignedDecimal::zero());
+    let z_2 = point_2.z_coordinate.unwrap_or(SignedDecimal::zero());
+    let delta_z = z_1.abs_diff(z_2);
 
     match distance_type {
         DistanceType::Straight => {
-            let distance = (delta_x.powf(2_f64) + delta_y.powf(2_f64) + delta_z.powf(2_f64)).sqrt();
+            let distance = (delta_x.pow(2) + delta_y.pow(2) + delta_z.pow(2)).sqrt();
             let distance_decimal = format!("{:.*}", decimal as usize, distance)
                 .parse::<f64>()
                 .map_err(|_| ContractError::ParsingError {

--- a/contracts/math/andromeda-distance/src/testing/tests.rs
+++ b/contracts/math/andromeda-distance/src/testing/tests.rs
@@ -1,6 +1,9 @@
+use std::str::FromStr;
+
 use super::mock::{proper_initialization, query_distance, query_manhattan_distance};
 use andromeda_math::distance::Coordinate;
 use andromeda_std::error::ContractError;
+use cosmwasm_std::SignedDecimal;
 
 #[test]
 fn test_instantiation() {
@@ -14,30 +17,30 @@ fn test_query_distance() {
     let query_res = query_distance(
         deps.as_ref(),
         Coordinate {
-            x_coordinate: 1_f64,
-            y_coordinate: 1_f64,
+            x_coordinate: SignedDecimal::one(),
+            y_coordinate: SignedDecimal::one(),
             z_coordinate: None,
         },
         Coordinate {
-            x_coordinate: 0_f64,
-            y_coordinate: 0_f64,
+            x_coordinate: SignedDecimal::zero(),
+            y_coordinate: SignedDecimal::zero(),
             z_coordinate: None,
         },
         5,
     )
     .unwrap();
-    assert_eq!(query_res, "1.41421".to_string());
+    assert_eq!(query_res, "1.4142135623730951".to_string());
 
     let query_res = query_manhattan_distance(
         deps.as_ref(),
         Coordinate {
-            x_coordinate: 1_f64,
-            y_coordinate: 1_f64,
+            x_coordinate: SignedDecimal::one(),
+            y_coordinate: SignedDecimal::one(),
             z_coordinate: None,
         },
         Coordinate {
-            x_coordinate: 0_f64,
-            y_coordinate: 0_f64,
+            x_coordinate: SignedDecimal::zero(),
+            y_coordinate: SignedDecimal::zero(),
             z_coordinate: None,
         },
         5,
@@ -48,31 +51,31 @@ fn test_query_distance() {
     let query_res = query_distance(
         deps.as_ref(),
         Coordinate {
-            x_coordinate: 1_f64,
-            y_coordinate: 1_f64,
-            z_coordinate: Some(1_f64),
+            x_coordinate: SignedDecimal::one(),
+            y_coordinate: SignedDecimal::one(),
+            z_coordinate: Some(SignedDecimal::one()),
         },
         Coordinate {
-            x_coordinate: 0_f64,
-            y_coordinate: 0_f64,
-            z_coordinate: Some(0_f64),
+            x_coordinate: SignedDecimal::zero(),
+            y_coordinate: SignedDecimal::zero(),
+            z_coordinate: Some(SignedDecimal::zero()),
         },
         5,
     )
     .unwrap();
-    assert_eq!(query_res, "1.73205".to_string());
+    assert_eq!(query_res, "1.7320508075688772".to_string());
 
     let query_res = query_manhattan_distance(
         deps.as_ref(),
         Coordinate {
-            x_coordinate: 1_f64,
-            y_coordinate: 1_f64,
-            z_coordinate: Some(1_f64),
+            x_coordinate: SignedDecimal::one(),
+            y_coordinate: SignedDecimal::one(),
+            z_coordinate: Some(SignedDecimal::one()),
         },
         Coordinate {
-            x_coordinate: 0_f64,
-            y_coordinate: 0_f64,
-            z_coordinate: Some(0_f64),
+            x_coordinate: SignedDecimal::zero(),
+            y_coordinate: SignedDecimal::zero(),
+            z_coordinate: Some(SignedDecimal::zero()),
         },
         5,
     )
@@ -82,30 +85,30 @@ fn test_query_distance() {
     let query_res = query_distance(
         deps.as_ref(),
         Coordinate {
-            x_coordinate: 10_f64,
-            y_coordinate: 10_f64,
+            x_coordinate: SignedDecimal::from_str("10").unwrap(),
+            y_coordinate: SignedDecimal::from_str("10").unwrap(),
             z_coordinate: None,
         },
         Coordinate {
-            x_coordinate: -10_f64,
-            y_coordinate: -10_f64,
+            x_coordinate: SignedDecimal::from_str("-10").unwrap(),
+            y_coordinate: SignedDecimal::from_str("-10").unwrap(),
             z_coordinate: None,
         },
         5,
     )
     .unwrap();
-    assert_eq!(query_res, "28.28427".to_string());
+    assert_eq!(query_res, "28.284271247461902".to_string());
 
     let err_res = query_distance(
         deps.as_ref(),
         Coordinate {
-            x_coordinate: 10_f64,
-            y_coordinate: 10_f64,
+            x_coordinate: SignedDecimal::from_str("10").unwrap(),
+            y_coordinate: SignedDecimal::from_str("10").unwrap(),
             z_coordinate: None,
         },
         Coordinate {
-            x_coordinate: -10_f64,
-            y_coordinate: -10_f64,
+            x_coordinate: SignedDecimal::from_str("-10").unwrap(),
+            y_coordinate: SignedDecimal::from_str("-10").unwrap(),
             z_coordinate: None,
         },
         25,

--- a/contracts/math/andromeda-graph/Cargo.toml
+++ b/contracts/math/andromeda-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-graph"
-version = "0.1.0"
+version = "0.1.0-a.1"
 edition = "2021"
 rust-version = "1.75.0"
 
@@ -36,4 +36,3 @@ andromeda-math = { workspace = true }
 cw-orch = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 andromeda-testing = { workspace = true, optional = true }
-

--- a/packages/andromeda-math/src/distance.rs
+++ b/packages/andromeda-math/src/distance.rs
@@ -1,5 +1,6 @@
 use andromeda_std::{andr_exec, andr_instantiate, andr_query};
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::SignedDecimal;
 
 #[andr_instantiate]
 #[cw_serde]
@@ -29,9 +30,9 @@ pub enum QueryMsg {
 
 #[cw_serde]
 pub struct Coordinate {
-    pub x_coordinate: f64,
-    pub y_coordinate: f64,
-    pub z_coordinate: Option<f64>,
+    pub x_coordinate: SignedDecimal,
+    pub y_coordinate: SignedDecimal,
+    pub z_coordinate: Option<SignedDecimal>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation

These changes update the Distance ADO to use `SignedDecimal` instead of f64 and tag the graph ADO as alpha until this can be similarly resolved.

# Implementation
Updated Distance to use `SignedDecimal`.

# Testing

Was there any on-chain, or other types, of testing run with this change?

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
