### PR TITLE
fix: Duplicate Relay in Kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: permission migration [(#792)](https://github.com/andromedaprotocol/andromeda-core/pull/792)
 - fix: IBC denom casing [(#795)](https://github.com/andromedaprotocol/andromeda-core/pull/795)
 - fix: macro error crate references [(#799)](https://github.com/andromedaprotocol/andromeda-core/pull/799)
+- fix: Prevent duplicate relay in Kernel [(#802)](https://github.com/andromedaprotocol/andromeda-core/pull/802)
+
 
 ## Release 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.1-b.2"
+version = "1.2.1-b.3"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.1-b.5"
+version = "1.5.1-b.6"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/contracts/modules/andromeda-schema/src/query.rs
+++ b/contracts/modules/andromeda-schema/src/query.rs
@@ -56,7 +56,7 @@ fn basic_type_matches(schema: &Value, data: &Value) -> bool {
                         let required_fields = schema.get("required").and_then(|r| r.as_array());
                         if let Some(required_fields) = required_fields {
                             if !required_fields.iter().all(|field| {
-                                field.as_str().map_or(false, |f| data_obj.contains_key(f))
+                                field.as_str().is_some_and(|f| data_obj.contains_key(f))
                             }) {
                                 return false;
                             }

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.1-b.2"
+version = "1.2.1-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -96,6 +96,7 @@ pub fn trigger_relay(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_ibc_transfer_funds_reply(
     deps: DepsMut,
     _info: MessageInfo,

--- a/contracts/os/andromeda-kernel/src/testing/tests.rs
+++ b/contracts/os/andromeda-kernel/src/testing/tests.rs
@@ -571,6 +571,7 @@ fn test_query_pending_packets(
             message: to_json_binary(&"test message").unwrap(),
             funds: coin(amount, "ucosm"),
             channel: channel.to_string(),
+            pending: true,
         };
         CHANNEL_TO_EXECUTE_MSG
             .save(

--- a/packages/deploy/src/os.rs
+++ b/packages/deploy/src/os.rs
@@ -87,9 +87,7 @@ impl OperatingSystemDeployment {
     pub fn instantiate(&self, kernel_address: Option<String>) -> Result<(), DeployError> {
         let sender = self.daemon.sender().address();
 
-        let has_kernel_address = kernel_address
-            .as_ref()
-            .map_or(false, |addr| !addr.is_empty());
+        let has_kernel_address = kernel_address.as_ref().is_some_and(|addr| !addr.is_empty());
         // If kernel address is provided, use it and migrate the contract to the new version
         if has_kernel_address {
             let code_id = self.kernel.code_id().unwrap();

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.1-b.5"
+version = "1.5.1-b.6"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/os/kernel.rs
+++ b/packages/std/src/os/kernel.rs
@@ -206,6 +206,7 @@ pub struct Ics20PacketInfo {
     pub funds: Coin,
     // The restricted wallet will probably already have access to this
     pub channel: String,
+    pub pending: bool,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Motivation

Closes: [ANDC-157](https://linear.app/andromedaprot/issue/ANDC-157/kernel-relay-doesnt-go-in-pending-state-causing-duplicate-relay-spam)

# Implementation
Add ` pub pending: bool` to `Ics20PacketInfo`, if true in `handle_ibc_transfer_funds_reply`, it returns an error. 
After the check it's set to `true` and saved in `CHANNEL_TO_EXECUTE_MSG`. 


# Testing
No tests were affected. 

# Version Changes

- `kernel`: `1.2.1-b.2` -> `1.2.1-b.3`
- `std`: `1.5.1-b.5` -> `1.5.1-b.6`

# Checklist

- [x ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
