### PR TITLE
fix: macro error crate references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Improved macros and execution flow for AMP [(#741)](https://github.com/andromedaprotocol/andromeda-core/pull/741)
 - chore: remove unused contracts & code [(#790)](https://github.com/andromedaprotocol/andromeda-core/pull/790)
+- fix: macro error crate references [(#799)](https://github.com/andromedaprotocol/andromeda-core/pull/799)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Improved macros and execution flow for AMP [(#741)](https://github.com/andromedaprotocol/andromeda-core/pull/741)
 - chore: remove unused contracts & code [(#790)](https://github.com/andromedaprotocol/andromeda-core/pull/790)
-- fix: macro error crate references [(#799)](https://github.com/andromedaprotocol/andromeda-core/pull/799)
 
 ### Fixed
 
 - fix: permission migration [(#792)](https://github.com/andromedaprotocol/andromeda-core/pull/792)
 - fix: IBC denom casing [(#795)](https://github.com/andromedaprotocol/andromeda-core/pull/795)
+- fix: macro error crate references [(#799)](https://github.com/andromedaprotocol/andromeda-core/pull/799)
 
 ## Release 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.1-b.4"
+version = "1.5.1-b.5"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.1-b.4"
+version = "1.5.1-b.5"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/macros/src/execute.rs
+++ b/packages/std/macros/src/execute.rs
@@ -79,13 +79,13 @@ pub(crate) fn fn_implementation(_attr: TokenStream, item: TokenStream) -> TokenS
                 let is_owner = ctx.contract.is_contract_owner(ctx.deps.storage, info.sender.as_str())?;
                 ::cosmwasm_std::ensure!(
                     is_owner,
-                    ContractError::Unauthorized {}
+                    ::andromeda_std::error::ContractError::Unauthorized {}
                 );
             }
 
             // Check if the message is payable
             if !msg.is_payable() {
-                ::cosmwasm_std::ensure!(info.funds.is_empty(), ContractError::Payment(andromeda_std::error::PaymentError::NonPayable {}));
+                ::cosmwasm_std::ensure!(info.funds.is_empty(), ::andromeda_std::error::ContractError::Payment(::andromeda_std::error::PaymentError::NonPayable {}));
             }
 
 

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -371,7 +371,7 @@ macro_rules! unwrap_amp_msg {
 
             ::cosmwasm_std::ensure!(
                 maybe_amp_msg.is_some(),
-                ContractError::InvalidPacket {
+                ::andromeda_std::error::ContractError::InvalidPacket {
                     error: Some("AMP Packet received with no messages".to_string()),
                 }
             );
@@ -379,7 +379,7 @@ macro_rules! unwrap_amp_msg {
             msg = ::cosmwasm_std::from_json(&amp_msg.message)?;
             ::cosmwasm_std::ensure!(
                 !msg.must_be_direct(),
-                ContractError::InvalidPacket {
+                ::andromeda_std::error::ContractError::InvalidPacket {
                     error: Some(format!(
                         "{} cannot be received via AMP packet",
                         msg.as_ref()


### PR DESCRIPTION
# Motivation

These changes adjust the `unwrap_amp_msg` and `andr_exec_fn` to reference the standard crate's error type directly, this should make it easier for implementations to use their own error types.

# Version Changes

- `std`: `1.5.1-b.4` -> `1.5.1-b.5`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
