### PR TITLE
fix: Andr Macros Adjustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.2.0-beta"
+version = "2.2.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-non-fungible-tokens"
-version = "1.0.0"
+version = "1.0.1-b.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.1-b.4"
+version = "1.5.1-b.5"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,6 @@ dependencies = [
  "cw-orch",
  "cw-orch-daemon",
  "cw-storage-plus 1.2.0",
- "cw-utils 1.0.3",
  "cw20",
  "cw721 0.18.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ andromeda-std = { path = "./packages/std", default-features = false, features = 
     "deploy",
 ] }
 andromeda-macros = { path = "./packages/std/macros", default-features = false }
-andromeda-non-fungible-tokens = { path = "./packages/andromeda-non-fungible-tokens", version = "1.0.0" }
+andromeda-non-fungible-tokens = { path = "./packages/andromeda-non-fungible-tokens", version = "1.0.1-b.1" }
 andromeda-fungible-tokens = { path = "./packages/andromeda-fungible-tokens", version = "1.0.0" }
 andromeda-finance = { path = "./packages/andromeda-finance", version = "1.0.0" }
 andromeda-data-storage = { path = "./packages/andromeda-data-storage", version = "1.0.0" }

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.2.0-beta"
+version = "2.2.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -19,7 +19,6 @@ testing = ["cw-multi-test", "andromeda-testing"]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
-cw-utils = { workspace = true }
 cw721 = { workspace = true }
 cw20 = { workspace = true }
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -32,15 +32,13 @@ use cosmwasm_std::{
     MessageInfo, Reply, Response, StdError, Storage, SubMsg, Uint128, Uint64, WasmMsg,
 };
 
-use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
-use cw_utils::nonpayable;
-
 use crate::state::{
     add_tier, clear_user_orders, get_and_increase_tier_token_id, get_config, get_current_capital,
     get_current_stage, get_duration, get_tier, get_tiers, get_user_orders, is_valid_tiers,
     remove_tier, set_config, set_current_capital, set_current_stage, set_duration, set_tier_orders,
     set_tiers, update_tier, Duration,
 };
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
 const CONTRACT_NAME: &str = "crates.io:andromeda-crowdfund";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -315,8 +313,6 @@ fn handle_receive_cw20(
 }
 
 fn execute_discard_campaign(mut ctx: ExecuteContext) -> Result<Response, ContractError> {
-    nonpayable(&ctx.info)?;
-
     let ExecuteContext { ref mut deps, .. } = ctx;
 
     let curr_stage = get_current_stage(deps.storage);
@@ -338,8 +334,6 @@ fn execute_discard_campaign(mut ctx: ExecuteContext) -> Result<Response, Contrac
 }
 
 fn execute_end_campaign(mut ctx: ExecuteContext) -> Result<Response, ContractError> {
-    nonpayable(&ctx.info)?;
-
     let ExecuteContext {
         ref mut deps,
         ref env,

--- a/packages/andromeda-non-fungible-tokens/Cargo.toml
+++ b/packages/andromeda-non-fungible-tokens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-non-fungible-tokens"
-version = "1.0.0"
+version = "1.0.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Message definitions and utility methods for Andromeda non-fungible token contracts"

--- a/packages/andromeda-non-fungible-tokens/src/auction.rs
+++ b/packages/andromeda-non-fungible-tokens/src/auction.rs
@@ -57,13 +57,13 @@ pub enum ExecuteMsg {
         token_id: String,
         token_address: String,
     },
-    /// Restricted to owner
+    #[attrs(nonpayable, restricted)]
     AuthorizeContract {
         action: PermissionAction,
         addr: AndrAddr,
         expiration: Option<Expiry>,
     },
-    /// Restricted to owner
+    #[attrs(nonpayable, restricted)]
     DeauthorizeContract {
         action: PermissionAction,
         addr: AndrAddr,

--- a/packages/andromeda-non-fungible-tokens/src/marketplace.rs
+++ b/packages/andromeda-non-fungible-tokens/src/marketplace.rs
@@ -46,13 +46,13 @@ pub enum ExecuteMsg {
         token_id: String,
         token_address: String,
     },
-    /// Restricted to owner
+    #[attrs(nonpayable, restricted)]
     AuthorizeContract {
         action: PermissionAction,
         addr: AndrAddr,
         expiration: Option<Expiry>,
     },
-    /// Restricted to owner
+    #[attrs(nonpayable, restricted)]
     DeauthorizeContract {
         action: PermissionAction,
         addr: AndrAddr,

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.1-b.4"
+version = "1.5.1-b.5"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -147,17 +147,11 @@ pub fn authorize_addresses(
 
 pub fn execute_authorize_contract(
     deps: DepsMut,
-    info: MessageInfo,
+    _info: MessageInfo,
     action: PermissionAction,
     address: AndrAddr,
     expiration: Option<Expiry>,
 ) -> Result<Response, ContractError> {
-    let contract = ADOContract::default();
-    ensure!(
-        contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {}
-    );
-
     let permission = expiration.map_or(
         Permission::Local(LocalPermission::whitelisted(None, None)),
         |expiration| Permission::Local(LocalPermission::whitelisted(None, Some(expiration))),
@@ -179,16 +173,10 @@ pub fn execute_authorize_contract(
 
 pub fn execute_deauthorize_contract(
     deps: DepsMut,
-    info: MessageInfo,
+    _info: MessageInfo,
     action: PermissionAction,
     address: AndrAddr,
 ) -> Result<Response, ContractError> {
-    let contract = ADOContract::default();
-    ensure!(
-        contract.is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {}
-    );
-
     let raw_address = address.get_raw_address(&deps.as_ref())?;
 
     ADOContract::remove_permission(deps.storage, action.as_str(), raw_address.to_string())?;


### PR DESCRIPTION
# Motivation
Some ExecuteMsgs had missing attributes, others had the attributes but kept `nonpayable` within the message's function. 
The findings were made by @daniel-wehbe 

# Implementation

Removed the authorization check from authorize and deauthorize contract and implemented the restricted (and nonpayable) attribute to their corresponding messages. 

Removed `nonpayable` and `cw-utils` as a dependency from the crowdfund contract. 

# Testing
No tests were impacted. 

# Version Changes

- `std`: `1.5.1-b.4` -> `1.5.1-b.5`
- `crowdfund`: `2.2.0-beta` -> `2.2.1-b.1`
- `andromeda-non-fungible-tokens`: `1.0.0` -> `1.0.1-b.1`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
