### PR TITLE
feat: Permissionless Macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Handle username on IBC packets [(#791)](https://github.com/andromedaprotocol/andromeda-core/pull/791)
 - Added Time Gate ADO [(#529)](https://github.com/andromedaprotocol/andromeda-core/pull/529)
 - feat: Add previous hops to AMP packets [(#796)](https://github.com/andromedaprotocol/andromeda-core/pull/796)
+- feat: Permissionless macro attribute [(#812)](https://github.com/andromedaprotocol/andromeda-core/pull/812)
+
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.2.5"
+version = "2.2.6-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-macros"
-version = "1.1.0-b.1"
+version = "1.1.0-b.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.2.5"
+version = "2.2.6-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/testing/tests.rs
@@ -1190,7 +1190,7 @@ fn execute_claim_permission() {
     );
 
     let info = mock_info("owner", &[]);
-    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
     let msg = ExecuteMsg::Claim {
         token_id: MOCK_UNCLAIMED_TOKEN.to_owned(),

--- a/e2e-tests/tests/macro_tests/attrs.rs
+++ b/e2e-tests/tests/macro_tests/attrs.rs
@@ -6,7 +6,7 @@ use andromeda_std::andr_exec;
 #[andr_exec]
 #[cw_serde]
 pub enum TestEnum {
-    #[attrs(restricted, nonpayable, direct)]
+    #[attrs(restricted, nonpayable, direct, permissionless)]
     AllAttrs,
     #[attrs(restricted)]
     Restricted,
@@ -14,20 +14,25 @@ pub enum TestEnum {
     NonPayable,
     #[attrs(direct)]
     Direct,
+    #[attrs(permissionless)]
+    Permissionless,
 }
 
 #[rstest]
-#[case(TestEnum::AllAttrs, true, false, true)]
-#[case(TestEnum::Restricted, true, true, false)]
-#[case(TestEnum::NonPayable, false, false, false)]
-#[case(TestEnum::Direct, false, true, true)]
+#[case(TestEnum::AllAttrs, true, false, true, true)]
+#[case(TestEnum::Restricted, true, true, false, false)]
+#[case(TestEnum::NonPayable, false, false, false, false)]
+#[case(TestEnum::Direct, false, true, true, false)]
+#[case(TestEnum::Permissionless, false, true, false, true)]
 fn test_attrs(
     #[case] test: TestEnum,
     #[case] restricted: bool,
     #[case] payable: bool,
     #[case] direct: bool,
+    #[case] permissionless: bool,
 ) {
     assert_eq!(test.is_restricted(), restricted);
     assert_eq!(test.is_payable(), payable);
     assert_eq!(test.must_be_direct(), direct);
+    assert_eq!(test.is_permissionless(), permissionless);
 }

--- a/packages/std/macros/Cargo.toml
+++ b/packages/std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-macros"
-version = "1.1.0-b.1"
+version = "1.1.0-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Macros for Andromeda Digital Objects"

--- a/packages/std/macros/src/attrs/mod.rs
+++ b/packages/std/macros/src/attrs/mod.rs
@@ -1,12 +1,14 @@
 mod direct;
 mod handler;
 mod payable;
+mod permissionless;
 mod restricted;
 mod utils;
 
 use direct::DirectAttribute;
 use handler::AttributeHandler;
 use payable::NonPayableAttribute;
+use permissionless::PermissionlessAttribute;
 use proc_macro::TokenStream;
 use quote::quote;
 use restricted::RestrictedAttribute;
@@ -25,6 +27,7 @@ pub fn derive_execute_attrs(input: TokenStream) -> TokenStream {
                 Box::new(NonPayableAttribute),
                 Box::new(RestrictedAttribute),
                 Box::new(DirectAttribute),
+                Box::new(PermissionlessAttribute),
             ];
 
             // Process variants and generate implementations for each handler

--- a/packages/std/macros/src/attrs/permissionless.rs
+++ b/packages/std/macros/src/attrs/permissionless.rs
@@ -1,0 +1,60 @@
+use super::{handler::AttributeHandler, utils::generate_match_pattern};
+use quote::quote;
+
+const ATTR_KEY: &str = "permissionless";
+/**
+ * PermissionlessAttribute is used to indicate that a message can not be permissioned.
+ *
+ * Example usage:
+ * ```rust
+ * #[andr_exec]
+ * enum ExecuteMsg {
+ *     #[attrs(permissionless)]
+ *     MyMessage{..},
+ * }
+ * ```
+ */
+pub struct PermissionlessAttribute;
+
+impl AttributeHandler for PermissionlessAttribute {
+    fn check_attribute(&self, attr: &syn::Attribute) -> bool {
+        if attr.path().is_ident("attrs") {
+            let mut is_permissionless = false;
+            attr.parse_args_with(|input: syn::parse::ParseStream| {
+                while !input.is_empty() {
+                    let ident: syn::Ident = input.parse()?;
+                    if ident == ATTR_KEY {
+                        is_permissionless = true;
+                    }
+                    if !input.is_empty() {
+                        input.parse::<syn::Token![,]>()?;
+                    }
+                }
+                Ok(())
+            })
+            .unwrap_or(());
+            return is_permissionless;
+        }
+        false
+    }
+
+    fn generate_impl(
+        &self,
+        data_enum: &syn::DataEnum,
+        variants: &[(syn::Ident, bool)],
+    ) -> proc_macro2::TokenStream {
+        let match_arms = variants.iter().map(|(variant_name, is_permissionless)| {
+            let pattern = generate_match_pattern(data_enum, variant_name);
+            quote! { #pattern => !#is_permissionless }
+        });
+
+        quote! {
+            #[inline]
+            pub fn is_permissionless(&self) -> bool {
+                match self {
+                    #(#match_arms,)*
+                }
+            }
+        }
+    }
+}

--- a/packages/std/macros/src/attrs/permissionless.rs
+++ b/packages/std/macros/src/attrs/permissionless.rs
@@ -45,7 +45,7 @@ impl AttributeHandler for PermissionlessAttribute {
     ) -> proc_macro2::TokenStream {
         let match_arms = variants.iter().map(|(variant_name, is_permissionless)| {
             let pattern = generate_match_pattern(data_enum, variant_name);
-            quote! { #pattern => !#is_permissionless }
+            quote! { #pattern => #is_permissionless }
         });
 
         quote! {

--- a/packages/std/macros/src/execute.rs
+++ b/packages/std/macros/src/execute.rs
@@ -88,12 +88,6 @@ pub(crate) fn fn_implementation(_attr: TokenStream, item: TokenStream) -> TokenS
                 ::cosmwasm_std::ensure!(info.funds.is_empty(), ::andromeda_std::error::ContractError::Payment(::andromeda_std::error::PaymentError::NonPayable {}));
             }
 
-            // Check if the message is permissionless
-            if msg.is_permissionless() {
-                // Make sure the message is not a Permission Message
-
-            }
-
             let res = execute_inner(ctx, msg)?;
 
             Ok(res

--- a/packages/std/macros/src/execute.rs
+++ b/packages/std/macros/src/execute.rs
@@ -88,6 +88,11 @@ pub(crate) fn fn_implementation(_attr: TokenStream, item: TokenStream) -> TokenS
                 ::cosmwasm_std::ensure!(info.funds.is_empty(), ::andromeda_std::error::ContractError::Payment(::andromeda_std::error::PaymentError::NonPayable {}));
             }
 
+            // Check if the message is permissionless
+            if msg.is_permissionless() {
+                // Make sure the message is not a Permission Message
+
+            }
 
             let res = execute_inner(ctx, msg)?;
 

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -386,25 +386,24 @@ macro_rules! unwrap_amp_msg {
                     )),
                 }
             );
+
             ctx.deps
                 .api
                 .debug(&format!("Unwrapped msg: {:?}", msg.as_ref()));
             ctx.amp_ctx = Some(pkt);
         }
 
-        if let ExecuteMsg::Permissioning(msg) = msg {
-            // Extract action from the permissioning message (all of them have an action field)
-            let action = match msg {
-                PermissioningMessage::SetPermission { action, .. } => action,
-                PermissioningMessage::RemovePermission { action, .. } => action,
-                PermissioningMessage::PermissionAction { action } => action,
-                PermissioningMessage::DisableActionPermissioning { action } => action,
-            };
-            // Find the ExecuteMsg corresponding to the action
-
-            // Check if the ExecuteMsg is permissionless
-
-            // Return error if it is permissionless
+        if !msg.is_permissionless() {
+            ::cosmwasm_std::ensure!(
+                ::andromeda_std::ado_contract::permissioning::is_context_permissioned(
+                    &mut ctx.deps,
+                    &ctx.info,
+                    &ctx.env,
+                    &ctx.amp_ctx,
+                    msg.as_ref(),
+                )?,
+                ::andromeda_std::error::ContractError::Unauthorized {}
+            );
         }
 
         let action_response = andromeda_std::common::actions::call_action(

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -392,6 +392,21 @@ macro_rules! unwrap_amp_msg {
             ctx.amp_ctx = Some(pkt);
         }
 
+        if let ExecuteMsg::Permissioning(msg) = msg {
+            // Extract action from the permissioning message (all of them have an action field)
+            let action = match msg {
+                PermissioningMessage::SetPermission { action, .. } => action,
+                PermissioningMessage::RemovePermission { action, .. } => action,
+                PermissioningMessage::PermissionAction { action } => action,
+                PermissioningMessage::DisableActionPermissioning { action } => action,
+            };
+            // Find the ExecuteMsg corresponding to the action
+
+            // Check if the ExecuteMsg is permissionless
+
+            // Return error if it is permissionless
+        }
+
         let action_response = andromeda_std::common::actions::call_action(
             &mut ctx.deps,
             &ctx.info,

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -393,18 +393,17 @@ macro_rules! unwrap_amp_msg {
             ctx.amp_ctx = Some(pkt);
         }
 
-        if !msg.is_permissionless() {
-            ::cosmwasm_std::ensure!(
-                ::andromeda_std::ado_contract::permissioning::is_context_permissioned(
+        ::cosmwasm_std::ensure!(
+            msg.is_permissionless()
+                || ::andromeda_std::ado_contract::permissioning::is_context_permissioned(
                     &mut ctx.deps,
                     &ctx.info,
                     &ctx.env,
                     &ctx.amp_ctx,
                     msg.as_ref(),
                 )?,
-                ::andromeda_std::error::ContractError::Unauthorized {}
-            );
-        }
+            ::andromeda_std::error::ContractError::Unauthorized {}
+        );
 
         let action_response = andromeda_std::common::actions::call_action(
             &mut ctx.deps,

--- a/packages/std/src/common/actions.rs
+++ b/packages/std/src/common/actions.rs
@@ -1,10 +1,8 @@
 use crate::{
-    ado_contract::{permissioning::is_context_permissioned, ADOContract},
-    amp::messages::AMPPkt,
-    error::ContractError,
+    ado_contract::ADOContract, amp::messages::AMPPkt, error::ContractError,
     os::aos_querier::AOSQuerier,
 };
-use cosmwasm_std::{ensure, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 
 pub fn call_action(
     deps: &mut DepsMut,
@@ -13,11 +11,6 @@ pub fn call_action(
     amp_ctx: &Option<AMPPkt>,
     action: &str,
 ) -> Result<Response, ContractError> {
-    ensure!(
-        is_context_permissioned(deps, info, env, amp_ctx, action)?,
-        ContractError::Unauthorized {}
-    );
-
     let payee = if let Some(amp_ctx) = amp_ctx.clone() {
         deps.api.addr_validate(amp_ctx.ctx.get_origin().as_str())?
     } else {


### PR DESCRIPTION
# Motivation

Closes: [ANDC-164](https://linear.app/andromedaprot/issue/ANDC-164/permissionless-attribute)

# Implementation
Similar implementation to the other macros. 
Moved permission checks from `call_action` to `unwrap_amp_msg` and is called only if the message isn't permissionless. 
Users can still set permissions to any message, but they'll only be applied for non-permissionless messages. 

# Testing
One unit test "execute_claim_permission"

# Version Changes
`andromeda-macros`: `1.1.0-b.1` -> `1.1.0-b.2`
`andromeda-auction`: `2.2.5` -> `2.2.6-b.1`

# Checklist

- [ x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
