### PR TITLE
chore: weighted distribution splitter release tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0-a.1"
+version = "2.1.0"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0-a.1"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.75.0"
 


### PR DESCRIPTION
# Motivation
These changes tag the weighted distribution splitter as R4R.

# Version Changes

- `weighted-distribution-splitter`: `2.1.0-a.1` -> `2.1.0`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
