### PR TITLE
fix: build script for updated ibc tests dir

### DIFF
--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/interface.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/interface.rs
@@ -1,7 +1,7 @@
 use andromeda_fungible_tokens::airdrop::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{ado_base::MigrateMsg, contract_interface, deploy::ADOMetadata};
 
-pub const CONTRACT_ID: &str = "merkle_airdrop";
+pub const CONTRACT_ID: &str = "merkle-airdrop";
 
 contract_interface!(
     MerkleAirdropContract,

--- a/contracts/modules/andromeda-address-list/src/interface.rs
+++ b/contracts/modules/andromeda-address-list/src/interface.rs
@@ -1,7 +1,7 @@
 use andromeda_modules::address_list::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{ado_base::MigrateMsg, contract_interface, deploy::ADOMetadata};
 
-pub const CONTRACT_ID: &str = "address_list";
+pub const CONTRACT_ID: &str = "address-list";
 
 contract_interface!(
     AddressListContract,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,7 +30,7 @@ build_contract () {
     
     local IN_FILE="./target/wasm32-unknown-unknown/release/$BUILD_TARGET.wasm"
     local OUT_FILE="./artifacts/$BUILD_TARGET.wasm"
-    local OUT_FILE_IBC_TEST="./ibc-tests/artifacts/$BUILD_TARGET.wasm"
+    local OUT_FILE_IBC_TEST="./tests/ibc-tests/artifacts/$BUILD_TARGET.wasm"
     local OUT_FILE_PACKAGE="./packages/andromeda-testing-e2e/artifacts/$BUILD_TARGET.wasm"
 
     wasm-opt -Os $IN_FILE -o $OUT_FILE
@@ -90,10 +90,10 @@ export RUSTFLAGS="-C link-arg=-s"
 rm -rf ./target
 rm -rf ./artifacts
 rm -rf ./packages/andromeda-testing-e2e/artifacts
-rm -rf ./ibc-tests/artifacts
+rm -rf ./tests/ibc-tests/artifacts
 mkdir artifacts
 mkdir packages/andromeda-testing-e2e/artifacts
-mkdir ibc-tests/artifacts
+mkdir tests/ibc-tests/artifacts
 
 set -e
 for target in "$@"; do


### PR DESCRIPTION
# Motivation

Fix broken directory for build scirpts

# Implementation

- Changed `ibc-tests/artifacts` to `tests/ibc-tests/artifacts`

# Testing

- `make build-contract` working locally for splitter

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
