### PR TITLE
feat: IBC denom casing

### DIFF
--- a/contracts/os/andromeda-ibc-registry/src/contract.rs
+++ b/contracts/os/andromeda-ibc-registry/src/contract.rs
@@ -99,7 +99,7 @@ pub fn execute_store_denom_info(
 
     let mut seen_denoms = HashSet::new(); // To track unique denoms
     for info in ibc_denom_info {
-        let denom = info.denom;
+        let denom = info.denom.to_lowercase();
         verify_denom(&denom, &info.denom_info)?;
 
         // Check for duplicates
@@ -131,7 +131,7 @@ pub fn get_denom_info(
     storage: &dyn Storage,
     denom: String,
 ) -> Result<DenomInfoResponse, ContractError> {
-    let denom_info = REGISTRY.load(storage, denom)?;
+    let denom_info = REGISTRY.load(storage, denom.to_lowercase())?;
     Ok(DenomInfoResponse { denom_info })
 }
 

--- a/contracts/os/andromeda-vfs/src/execute.rs
+++ b/contracts/os/andromeda-vfs/src/execute.rs
@@ -155,8 +155,6 @@ pub fn register_user(
     username: String,
     address: Option<Addr>,
 ) -> Result<Response, ContractError> {
-    #[cfg(not(test))]
-    ensure!(false, ContractError::TemporarilyDisabled {});
     ensure!(
         username.len() as u64 <= MAX_USERNAME_LENGTH,
         ContractError::InvalidUsername {
@@ -168,7 +166,9 @@ pub fn register_user(
     let username = username.to_lowercase();
     let kernel = &ADOContract::default().get_kernel_address(env.deps.storage)?;
     let is_registration_enabled =
-        AOSQuerier::get_env_variable::<bool>(&env.deps.querier, kernel, "username_registration")?
+        AOSQuerier::get_env_variable::<String>(&env.deps.querier, kernel, "username_registration")?
+            .unwrap_or("false".to_string())
+            .parse::<bool>()
             .unwrap_or(false);
     // Can only register username directly on Andromeda chain
     ensure!(

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -327,7 +327,10 @@ impl AOSQuerier {
         kernel_addr: &Addr,
         variable: &str,
     ) -> Result<Option<T>, ContractError> {
-        let key = AOSQuerier::get_map_storage_key("kernel_env_variables", &[variable.as_bytes()])?;
+        let key = AOSQuerier::get_map_storage_key(
+            "kernel_env_variables",
+            &[variable.to_ascii_uppercase().as_bytes()],
+        )?;
         let verify: Option<T> = AOSQuerier::query_storage(querier, kernel_addr, &key)?;
         Ok(verify)
     }

--- a/packages/std/src/os/aos_querier.rs
+++ b/packages/std/src/os/aos_querier.rs
@@ -260,7 +260,7 @@ impl AOSQuerier {
         denom: &str,
     ) -> Result<DenomInfo, ContractError> {
         let query = IBCRegistryQueryMsg::DenomInfo {
-            denom: denom.to_string(),
+            denom: denom.to_lowercase(),
         };
         let denom_info_response: DenomInfoResponse =
             querier.query_wasm_smart(ibc_registry_addr, &query)?;


### PR DESCRIPTION
# Motivation

These changes alter the way IBC denoms are referenced in the IBC registry by converting them all to lowercase.

It also includes a similar fix for environment variable queries for the kernel, and a small change to the VFS to enable username registration when the environment variable is set.

# Testing

Tested on devnet.

# Version Changes

Were there any required version changes?

Example:

- `std`: `1.5.1-b.2` -> `1.5.1-b.3`
- `vfs`: `1.1.0` -> `1.1.1-b.1`
- `validator-staking`: `1.1.0` -> `1.1.1-b.1`
- `ibc-registry` 1.1.0` -> `1.1.1-b.1`

# Checklist

- [x] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
