### PR TITLE
fix: ibc username not working for ibc send with funds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - chore: refactored tests to be more readable [(#808)](https://github.com/andromedaprotocol/andromeda-core/pull/808)
 
 ### Added
@@ -27,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: IBC denom casing [(#795)](https://github.com/andromedaprotocol/andromeda-core/pull/795)
 - fix: macro error crate references [(#799)](https://github.com/andromedaprotocol/andromeda-core/pull/799)
 - fix: Prevent duplicate relay in Kernel [(#802)](https://github.com/andromedaprotocol/andromeda-core/pull/802)
-
+- fix: ibc username not working for ibc send with funds [(#814)](https://github.com/andromedaprotocol/andromeda-core/pull/814)
 
 ## Release 4
 

--- a/contracts/os/andromeda-kernel/src/ibc.rs
+++ b/contracts/os/andromeda-kernel/src/ibc.rs
@@ -163,7 +163,7 @@ pub fn do_ibc_packet_receive(
                     }
                 }
                 None => {
-                    execute_env.amp_ctx = Some(amp_packet.clone());
+                    execute_env.amp_ctx = None;
                 }
             }
 
@@ -189,29 +189,38 @@ pub fn do_ibc_packet_receive(
                 funds: vec![funds.clone()],
                 sender: env.contract.address.clone(),
             };
-            // Add potential username to the context
-            let mut ctx = AMPCtx::new(
-                original_sender.clone(),
-                env.contract.address,
-                0,
-                original_sender_username,
-            );
-            // Add previous hops to the context
-            for hop in previous_hops {
-                ctx.add_hop(hop);
+            // Attempt to fetch the address for the original sender by their username
+            let vfs_address = KERNEL_ADDRESSES.load(execute_env.deps.storage, VFS_KEY)?;
+            let username_addr = if let Some(username) = original_sender_username.clone() {
+                AOSQuerier::get_address_from_username(
+                    &execute_env.deps.querier,
+                    &vfs_address,
+                    username.as_str(),
+                )?
+            } else {
+                None
+            };
+            let msg = AMPMsg::new(recipient.clone(), message, Some(vec![funds.clone()]));
+            match username_addr {
+                Some(addr) => {
+                    // Add potential username to the context
+                    let mut ctx =
+                        AMPCtx::new(addr, env.contract.address, 0, original_sender_username);
+                    // Add previous hops to the context
+                    for hop in previous_hops {
+                        ctx.add_hop(hop);
+                    }
+
+                    let amp_packet = AMPPkt::new_with_ctx(ctx, vec![msg.clone()]);
+                    execute_env.amp_ctx = Some(amp_packet.clone());
+                }
+                // If the original sender does not have a username registered on this chain we cannot use AMP
+                None => {
+                    execute_env.amp_ctx = None;
+                }
             }
 
-            let amp_packet = AMPPkt::new_with_ctx(
-                ctx,
-                vec![AMPMsg::new(
-                    recipient.clone(),
-                    message,
-                    Some(vec![funds.clone()]),
-                )],
-            );
-            execute_env.amp_ctx = Some(amp_packet.clone());
-
-            let res = execute::send(execute_env, amp_packet.messages.first().unwrap().clone())?;
+            let res = execute::send(execute_env, msg)?;
 
             // Refunds must be done via the ICS20 channel
             let ics20_channel_id = channel_info


### PR DESCRIPTION
# Motivation

When sending an IBC message with funds we were not correctly setting the origin or removing the AMP packet structure if the user did not have a username registered.

# Implementation

- Implemented attempt to get username from the sent packet similar to messages without funds.

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
