### PR TITLE
chore: versions & changelog for release 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## Release 4
+
+### Added
+
 - Crowdfund, added additional state [(#715)](https://github.com/andromedaprotocol/andromeda-core/pull/715)
 - Added optional config for Send in Splitter contracts [(#686)](https://github.com/andromedaprotocol/andromeda-core/pull/686)
 - Added CW20 suppport in Splitter contracts [(#703)](https://github.com/andromedaprotocol/andromeda-core/pull/703)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-graph"
-version = "0.1.0-a.2"
+version = "0.1.0"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-point"
-version = "0.1.0-a.1"
+version = "0.1.0"
 dependencies = [
  "andromeda-math",
  "andromeda-std",

--- a/contracts/math/andromeda-graph/Cargo.toml
+++ b/contracts/math/andromeda-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-graph"
-version = "0.1.0-a.2"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/math/andromeda-point/Cargo.toml
+++ b/contracts/math/andromeda-point/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-point"
-version = "0.1.0-a.1"
+version = "0.1.0"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"


### PR DESCRIPTION
# Motivation

These changes update the changelog to account for release 4 and tag graph and point as releasable.
