### PR TITLE
feat: Recipient in rate limiting withdrawals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: Improved macros and execution flow for AMP [(#741)](https://github.com/andromedaprotocol/andromeda-core/pull/741)
 - chore: remove unused contracts & code [(#790)](https://github.com/andromedaprotocol/andromeda-core/pull/790)
+- feat: Recipient in rate limiting withdrawals [(#804)](https://github.com/andromedaprotocol/andromeda-core/pull/804)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.0-beta"
+version = "2.1.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20",
+ "rstest",
 ]
 
 [[package]]

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -33,3 +33,4 @@ cw-orch = { workspace = true }
 
 [dev-dependencies]
 andromeda-app = { workspace = true }
+rstest = { workspace = true }

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.0-beta"
+version = "2.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/contract.rs
@@ -14,8 +14,8 @@ use andromeda_std::{
     error::ContractError,
 };
 use cosmwasm_std::{
-    ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo,
-    Reply, Response, StdError, SubMsg, Uint128,
+    ensure, entry_point, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply,
+    Response, StdError, SubMsg, Uint128,
 };
 use cw_utils::one_coin;
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/src/testing/tests.rs
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/src/testing/tests.rs
@@ -1,5 +1,5 @@
 use andromeda_std::{
-    amp::{messages::AMPPkt, AndrAddr, Recipient},
+    amp::{AndrAddr, Recipient},
     common::Milliseconds,
     error::ContractError,
 };

--- a/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
+++ b/packages/andromeda-finance/src/rate_limiting_withdrawals.rs
@@ -1,4 +1,6 @@
-use andromeda_std::{andr_exec, andr_instantiate, andr_query, common::MillisecondsDuration};
+use andromeda_std::{
+    amp::Recipient, andr_exec, andr_instantiate, andr_query, common::MillisecondsDuration,
+};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Timestamp, Uint128};
 
@@ -55,6 +57,7 @@ pub enum ExecuteMsg {
     #[attrs(nonpayable)]
     Withdraw {
         amount: Uint128,
+        recipient: Option<Recipient>,
     },
 }
 


### PR DESCRIPTION
# Motivation

These changes add a `Recipient` field to rate limiting withdrawals `Withdraw`.

# Implementation

- Updated the `ExecuteMsg::Withdraw` enum:
```rust
    #[attrs(nonpayable)]
    Withdraw {
        amount: Uint128,
        recipient: Option<Recipient>,
    },
```

# Testing

Added a unit test with a recipient attached

# Version Changes

- `rate-limiting-withdrawals`: `2.1.0-beta` -> `2.1.1-b.1`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
