### PR TITLE
fix: apply serde default for previous_hops 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.1-b.6"
+version = "1.5.1-b.7"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.1-b.6"
+version = "1.5.1-b.7"
 edition = "2021"
 rust-version = "1.75.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -218,6 +218,7 @@ pub struct AMPCtx {
     origin_username: Option<AndrAddr>,
     pub previous_sender: String,
     pub id: u64,
+    #[serde(default)]
     pub previous_hops: Vec<CrossChainHop>,
 }
 


### PR DESCRIPTION
# Motivation
Old ADOs became incompatible with the updated kernel after adding `previous_hops` field to `AMPCtx`.

# Implementation
Added `#[serde(default)]` to `previous_hops` in `AMPCtx`

# Testing
None

# Version Changes
- `andromeda-std`: `1.5.1-b.6` -> `1.5.1-b.7`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
