### PR TITLE
ci: mergify target branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,4 +28,4 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - release/4
+          - release/4.x


### PR DESCRIPTION
# Motivation

Changes mergify's target branch for release 4 to release/4.x
