### PR TITLE
CW20 Redeem ADO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Batch send NFTs [(#816)](https://github.com/andromedaprotocol/andromeda-core/pull/816)
 - feat: Added Permissionless attribute to relevant messages [(#825)](https://github.com/andromedaprotocol/andromeda-core/pull/825)
 - feat: Apply Serde default to previous_hops [(#829)](https://github.com/andromedaprotocol/andromeda-core/pull/829)
+- feat: CW20 Redeem ADO [(#842)](https://github.com/andromedaprotocol/andromeda-core/pull/842)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20",
+ "rstest",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "andromeda-cw20-redeem"
+version = "2.1.0"
+dependencies = [
+ "andromeda-app",
+ "andromeda-fungible-tokens",
+ "andromeda-std",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-asset",
+ "cw-multi-test",
+ "cw-orch",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw20",
+]
+
+[[package]]
 name = "andromeda-cw20-staking"
 version = "2.1.1-b.1"
 dependencies = [
@@ -359,6 +376,7 @@ dependencies = [
  "andromeda-curve",
  "andromeda-cw20",
  "andromeda-cw20-exchange",
+ "andromeda-cw20-redeem",
  "andromeda-cw20-staking",
  "andromeda-cw721",
  "andromeda-date-time",
@@ -5081,6 +5099,7 @@ dependencies = [
  "andromeda-crowdfund",
  "andromeda-curve",
  "andromeda-cw20",
+ "andromeda-cw20-redeem",
  "andromeda-cw20-staking",
  "andromeda-cw721",
  "andromeda-data-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-exchange"
-version = "2.1.0"
+version = "2.1.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-redeem"
-version = "2.1.0"
+version = "0.1.0-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",

--- a/contracts/app/andromeda-app-contract/src/execute.rs
+++ b/contracts/app/andromeda-app-contract/src/execute.rs
@@ -38,8 +38,8 @@ pub fn handle_add_app_component(
     let idx = add_app_component(ctx.deps.storage, &component)?;
     ensure!(idx < 50, ContractError::TooManyAppComponents {});
 
-    let adodb_addr = ADOContract::default().get_adodb_address(ctx.deps.storage, querier)?;
-    let vfs_addr = ADOContract::default().get_vfs_address(ctx.deps.storage, querier)?;
+    let adodb_addr = ctx.contract.get_adodb_address(ctx.deps.storage, querier)?;
+    let vfs_addr = ctx.contract.get_vfs_address(ctx.deps.storage, querier)?;
 
     let mut resp = Response::new()
         .add_attribute("method", "add_app_component")
@@ -198,7 +198,7 @@ pub fn update_address(
         .add_attribute("address", addr.clone());
 
     if !name.starts_with('.') {
-        let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
+        let kernel_address = ctx.contract.get_kernel_address(deps.storage)?;
         let register_component_path_msg = register_component_path(
             kernel_address,
             &deps.querier,

--- a/contracts/data-storage/andromeda-boolean/src/execute.rs
+++ b/contracts/data-storage/andromeda-boolean/src/execute.rs
@@ -42,7 +42,7 @@ pub fn set_value(
         ensure!(has_permission, ContractError::Unauthorized {});
     } else if restriction == BooleanRestriction::Restricted {
         let addr = sender.as_str();
-        let is_operator = ADOContract::default().is_owner_or_operator(ctx.deps.storage, addr)?;
+        let is_operator = ctx.contract.is_owner_or_operator(ctx.deps.storage, addr)?;
         let allowed = match DATA_OWNER.load(ctx.deps.storage).ok() {
             Some(owner) => addr == owner,
             None => true,
@@ -89,7 +89,7 @@ pub fn delete_value(mut ctx: ExecuteContext) -> Result<Response, ContractError> 
         ensure!(has_permission, ContractError::Unauthorized {});
     } else if restriction == BooleanRestriction::Restricted {
         let addr = sender.as_str();
-        let is_operator = ADOContract::default().is_owner_or_operator(ctx.deps.storage, addr)?;
+        let is_operator = ctx.contract.is_owner_or_operator(ctx.deps.storage, addr)?;
         let allowed = match DATA_OWNER.load(ctx.deps.storage).ok() {
             Some(owner) => addr == owner,
             None => true,

--- a/contracts/data-storage/andromeda-form/src/execute.rs
+++ b/contracts/data-storage/andromeda-form/src/execute.rs
@@ -1,7 +1,6 @@
 use andromeda_data_storage::form::SubmissionInfo;
 use andromeda_modules::schema::{QueryMsg as SchemaQueryMsg, ValidateDataResponse};
 use andromeda_std::{
-    ado_contract::ADOContract,
     amp::AndrAddr,
     common::{context::ExecuteContext, encode_binary, Milliseconds},
     error::ContractError,
@@ -21,7 +20,7 @@ pub fn execute_submit_form(
     data: String,
 ) -> Result<Response, ContractError> {
     let sender = ctx.info.sender;
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         SUBMIT_FORM_ACTION,

--- a/contracts/finance/andromeda-conditional-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/contract.rs
@@ -168,7 +168,7 @@ fn execute_send(ctx: ExecuteContext) -> Result<Response, ContractError> {
         })));
     }
     if !pkt.messages.is_empty() {
-        let kernel_address = ADOContract::default().get_kernel_address(deps.as_ref().storage)?;
+        let kernel_address = ctx.contract.get_kernel_address(deps.as_ref().storage)?;
         let distro_msg = pkt.to_sub_msg(kernel_address, Some(amp_funds), 1)?;
         msgs.push(distro_msg);
     }

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/contract.rs
@@ -206,7 +206,7 @@ fn execute_send_cw20(
         msgs.push(cw20_msg);
     }
 
-    let kernel_address = ADOContract::default().get_kernel_address(deps.as_ref().storage)?;
+    let kernel_address = ctx.contract.get_kernel_address(deps.as_ref().storage)?;
     if !pkt.messages.is_empty() && !amp_funds.is_empty() {
         let distro_msg = pkt.to_sub_msg_cw20(kernel_address, amp_funds.clone(), 1)?;
         msgs.push(distro_msg.clone());
@@ -342,7 +342,7 @@ fn execute_send(
         }
     }
 
-    let kernel_address = ADOContract::default().get_kernel_address(deps.as_ref().storage)?;
+    let kernel_address = ctx.contract.get_kernel_address(deps.as_ref().storage)?;
 
     if !pkt.messages.is_empty() {
         let distro_msg = pkt.to_sub_msg(kernel_address, Some(amp_funds), 1)?;

--- a/contracts/finance/andromeda-splitter/src/contract.rs
+++ b/contracts/finance/andromeda-splitter/src/contract.rs
@@ -267,7 +267,7 @@ fn execute_send_cw20(
         msgs.push(cw20_msg);
     }
 
-    let kernel_address = ADOContract::default().get_kernel_address(deps.as_ref().storage)?;
+    let kernel_address = ctx.contract.get_kernel_address(deps.as_ref().storage)?;
     if !pkt.messages.is_empty() && !amp_funds.is_empty() {
         let distro_msg = pkt.to_sub_msg_cw20(kernel_address, amp_funds.clone(), 1)?;
         msgs.push(distro_msg.clone());

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -322,12 +322,8 @@ fn execute_claim(
     // Only one denom is allowed to be restaked at a time
     let res = if restake && res.accumulated_rewards.len() == 1 {
         // Only the contract owner and permissioned actors can restake
-        ctx.contract.is_permissioned(
-            deps.branch(),
-            env,
-            RESTAKING_ACTION,
-            info.sender,
-        )?;
+        ctx.contract
+            .is_permissioned(deps.branch(), env, RESTAKING_ACTION, info.sender)?;
         RESTAKING_QUEUE.save(deps.storage, &res)?;
         Response::new()
             .add_submessage(SubMsg::reply_always(
@@ -339,7 +335,8 @@ fn execute_claim(
     } else {
         // Ensure msg sender is the contract owner
         ensure!(
-            ctx.contract.is_contract_owner(deps.storage, info.sender.as_str())?,
+            ctx.contract
+                .is_contract_owner(deps.storage, info.sender.as_str())?,
             ContractError::Unauthorized {}
         );
         Response::new()

--- a/contracts/finance/andromeda-validator-staking/src/contract.rs
+++ b/contracts/finance/andromeda-validator-staking/src/contract.rs
@@ -295,7 +295,7 @@ fn execute_claim(
         ContractError::InvalidClaim {}
     );
 
-    let kernel_addr = ADOContract::default().get_kernel_address(deps.storage)?;
+    let kernel_addr = ctx.contract.get_kernel_address(deps.storage)?;
 
     let is_andromeda_distribution = AOSQuerier::get_env_variable::<String>(
         &deps.querier,
@@ -322,7 +322,7 @@ fn execute_claim(
     // Only one denom is allowed to be restaked at a time
     let res = if restake && res.accumulated_rewards.len() == 1 {
         // Only the contract owner and permissioned actors can restake
-        ADOContract::default().is_permissioned(
+        ctx.contract.is_permissioned(
             deps.branch(),
             env,
             RESTAKING_ACTION,
@@ -339,7 +339,7 @@ fn execute_claim(
     } else {
         // Ensure msg sender is the contract owner
         ensure!(
-            ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+            ctx.contract.is_contract_owner(deps.storage, info.sender.as_str())?,
             ContractError::Unauthorized {}
         );
         Response::new()

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-exchange"
-version = "2.1.0"
+version = "2.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -158,7 +158,7 @@ pub fn execute_start_sale(
         ContractError::InvalidZeroAmount {}
     );
     ensure!(
-        ADOContract::default().is_contract_owner(deps.storage, &sender)?,
+        ctx.contract.is_contract_owner(deps.storage, &sender)?,
         ContractError::Unauthorized {}
     );
     // Message sender in this case should be the token address

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -9,13 +9,14 @@ use andromeda_std::{
     common::{
         context::ExecuteContext,
         expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},
+        msg_generation::generate_transfer_message,
         Milliseconds, MillisecondsDuration,
     },
     error::ContractError,
 };
 use cosmwasm_std::{
-    attr, coin, ensure, entry_point, from_json, to_json_binary, wasm_execute, BankMsg, Binary,
-    CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
+    attr, ensure, entry_point, from_json, to_json_binary, wasm_execute, Binary, CosmosMsg, Deps,
+    DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
@@ -208,34 +209,6 @@ pub fn execute_start_sale(
     ]))
 }
 
-/// Generates a transfer message given an asset and an amount
-fn generate_transfer_message(
-    asset: AssetInfo,
-    amount: Uint128,
-    recipient: String,
-    id: u64,
-) -> Result<SubMsg, ContractError> {
-    match asset.clone() {
-        AssetInfo::Native(denom) => {
-            let bank_msg = BankMsg::Send {
-                to_address: recipient,
-                amount: vec![coin(amount.u128(), denom)],
-            };
-
-            Ok(SubMsg::reply_on_error(CosmosMsg::Bank(bank_msg), id))
-        }
-        AssetInfo::Cw20(addr) => {
-            let transfer_msg = Cw20ExecuteMsg::Transfer { recipient, amount };
-            let wasm_msg = wasm_execute(addr, &transfer_msg, vec![])?;
-            Ok(SubMsg::reply_on_error(CosmosMsg::Wasm(wasm_msg), id))
-        }
-        // Does not support 1155 currently
-        _ => Err(ContractError::InvalidAsset {
-            asset: asset.to_string(),
-        }),
-    }
-}
-
 pub fn execute_purchase(
     ctx: ExecuteContext,
     amount_sent: Uint128,
@@ -281,7 +254,7 @@ pub fn execute_purchase(
                 asset_sent.clone(),
                 remainder,
                 sender.to_string(),
-                REFUND_REPLY_ID,
+                Some(REFUND_REPLY_ID),
             )?)
             .add_attribute("refunded_amount", remainder);
     }
@@ -309,7 +282,7 @@ pub fn execute_purchase(
         asset_sent.clone(),
         amount_sent - remainder,
         sale.recipient.clone(),
-        RECIPIENT_REPLY_ID,
+        Some(RECIPIENT_REPLY_ID),
     )?);
 
     Ok(resp.add_attributes(vec![
@@ -368,7 +341,7 @@ pub fn execute_cancel_sale(
                 token,
                 sale.amount,
                 info.sender.to_string(),
-                REFUND_REPLY_ID,
+                Some(REFUND_REPLY_ID),
             )?)
             .add_attribute("refunded_amount", sale.amount);
     }

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -339,9 +339,7 @@ pub fn execute_purchase_native(
     let sender = info.sender.to_string();
 
     // Only allow one coin for purchasing
-    one_coin(info)?;
-
-    let payment = info.funds.first().unwrap();
+    let payment = one_coin(info)?;
     let asset = AssetInfo::Native(payment.denom.to_string());
     let amount = payment.amount;
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -195,7 +195,6 @@ pub fn execute_start_sale(
         recipient: recipient.unwrap_or(sender),
         start_time: start_expiration,
         end_time: end_expiration,
-        start_amount: amount,
     };
     SALE.save(deps.storage, &asset.to_string(), &sale)?;
 
@@ -206,7 +205,6 @@ pub fn execute_start_sale(
         attr("amount", amount),
         attr("start_time", start_expiration.to_string()),
         attr("end_time", end_expiration.to_string()),
-        attr("start_amount", amount),
     ]))
 }
 

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/testing/tests.rs
@@ -391,7 +391,6 @@ pub fn test_purchase_not_enough_sent() {
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -438,7 +437,6 @@ pub fn test_purchase_no_tokens_left() {
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
             end_time: Expiration::Never {},
-            start_amount: Uint128::zero(),
         },
     )
     .unwrap();
@@ -479,9 +477,7 @@ pub fn test_purchase_not_enough_tokens() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::one(),
         },
     )
     .unwrap();
@@ -523,9 +519,7 @@ pub fn test_purchase() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -611,7 +605,6 @@ pub fn test_purchase_with_start_and_duration() {
             start_time: Expiration::AtTime(env.block.time.minus_nanos(1)),
             // end time in the future
             end_time: Expiration::AtTime(env.block.time.plus_nanos(1)),
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -695,7 +688,6 @@ pub fn test_purchase_sale_not_started() {
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time.plus_nanos(1)),
             end_time: Expiration::Never {},
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -738,7 +730,6 @@ pub fn test_purchase_sale_duration_ended() {
             start_time: Expiration::AtTime(env.block.time),
 
             end_time: Expiration::AtTime(env.block.time.minus_nanos(1)),
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -793,9 +784,7 @@ pub fn test_purchase_not_enough_sent_native() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -833,9 +822,7 @@ pub fn test_purchase_no_tokens_left_native() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::zero(),
         },
     )
     .unwrap();
@@ -869,9 +856,7 @@ pub fn test_purchase_not_enough_tokens_native() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(1u128),
         },
     )
     .unwrap();
@@ -907,9 +892,7 @@ pub fn test_purchase_native() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -985,9 +968,7 @@ pub fn test_purchase_refund() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -1035,9 +1016,7 @@ pub fn test_cancel_sale_unauthorised() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -1094,7 +1073,6 @@ pub fn test_cancel_sale() {
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
             end_time: Expiration::Never {},
-            start_amount: sale_amount,
         },
     )
     .unwrap();
@@ -1154,7 +1132,6 @@ fn test_query_sale() {
         start_time: Expiration::AtTime(env.block.time),
 
         end_time: Expiration::Never {},
-        start_amount: sale_amount,
     };
     SALE.save(deps.as_mut().storage, &exchange_asset.to_string(), &sale)
         .unwrap();
@@ -1193,7 +1170,6 @@ fn test_andr_query() {
         start_time: Expiration::AtTime(env.block.time),
 
         end_time: Expiration::Never {},
-        start_amount: sale_amount,
     };
     SALE.save(deps.as_mut().storage, &exchange_asset.to_string(), &sale)
         .unwrap();
@@ -1233,9 +1209,7 @@ fn test_purchase_native_invalid_coins() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -1287,9 +1261,7 @@ fn test_query_sale_assets() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();
@@ -1301,9 +1273,7 @@ fn test_query_sale_assets() {
             exchange_rate,
             recipient: owner.to_string(),
             start_time: Expiration::AtTime(env.block.time),
-
             end_time: Expiration::Never {},
-            start_amount: Uint128::from(100u128),
         },
     )
     .unwrap();

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/.cargo/config
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/Cargo.toml
@@ -32,3 +32,4 @@ cw-orch = { workspace = true }
 
 [dev-dependencies]
 andromeda-app = { workspace = true }
+rstest = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-redeem"
-version = "2.1.0"
+version = "0.1.0-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "andromeda-cw20-redeem"
+version = "2.1.0"
+edition = "2021"
+rust-version = "1.75.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+testing = ["cw-multi-test"]
+
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw-utils = { workspace = true }
+cw20 = { workspace = true }
+cw-asset = { workspace = true }
+
+andromeda-std = { workspace = true }
+andromeda-fungible-tokens = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cw-multi-test = { workspace = true, optional = true }
+cw-orch = { workspace = true }
+
+[dev-dependencies]
+andromeda-app = { workspace = true }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/README.md
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/README.md
@@ -1,0 +1,12 @@
+# Overview
+
+The CW20 Exchange ADO is used to sell CW20 tokens for other assets. The CW20 token to be sold is specified at instantiation, and then sales can be started on the token by the contract owner by sending them to this ADO. Each sale has an "asset" to purchase the tokens with. This asset can be:
+
+- CW20 
+- Native
+
+Users can then purchase the CW20 token being sold by sending the required asset to the contract.
+
+[CW20 Exchange Full Documentation](https://docs.andromedaprotocol.io/andromeda/andromeda-digital-objects/cw20-exchange)
+
+

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/examples/schema.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/examples/schema.rs
@@ -1,0 +1,16 @@
+use std::env::current_dir;
+
+use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
+
+use andromeda_fungible_tokens::cw20_redeem::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+        execute: ExecuteMsg,
+    };
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20redeem");
+}

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
@@ -1,0 +1,442 @@
+use andromeda_fungible_tokens::cw20_redeem::{
+    Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, RedemptionAssetResponse, RedemptionClause,
+    RedemptionResponse, TokenAddressResponse,
+};
+use andromeda_std::{
+    ado_base::{InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
+    ado_contract::ADOContract,
+    andr_execute_fn,
+    common::{
+        context::ExecuteContext,
+        expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},
+        Milliseconds, MillisecondsDuration,
+    },
+    error::ContractError,
+};
+use cosmwasm_std::{
+    attr, coin, ensure, entry_point, from_json, to_json_binary, wasm_execute, BankMsg, Binary,
+    CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, SubMsg, Uint128,
+};
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
+use cw_asset::AssetInfo;
+use cw_utils::{one_coin, Expiration};
+
+use crate::state::{REDEMPTION_CLAUSE, TOKEN_ADDRESS};
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:andromeda-cw20-redeem";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// ID used for any refund sub messgaes
+const REFUND_REPLY_ID: u64 = 1;
+/// ID used for any purchased token transfer sub messages
+// const PURCHASE_REPLY_ID: u64 = 2;
+/// ID used for transfer to sale recipient
+const RECIPIENT_REPLY_ID: u64 = 3;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    TOKEN_ADDRESS.save(deps.storage, &msg.token_address)?;
+
+    let contract = ADOContract::default();
+    let resp = contract.instantiate(
+        deps.storage,
+        env,
+        deps.api,
+        &deps.querier,
+        info,
+        BaseInstantiateMsg {
+            ado_type: CONTRACT_NAME.to_string(),
+            ado_version: CONTRACT_VERSION.to_string(),
+            kernel_address: msg.kernel_address,
+            owner: msg.owner,
+        },
+    )?;
+
+    Ok(resp)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    if msg.result.is_err() {
+        return Err(ContractError::Std(StdError::generic_err(
+            msg.result.unwrap_err(),
+        )));
+    }
+
+    Ok(Response::default())
+}
+
+#[andr_execute_fn]
+pub fn execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Receive(cw20_msg) => execute_receive(ctx, cw20_msg),
+        ExecuteMsg::SetRedemptionClause {
+            exchange_rate,
+            start_time,
+            duration,
+        } => execute_set_redemption_clause_native(ctx, exchange_rate, start_time, duration),
+        ExecuteMsg::CancelRedemptionClause {} => execute_cancel_redemption_clause(ctx),
+        _ => ADOContract::default().execute(ctx, msg),
+    }
+}
+
+pub fn execute_receive(
+    ctx: ExecuteContext,
+    receive_msg: Cw20ReceiveMsg,
+) -> Result<Response, ContractError> {
+    let ExecuteContext { ref info, .. } = ctx;
+    let asset_sent = AssetInfo::Cw20(info.sender.clone());
+    let amount_sent = receive_msg.amount;
+    let sender = receive_msg.sender;
+
+    ensure!(
+        !amount_sent.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Cannot send a 0 amount".to_string()
+        }
+    );
+
+    match from_json(&receive_msg.msg)? {
+        Cw20HookMsg::StartRedemptionClause {
+            exchange_rate,
+            start_time,
+            duration,
+        } => execute_set_redemption_clause_cw20(
+            ctx,
+            amount_sent,
+            asset_sent,
+            sender,
+            exchange_rate,
+            start_time,
+            duration,
+        ),
+        Cw20HookMsg::Redeem {} => execute_redeem(ctx, amount_sent, asset_sent, &sender),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_set_redemption_clause_cw20(
+    ctx: ExecuteContext,
+    amount_sent: Uint128,
+    asset_sent: AssetInfo,
+    sender: String,
+    exchange_rate: Uint128,
+    start_time: Option<Expiry>,
+    duration: Option<MillisecondsDuration>,
+) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, env, .. } = ctx;
+
+    ensure!(
+        !exchange_rate.is_zero(),
+        ContractError::InvalidZeroAmount {}
+    );
+
+    // Check if the creator of the redemption clause is either the cw20 contract owner or admin
+    let cw20_address = TOKEN_ADDRESS
+        .load(deps.storage)?
+        .get_raw_address(&deps.as_ref())?;
+    let contract_info = deps
+        .querier
+        .query_wasm_contract_info(cw20_address.clone())?;
+    let cw20_owner = contract_info.creator;
+
+    ensure!(
+        cw20_owner == sender || contract_info.admin == Some(sender.to_string()),
+        ContractError::Unauthorized {}
+    );
+
+    // If start time wasn't provided, it will be set as the current_time
+    let (start_expiration, _current_time) = get_and_validate_start_time(&env, start_time.clone())?;
+
+    let end_expiration = if let Some(duration) = duration {
+        ensure!(!duration.is_zero(), ContractError::InvalidExpiration {});
+        expiration_from_milliseconds(
+            start_time
+                // If start time isn't provided, it is set one second in advance from the current time
+                .unwrap_or(Expiry::FromNow(Milliseconds::from_seconds(1)))
+                .get_time(&env.block)
+                .plus_milliseconds(duration),
+        )?
+    } else {
+        Expiration::Never {}
+    };
+
+    // Do not allow duplicate sales
+    let redemption_clause = REDEMPTION_CLAUSE.may_load(deps.storage)?;
+    ensure!(
+        redemption_clause.is_none(),
+        ContractError::RedemptionClauseAlreadyExists {}
+    );
+
+    let redemption_clause = RedemptionClause {
+        recipient: sender.to_string(),
+        asset: asset_sent.clone(),
+        amount: amount_sent,
+        exchange_rate,
+        start_time: start_expiration,
+        end_time: end_expiration,
+    };
+    REDEMPTION_CLAUSE.save(deps.storage, &redemption_clause)?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "start_redemption_clause"),
+        attr("asset", asset_sent.to_string()),
+        attr("rate", exchange_rate),
+        attr("amount", amount_sent),
+        attr("start_time", start_expiration.to_string()),
+        attr("end_time", end_expiration.to_string()),
+    ]))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_set_redemption_clause_native(
+    ctx: ExecuteContext,
+    exchange_rate: Uint128,
+    start_time: Option<Expiry>,
+    duration: Option<MillisecondsDuration>,
+) -> Result<Response, ContractError> {
+    let ExecuteContext {
+        deps, env, info, ..
+    } = ctx;
+
+    let payment = one_coin(&info)?;
+
+    let asset = AssetInfo::Native(payment.denom.to_string());
+    let amount = payment.amount;
+    ensure!(
+        !amount.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Cannot send a 0 amount".to_string()
+        }
+    );
+
+    ensure!(
+        !exchange_rate.is_zero(),
+        ContractError::InvalidZeroAmount {}
+    );
+
+    // Check if the creator of the redemption clause is either the cw20 contract owner or admin
+    let cw20_address = TOKEN_ADDRESS
+        .load(deps.storage)?
+        .get_raw_address(&deps.as_ref())?;
+    let contract_info = deps
+        .querier
+        .query_wasm_contract_info(cw20_address.clone())?;
+    let cw20_owner = contract_info.creator;
+
+    println!("cw20_owner: {}", cw20_owner);
+    println!("sender: {}", info.sender);
+    ensure!(
+        cw20_owner == info.sender || contract_info.admin == Some(info.sender.to_string()),
+        ContractError::Unauthorized {}
+    );
+
+    // If start time wasn't provided, it will be set as the current_time
+    let (start_expiration, _current_time) = get_and_validate_start_time(&env, start_time.clone())?;
+
+    let end_expiration = if let Some(duration) = duration {
+        ensure!(!duration.is_zero(), ContractError::InvalidExpiration {});
+        expiration_from_milliseconds(
+            start_time
+                // If start time isn't provided, it is set one second in advance from the current time
+                .unwrap_or(Expiry::FromNow(Milliseconds::from_seconds(1)))
+                .get_time(&env.block)
+                .plus_milliseconds(duration),
+        )?
+    } else {
+        Expiration::Never {}
+    };
+
+    // Do not allow duplicate sales
+    let redemption_clause = REDEMPTION_CLAUSE.may_load(deps.storage)?;
+    ensure!(
+        redemption_clause.is_none(),
+        ContractError::RedemptionClauseAlreadyExists {}
+    );
+
+    let redemption_clause = RedemptionClause {
+        recipient: info.sender.to_string(),
+        asset: asset.clone(),
+        amount,
+        exchange_rate,
+        start_time: start_expiration,
+        end_time: end_expiration,
+    };
+    REDEMPTION_CLAUSE.save(deps.storage, &redemption_clause)?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "start_redemption_clause"),
+        attr("asset", asset.to_string()),
+        attr("rate", exchange_rate),
+        attr("amount", amount),
+        attr("start_time", start_expiration.to_string()),
+        attr("end_time", end_expiration.to_string()),
+    ]))
+}
+
+/// Generates a transfer message given an asset and an amount
+fn generate_transfer_message(
+    asset: AssetInfo,
+    amount: Uint128,
+    recipient: String,
+    id: u64,
+) -> Result<SubMsg, ContractError> {
+    match asset.clone() {
+        AssetInfo::Native(denom) => {
+            let bank_msg = BankMsg::Send {
+                to_address: recipient,
+                amount: vec![coin(amount.u128(), denom)],
+            };
+
+            Ok(SubMsg::reply_on_error(CosmosMsg::Bank(bank_msg), id))
+        }
+        AssetInfo::Cw20(addr) => {
+            let transfer_msg = Cw20ExecuteMsg::Transfer { recipient, amount };
+            let wasm_msg = wasm_execute(addr, &transfer_msg, vec![])?;
+            Ok(SubMsg::reply_on_error(CosmosMsg::Wasm(wasm_msg), id))
+        }
+        // Does not support 1155 currently
+        _ => Err(ContractError::InvalidAsset {
+            asset: asset.to_string(),
+        }),
+    }
+}
+
+pub fn execute_redeem(
+    ctx: ExecuteContext,
+    amount_sent: Uint128,
+    asset_sent: AssetInfo,
+    // For refund purposes
+    sender: &str,
+) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, .. } = ctx;
+
+    let Some(mut redemption_clause) = REDEMPTION_CLAUSE.may_load(deps.storage)? else {
+        return Err(ContractError::NoOngoingSale {});
+    };
+
+    // Check if sale has started
+    ensure!(
+        redemption_clause.start_time.is_expired(&ctx.env.block),
+        ContractError::SaleNotStarted {}
+    );
+    // Check if sale has ended
+    ensure!(
+        !redemption_clause.end_time.is_expired(&ctx.env.block),
+        ContractError::SaleEnded {}
+    );
+
+    let redeemed = amount_sent.checked_mul(redemption_clause.exchange_rate)?;
+
+    ensure!(
+        !redeemed.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Not enough funds sent to redeem".to_string()
+        }
+    );
+    ensure!(
+        redemption_clause.amount >= redeemed,
+        ContractError::NotEnoughTokens {}
+    );
+
+    // Transfer tokens to the user redeeming the cw20 token
+    let transfer_msg_to_user = generate_transfer_message(
+        redemption_clause.asset.clone(),
+        redeemed,
+        sender.to_string(),
+        RECIPIENT_REPLY_ID,
+    )?;
+
+    // Tranfer the redeemed tokens to the redemtion clause recipient
+    let transfer_msg_to_redemption_clause_recipient = generate_transfer_message(
+        asset_sent.clone(),
+        amount_sent,
+        redemption_clause.recipient.clone(),
+        RECIPIENT_REPLY_ID,
+    )?;
+
+    // Update sale amount remaining
+    redemption_clause.amount = redemption_clause.amount.checked_sub(redeemed)?;
+    REDEMPTION_CLAUSE.save(deps.storage, &redemption_clause)?;
+
+    Ok(Response::default()
+        .add_submessage(transfer_msg_to_user)
+        .add_submessage(transfer_msg_to_redemption_clause_recipient)
+        .add_attributes(vec![
+            attr("action", "redeem"),
+            attr("purchaser", sender),
+            attr("amount", redeemed),
+            attr("purchase_asset", asset_sent.to_string()),
+            attr("purchase_asset_amount_send", amount_sent),
+        ]))
+}
+
+pub fn execute_cancel_redemption_clause(ctx: ExecuteContext) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, info, .. } = ctx;
+
+    let Some(redemption_clause) = REDEMPTION_CLAUSE.may_load(deps.storage)? else {
+        return Err(ContractError::NoOngoingSale {});
+    };
+
+    let mut resp = Response::default();
+
+    // Refund any remaining amount
+    if !redemption_clause.amount.is_zero() {
+        resp = resp
+            .add_submessage(generate_transfer_message(
+                redemption_clause.asset.clone(),
+                redemption_clause.amount,
+                info.sender.to_string(),
+                REFUND_REPLY_ID,
+            )?)
+            .add_attribute("refunded_amount", redemption_clause.amount);
+    }
+
+    // Redemption clause can now be removed
+    REDEMPTION_CLAUSE.remove(deps.storage);
+
+    Ok(resp.add_attributes(vec![attr("action", "cancel_redemption_clause")]))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    ADOContract::default().migrate(deps, env, CONTRACT_NAME, CONTRACT_VERSION)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+    match msg {
+        QueryMsg::RedemptionClause {} => query_redemption(deps),
+        QueryMsg::TokenAddress {} => query_token_address(deps),
+        QueryMsg::RedemptionAsset {} => query_redemption_asset(deps),
+        _ => ADOContract::default().query(deps, env, msg),
+    }
+}
+
+fn query_redemption(deps: Deps) -> Result<Binary, ContractError> {
+    let redemption = REDEMPTION_CLAUSE.may_load(deps.storage)?;
+
+    Ok(to_json_binary(&RedemptionResponse { redemption })?)
+}
+
+fn query_token_address(deps: Deps) -> Result<Binary, ContractError> {
+    let address = TOKEN_ADDRESS.load(deps.storage)?.get_raw_address(&deps)?;
+
+    Ok(to_json_binary(&TokenAddressResponse {
+        address: address.to_string(),
+    })?)
+}
+
+fn query_redemption_asset(deps: Deps) -> Result<Binary, ContractError> {
+    let redemption_clause = REDEMPTION_CLAUSE.load(deps.storage)?;
+
+    Ok(to_json_binary(&RedemptionAssetResponse {
+        asset: redemption_clause.asset.to_string(),
+    })?)
+}

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
@@ -182,6 +182,7 @@ pub fn execute_set_redemption_condition_cw20(
         recipient,
         asset: asset_sent.clone(),
         amount: amount_sent,
+        total_amount_redeemed: Uint128::zero(),
         exchange_rate,
         start_time: start_expiration,
         end_time: end_expiration,
@@ -262,6 +263,7 @@ pub fn execute_set_redemption_condition_native(
         recipient,
         asset: asset.clone(),
         amount,
+        total_amount_redeemed: Uint128::zero(),
         exchange_rate,
         start_time: start_expiration,
         end_time: end_expiration,
@@ -365,6 +367,9 @@ pub fn execute_redeem(
 
     // Update sale amount remaining
     redemption_condition.amount = redemption_condition.amount.checked_sub(redeemed_amount)?;
+    redemption_condition.total_amount_redeemed = redemption_condition
+        .total_amount_redeemed
+        .checked_add(redeemed_amount)?;
     REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
 
     let mut attributes = vec![

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
@@ -125,6 +125,7 @@ pub fn execute_receive(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_set_redemption_clause_cw20(
     ctx: ExecuteContext,
     amount_sent: Uint128,

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
@@ -121,7 +121,6 @@ pub fn execute_receive(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn execute_set_redemption_clause_cw20(
     ctx: ExecuteContext,
     amount_sent: Uint128,
@@ -138,17 +137,8 @@ pub fn execute_set_redemption_clause_cw20(
         ContractError::InvalidZeroAmount {}
     );
 
-    // Check if the creator of the redemption clause is either the cw20 contract owner or admin
-    let cw20_address = TOKEN_ADDRESS
-        .load(deps.storage)?
-        .get_raw_address(&deps.as_ref())?;
-    let contract_info = deps
-        .querier
-        .query_wasm_contract_info(cw20_address.clone())?;
-    let cw20_owner = contract_info.creator;
-
     ensure!(
-        cw20_owner == sender || contract_info.admin == Some(sender.to_string()),
+        ctx.contract.is_contract_owner(deps.storage, &sender)?,
         ContractError::Unauthorized {}
     );
 
@@ -195,7 +185,6 @@ pub fn execute_set_redemption_clause_cw20(
     ]))
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn execute_set_redemption_clause_native(
     ctx: ExecuteContext,
     exchange_rate: Uint128,
@@ -220,20 +209,6 @@ pub fn execute_set_redemption_clause_native(
     ensure!(
         !exchange_rate.is_zero(),
         ContractError::InvalidZeroAmount {}
-    );
-
-    // Check if the creator of the redemption clause is either the cw20 contract owner or admin
-    let cw20_address = TOKEN_ADDRESS
-        .load(deps.storage)?
-        .get_raw_address(&deps.as_ref())?;
-    let contract_info = deps
-        .querier
-        .query_wasm_contract_info(cw20_address.clone())?;
-    let cw20_owner = contract_info.creator;
-
-    ensure!(
-        cw20_owner == info.sender || contract_info.admin == Some(info.sender.to_string()),
-        ContractError::Unauthorized {}
     );
 
     // Check if a redemption clause already exists

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/interface.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/interface.rs
@@ -1,0 +1,10 @@
+use andromeda_fungible_tokens::cw20_redeem::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::{ado_base::MigrateMsg, contract_interface, deploy::ADOMetadata};
+
+pub const CONTRACT_ID: &str = "cw20-redeem";
+
+contract_interface!(
+    Cw20RedeemContract,
+    CONTRACT_ID,
+    "andromeda_cw20_redeem.wasm"
+);

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/lib.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod contract;
+#[cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+pub mod mock;
+
+mod state;
+
+#[cfg(test)]
+mod testing;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod interface;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::interface::Cw20RedeemContract;

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
@@ -24,13 +24,13 @@ pub fn mock_cw20_redeem_instantiate_msg(
     }
 }
 
-pub fn mock_cw20_redeem_start_redemption_clause_hook_msg(
+pub fn mock_cw20_redeem_start_redemption_condition_hook_msg(
     exchange_rate: Uint128,
     recipient: Option<Recipient>,
     start_time: Option<Expiry>,
     duration: Option<MillisecondsDuration>,
 ) -> Cw20HookMsg {
-    Cw20HookMsg::StartRedemptionClause {
+    Cw20HookMsg::StartRedemptionCondition {
         exchange_rate,
         recipient,
         start_time,
@@ -42,13 +42,13 @@ pub fn mock_cw20_redeem_hook_redeem_msg() -> Cw20HookMsg {
     Cw20HookMsg::Redeem {}
 }
 
-pub fn mock_cw20_set_redemption_clause_native_msg(
+pub fn mock_cw20_set_redemption_condition_native_msg(
     exchange_rate: Uint128,
     recipient: Option<Recipient>,
     start_time: Option<Expiry>,
     duration: Option<MillisecondsDuration>,
 ) -> ExecuteMsg {
-    ExecuteMsg::SetRedemptionClause {
+    ExecuteMsg::SetRedemptionCondition {
         exchange_rate,
         recipient,
         start_time,
@@ -56,10 +56,10 @@ pub fn mock_cw20_set_redemption_clause_native_msg(
     }
 }
 
-pub fn mock_cw20_redeem_cancel_redemption_clause_msg() -> ExecuteMsg {
-    ExecuteMsg::CancelRedemptionClause {}
+pub fn mock_cw20_redeem_cancel_redemption_condition_msg() -> ExecuteMsg {
+    ExecuteMsg::CancelRedemptionCondition {}
 }
 
-pub fn mock_get_redemption_clause() -> QueryMsg {
-    QueryMsg::RedemptionClause {}
+pub fn mock_get_redemption_condition() -> QueryMsg {
+    QueryMsg::RedemptionCondition {}
 }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
@@ -1,0 +1,58 @@
+#![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+
+use crate::contract::{execute, instantiate, query};
+use andromeda_fungible_tokens::cw20_redeem::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::amp::AndrAddr;
+use andromeda_std::common::{expiration::Expiry, MillisecondsDuration};
+use cosmwasm_std::{Empty, Uint128};
+use cw_multi_test::{Contract, ContractWrapper};
+
+pub fn mock_andromeda_cw20_redeem() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new_with_empty(execute, instantiate, query);
+    Box::new(contract)
+}
+
+pub fn mock_cw20_redeem_instantiate_msg(
+    token_address: String,
+    kernel_address: String,
+    owner: Option<String>,
+) -> InstantiateMsg {
+    InstantiateMsg {
+        token_address: AndrAddr::from_string(token_address),
+        kernel_address,
+        owner,
+    }
+}
+
+pub fn mock_cw20_redeem_start_redemption_clause_hook_msg(
+    exchange_rate: Uint128,
+    start_time: Option<Expiry>,
+    duration: Option<MillisecondsDuration>,
+) -> Cw20HookMsg {
+    Cw20HookMsg::StartRedemptionClause {
+        exchange_rate,
+
+        start_time,
+        duration,
+    }
+}
+
+pub fn mock_cw20_redeem_hook_redeem_msg() -> Cw20HookMsg {
+    Cw20HookMsg::Redeem {}
+}
+
+pub fn mock_cw20_set_redemption_clause_native_msg(
+    exchange_rate: Uint128,
+    start_time: Option<Expiry>,
+    duration: Option<MillisecondsDuration>,
+) -> ExecuteMsg {
+    ExecuteMsg::SetRedemptionClause {
+        exchange_rate,
+        start_time,
+        duration,
+    }
+}
+
+pub fn mock_get_redemption_clause() -> QueryMsg {
+    QueryMsg::RedemptionClause {}
+}

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
@@ -2,7 +2,7 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::cw20_redeem::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_std::amp::AndrAddr;
+use andromeda_std::amp::{AndrAddr, Recipient};
 use andromeda_std::common::{expiration::Expiry, MillisecondsDuration};
 use cosmwasm_std::{Empty, Uint128};
 use cw_multi_test::{Contract, ContractWrapper};
@@ -26,12 +26,13 @@ pub fn mock_cw20_redeem_instantiate_msg(
 
 pub fn mock_cw20_redeem_start_redemption_clause_hook_msg(
     exchange_rate: Uint128,
+    recipient: Option<Recipient>,
     start_time: Option<Expiry>,
     duration: Option<MillisecondsDuration>,
 ) -> Cw20HookMsg {
     Cw20HookMsg::StartRedemptionClause {
         exchange_rate,
-
+        recipient,
         start_time,
         duration,
     }
@@ -43,11 +44,13 @@ pub fn mock_cw20_redeem_hook_redeem_msg() -> Cw20HookMsg {
 
 pub fn mock_cw20_set_redemption_clause_native_msg(
     exchange_rate: Uint128,
+    recipient: Option<Recipient>,
     start_time: Option<Expiry>,
     duration: Option<MillisecondsDuration>,
 ) -> ExecuteMsg {
     ExecuteMsg::SetRedemptionClause {
         exchange_rate,
+        recipient,
         start_time,
         duration,
     }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
@@ -53,6 +53,10 @@ pub fn mock_cw20_set_redemption_clause_native_msg(
     }
 }
 
+pub fn mock_cw20_redeem_cancel_redemption_clause_msg() -> ExecuteMsg {
+    ExecuteMsg::CancelRedemptionClause {}
+}
+
 pub fn mock_get_redemption_clause() -> QueryMsg {
     QueryMsg::RedemptionClause {}
 }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/state.rs
@@ -1,0 +1,6 @@
+use andromeda_fungible_tokens::cw20_redeem::RedemptionClause;
+use andromeda_std::amp::AndrAddr;
+use cw_storage_plus::Item;
+
+pub const TOKEN_ADDRESS: Item<AndrAddr> = Item::new("token_address");
+pub const REDEMPTION_CLAUSE: Item<RedemptionClause> = Item::new("redemption_clause");

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/state.rs
@@ -1,6 +1,6 @@
-use andromeda_fungible_tokens::cw20_redeem::RedemptionClause;
+use andromeda_fungible_tokens::cw20_redeem::RedemptionCondition;
 use andromeda_std::amp::AndrAddr;
 use cw_storage_plus::Item;
 
 pub const TOKEN_ADDRESS: Item<AndrAddr> = Item::new("token_address");
-pub const REDEMPTION_CLAUSE: Item<RedemptionClause> = Item::new("redemption_clause");
+pub const REDEMPTION_CONDITION: Item<RedemptionCondition> = Item::new("redemption_condition");

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/mock_querier.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/mock_querier.rs
@@ -1,0 +1,122 @@
+use andromeda_std::ado_base::InstantiateMsg;
+use andromeda_std::ado_contract::ADOContract;
+use andromeda_std::testing::mock_querier::{MockAndromedaQuerier, MOCK_KERNEL_CONTRACT};
+use cosmwasm_std::testing::{
+    mock_env, mock_info, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
+};
+use cosmwasm_std::{
+    from_json, to_json_binary, Coin, ContractResult, Empty, OwnedDeps, Querier, QuerierResult,
+    QuerierWrapper, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+};
+use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg};
+use std::collections::HashMap;
+
+pub fn mock_dependencies_custom(
+    contract_balance: &[Coin],
+) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+    let custom_querier: WasmMockQuerier =
+        WasmMockQuerier::new(MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]));
+    let storage = MockStorage::default();
+    let mut deps = OwnedDeps {
+        storage,
+        api: MockApi::default(),
+        querier: custom_querier,
+        custom_query_type: std::marker::PhantomData,
+    };
+    ADOContract::default()
+        .instantiate(
+            &mut deps.storage,
+            mock_env(),
+            &deps.api,
+            &QuerierWrapper::new(&deps.querier),
+            mock_info("sender", &[]),
+            InstantiateMsg {
+                ado_type: "cw20-staking".to_string(),
+                ado_version: "test".to_string(),
+
+                kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+                owner: None,
+            },
+        )
+        .unwrap();
+    deps
+}
+
+pub struct WasmMockQuerier {
+    pub base: MockQuerier<Empty>,
+    token_querier: TokenQuerier,
+}
+
+#[derive(Clone, Default)]
+pub struct TokenQuerier {
+    // this lets us iterate over all pairs that match the first string
+    balances: HashMap<String, HashMap<String, Uint128>>,
+}
+
+impl Querier for WasmMockQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        // MockQuerier doesn't support Custom, so we ignore it completely here
+        let request: QueryRequest<Empty> = match from_json(bin_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: format!("Parsing query request: {e}"),
+                    request: bin_request.into(),
+                })
+            }
+        };
+        self.handle_query(&request)
+    }
+}
+
+impl WasmMockQuerier {
+    pub fn handle_query(&self, request: &QueryRequest<Empty>) -> QuerierResult {
+        match &request {
+            QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
+                match from_json(msg).unwrap() {
+                    Cw20QueryMsg::Balance { address } => {
+                        let balances: &HashMap<String, Uint128> =
+                            match self.token_querier.balances.get(contract_addr) {
+                                Some(balances) => balances,
+                                None => {
+                                    return SystemResult::Err(SystemError::InvalidRequest {
+                                        error: format!(
+                                        "No balance info exists for the contract {contract_addr}"
+                                    ),
+                                        request: msg.as_slice().into(),
+                                    })
+                                }
+                            };
+
+                        let balance = match balances.get(&address) {
+                            Some(v) => *v,
+                            None => {
+                                return SystemResult::Ok(ContractResult::Ok(
+                                    to_json_binary(&Cw20BalanceResponse {
+                                        balance: Uint128::zero(),
+                                    })
+                                    .unwrap(),
+                                ));
+                            }
+                        };
+
+                        SystemResult::Ok(ContractResult::Ok(
+                            to_json_binary(&Cw20BalanceResponse { balance }).unwrap(),
+                        ))
+                    }
+                    _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
+                }
+            }
+            _ => MockAndromedaQuerier::default().handle_query(&self.base, request),
+        }
+    }
+}
+
+impl WasmMockQuerier {
+    pub fn new(base: MockQuerier<Empty>) -> Self {
+        WasmMockQuerier {
+            base,
+            token_querier: TokenQuerier::default(),
+        }
+    }
+}

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/mod.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/mod.rs
@@ -1,0 +1,2 @@
+mod mock_querier;
+mod tests;

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/tests.rs
@@ -1,0 +1,157 @@
+use andromeda_fungible_tokens::cw20_redeem::{Cw20HookMsg, ExecuteMsg, InstantiateMsg};
+use andromeda_std::{
+    amp::AndrAddr, error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT,
+};
+use cosmwasm_std::{
+    attr, coins,
+    testing::{mock_env, mock_info},
+    to_json_binary, DepsMut, Response, Uint128,
+};
+use cw20::Cw20ReceiveMsg;
+pub const MOCK_TOKEN_ADDRESS: &str = "cw20";
+
+use crate::{
+    contract::{execute, instantiate},
+    state::TOKEN_ADDRESS,
+    testing::mock_querier::mock_dependencies_custom,
+};
+
+fn init(deps: DepsMut) -> Result<Response, ContractError> {
+    let info = mock_info("owner", &[]);
+
+    let msg = InstantiateMsg {
+        kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
+        owner: None,
+
+        token_address: AndrAddr::from_string("cw20"),
+    };
+
+    instantiate(deps, mock_env(), info, msg)
+}
+#[test]
+pub fn test_instantiate() {
+    let mut deps = mock_dependencies_custom(&[]);
+    init(deps.as_mut()).unwrap();
+
+    let saved_mock_token_address = TOKEN_ADDRESS.load(deps.as_ref().storage).unwrap();
+
+    assert_eq!(saved_mock_token_address, MOCK_TOKEN_ADDRESS.to_string())
+}
+
+const OWNER: &str = "owner";
+const USER: &str = "user";
+const REDEEMED_TOKEN_CONTRACT: &str = "redeemed_token_contract";
+const CW20_CONTRACT: &str = "cw20_contract";
+const NATIVE_DENOM: &str = "uusd";
+
+#[test]
+fn test_native_token_redemption() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let env = mock_env();
+    let info = mock_info(OWNER, &[]);
+
+    // First instantiate the contract
+    let msg = InstantiateMsg {
+        token_address: AndrAddr::from_string(REDEEMED_TOKEN_CONTRACT),
+        kernel_address: "kernel".to_string(),
+        owner: Some(OWNER.to_string()),
+    };
+    instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // Start redemption clause with native token
+    let exchange_rate = Uint128::from(2u128); // 2:1 exchange rate
+    let amount = Uint128::from(1000u128);
+    let info = mock_info(OWNER, &coins(amount.into(), NATIVE_DENOM));
+
+    let msg = ExecuteMsg::SetRedemptionClause {
+        exchange_rate,
+        start_time: None,
+        duration: None,
+    };
+
+    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // Now try to redeem tokens
+    let redeem_amount = Uint128::from(100u128);
+    let info = mock_info(USER, &coins(100, NATIVE_DENOM));
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: USER.to_string(),
+        amount: redeem_amount,
+        msg: to_json_binary(&Cw20HookMsg::Redeem {}).unwrap(),
+    });
+
+    let response = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // Verify the response contains the correct attributes
+    assert_eq!(
+        response.attributes,
+        vec![
+            attr("action", "redeem"),
+            attr("purchaser", USER),
+            attr("amount", (redeem_amount * exchange_rate).to_string()),
+            attr("purchase_asset", format!("native:{}", NATIVE_DENOM)),
+            attr("purchase_asset_amount_send", redeem_amount.to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_cw20_token_redemption() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let env = mock_env();
+    let info = mock_info(OWNER, &[]);
+
+    // First instantiate the contract
+    let msg = InstantiateMsg {
+        token_address: AndrAddr::from_string(REDEEMED_TOKEN_CONTRACT),
+        kernel_address: "kernel".to_string(),
+        owner: Some(OWNER.to_string()),
+    };
+    instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // Start redemption clause with CW20 token
+    let exchange_rate = Uint128::from(2u128); // 2:1 exchange rate
+    let amount = Uint128::from(1000u128);
+
+    let msg = Cw20ReceiveMsg {
+        sender: OWNER.to_string(),
+        amount,
+        msg: to_json_binary(&Cw20HookMsg::StartRedemptionClause {
+            exchange_rate,
+            start_time: None,
+            duration: None,
+        })
+        .unwrap(),
+    };
+
+    let info = mock_info(REDEEMED_TOKEN_CONTRACT, &[]);
+
+    let msg = ExecuteMsg::Receive(msg);
+    execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // Now try to redeem tokens
+    let redeem_amount = Uint128::from(100u128);
+    let info = mock_info(REDEEMED_TOKEN_CONTRACT, &[]);
+
+    let msg = Cw20ReceiveMsg {
+        sender: USER.to_string(),
+        amount: redeem_amount,
+        msg: to_json_binary(&Cw20HookMsg::Redeem {}).unwrap(),
+    };
+    let msg = ExecuteMsg::Receive(msg);
+
+    let response = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // Verify the response contains the correct attributes
+    assert_eq!(
+        response.attributes,
+        vec![
+            attr("action", "redeem"),
+            attr("purchaser", USER),
+            attr("amount", (redeem_amount * exchange_rate).to_string()),
+            attr("purchase_asset", format!("cw20:{}", CW20_CONTRACT)),
+            attr("purchase_asset_amount_send", redeem_amount.to_string()),
+        ]
+    );
+}

--- a/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-lockdrop/src/contract.rs
@@ -404,7 +404,7 @@ pub fn execute_claim_rewards(ctx: ExecuteContext) -> Result<Response, ContractEr
 //     let state = STATE.load(deps.storage)?;
 //     // CHECK :: Only Owner can call this function
 //     ensure!(
-//         ADOContract::default().is_contract_owner(deps.storage, info.sender.as_str())?,
+//         ctx.contract.is_contract_owner(deps.storage, info.sender.as_str())?,
 //         ContractError::Unauthorized {}
 //     );
 

--- a/contracts/math/andromeda-curve/src/contract.rs
+++ b/contracts/math/andromeda-curve/src/contract.rs
@@ -93,7 +93,7 @@ pub fn execute_update_curve_config(
     curve_config: CurveConfig,
 ) -> Result<Response, ContractError> {
     let sender = ctx.info.sender.clone();
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         UPDATE_CURVE_CONFIG_ACTION,
@@ -110,7 +110,7 @@ pub fn execute_update_curve_config(
 
 pub fn execute_reset(mut ctx: ExecuteContext) -> Result<Response, ContractError> {
     let sender = ctx.info.sender.clone();
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         RESET_ACTION,

--- a/contracts/math/andromeda-graph/src/contract.rs
+++ b/contracts/math/andromeda-graph/src/contract.rs
@@ -314,8 +314,9 @@ pub fn execute_store_user_coordinate(
         let contract_info = ctx.deps.querier.query_wasm_contract_info(address.clone());
         if let Ok(contract_info) = contract_info {
             let code_id = contract_info.code_id;
-            let adodb_addr =
-                ctx.contract.get_adodb_address(ctx.deps.storage, &ctx.deps.querier)?;
+            let adodb_addr = ctx
+                .contract
+                .get_adodb_address(ctx.deps.storage, &ctx.deps.querier)?;
             let ado_type = AOSQuerier::ado_type_getter(&ctx.deps.querier, &adodb_addr, code_id)?;
 
             if ado_type.is_none() {

--- a/contracts/math/andromeda-graph/src/contract.rs
+++ b/contracts/math/andromeda-graph/src/contract.rs
@@ -315,7 +315,7 @@ pub fn execute_store_user_coordinate(
         if let Ok(contract_info) = contract_info {
             let code_id = contract_info.code_id;
             let adodb_addr =
-                ADOContract::default().get_adodb_address(ctx.deps.storage, &ctx.deps.querier)?;
+                ctx.contract.get_adodb_address(ctx.deps.storage, &ctx.deps.querier)?;
             let ado_type = AOSQuerier::ado_type_getter(&ctx.deps.querier, &adodb_addr, code_id)?;
 
             if ado_type.is_none() {

--- a/contracts/math/andromeda-matrix/src/contract.rs
+++ b/contracts/math/andromeda-matrix/src/contract.rs
@@ -103,7 +103,7 @@ pub fn store_matrix(
 ) -> Result<Response, ContractError> {
     let sender = ctx.info.sender.clone();
 
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         STORE_MATRIX_ACTION,
@@ -140,7 +140,7 @@ pub fn delete_matrix(
 ) -> Result<Response, ContractError> {
     let sender = ctx.info.sender;
 
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         DELETE_MATRIX_ACTION,

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -136,7 +136,7 @@ fn handle_receive_cw721(
     mut ctx: ExecuteContext,
     msg: Cw721ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         SEND_NFT_ACTION,
@@ -455,7 +455,7 @@ fn execute_place_bid(
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
 
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         deps.branch(),
         env.clone(),
         token_auction_state.auction_id,
@@ -684,7 +684,7 @@ fn execute_place_bid_cw20(
     let mut token_auction_state =
         get_existing_token_auction_state(deps.storage, &token_id, &token_address)?;
 
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         deps.branch(),
         env.clone(),
         token_auction_state.auction_id,
@@ -804,7 +804,7 @@ fn execute_buy_now_cw20(
 
     validate_auction(token_auction_state.clone(), info.clone(), &env.block)?;
 
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         deps.branch(),
         env.clone(),
         token_auction_state.auction_id,

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -521,8 +521,7 @@ fn withdraw_to_recipient(
 ) -> Result<SubMsg, ContractError> {
     match denom {
         Asset::NativeToken(denom) => {
-            let kernel_address =
-                ADOContract::default().get_kernel_address(ctx.deps.as_ref().storage)?;
+            let kernel_address = ctx.contract.get_kernel_address(ctx.deps.as_ref().storage)?;
 
             let owner = ADOContract::default().owner(ctx.deps.as_ref().storage)?;
             let mut pkt = AMPPkt::from_ctx(ctx.amp_ctx, ctx.env.contract.address.to_string())

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/contract.rs
@@ -114,7 +114,7 @@ fn handle_receive_cw721(
     mut ctx: ExecuteContext,
     msg: Cw721ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         SEND_NFT_ACTION,
@@ -147,7 +147,7 @@ pub fn handle_receive_cw20(
     mut ctx: ExecuteContext,
     receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    ADOContract::default().is_permissioned(
+    ctx.contract.is_permissioned(
         ctx.deps.branch(),
         ctx.env.clone(),
         SEND_CW20_ACTION,

--- a/contracts/os/andromeda-ibc-registry/src/contract.rs
+++ b/contracts/os/andromeda-ibc-registry/src/contract.rs
@@ -84,7 +84,7 @@ pub fn execute_store_denom_info(
 ) -> Result<Response, ContractError> {
     let sender = ctx.info.sender.clone();
     // Verify authority
-    ADOContract::default().is_permissioned_strict(
+    ctx.contract.is_permissioned_strict(
         ctx.deps.branch(),
         ctx.env.clone(),
         "StoreDenomInfo",

--- a/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_exchange.rs
@@ -42,8 +42,6 @@ pub struct Sale {
     pub start_time: Expiration,
     /// The time when the sale ends
     pub end_time: Expiration,
-    /// The amount for sale at the given rate at the start of the sale
-    pub start_amount: Uint128,
 }
 
 #[cw_serde]

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -1,5 +1,5 @@
 use andromeda_std::{
-    amp::AndrAddr,
+    amp::{AndrAddr, Recipient},
     andr_exec, andr_instantiate, andr_query,
     common::{expiration::Expiry, MillisecondsDuration},
 };
@@ -29,6 +29,7 @@ pub enum ExecuteMsg {
     #[attrs(restricted)]
     SetRedemptionClause {
         exchange_rate: Uint128,
+        recipient: Option<Recipient>,
         start_time: Option<Expiry>,
         duration: Option<MillisecondsDuration>,
     },
@@ -39,7 +40,7 @@ pub enum ExecuteMsg {
 #[cw_serde]
 pub struct RedemptionClause {
     /// Recipient of the redeemed tokens
-    pub recipient: String,
+    pub recipient: Recipient,
     /// The asset that may be used to redeem the tokens with
     pub asset: AssetInfo,
     /// The rate at which to exchange tokens (amount of exchanged asset to purchase sale asset)
@@ -58,6 +59,7 @@ pub enum Cw20HookMsg {
     StartRedemptionClause {
         /// The amount of the above asset required to purchase a single token
         exchange_rate: Uint128,
+        recipient: Option<Recipient>,
         start_time: Option<Expiry>,
         duration: Option<MillisecondsDuration>,
     },

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -21,13 +21,13 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     /// Cancels an ongoing sale
     #[attrs(restricted)]
-    CancelRedemptionClause {},
+    CancelRedemptionCondition {},
     /// Receive for CW20 tokens, used for purchasing and starting sales
     #[attrs(nonpayable)]
     Receive(Cw20ReceiveMsg),
     /// Starts a redemption with the native funds sent
     #[attrs(restricted)]
-    SetRedemptionClause {
+    SetRedemptionCondition {
         exchange_rate: Uint128,
         recipient: Option<Recipient>,
         start_time: Option<Expiry>,
@@ -38,7 +38,7 @@ pub enum ExecuteMsg {
 
 /// Struct used to define a token redemption. The asset used for the redemption is defined as the key for the storage map.
 #[cw_serde]
-pub struct RedemptionClause {
+pub struct RedemptionCondition {
     /// Recipient of the redeemed tokens
     pub recipient: Recipient,
     /// The asset that may be used to redeem the tokens with
@@ -56,7 +56,7 @@ pub struct RedemptionClause {
 #[cw_serde]
 pub enum Cw20HookMsg {
     /// Starts a sale
-    StartRedemptionClause {
+    StartRedemptionCondition {
         /// The amount of the above asset required to purchase a single token
         exchange_rate: Uint128,
         recipient: Option<Recipient>,
@@ -73,7 +73,7 @@ pub enum Cw20HookMsg {
 pub enum QueryMsg {
     /// Redemption info for a given asset
     #[returns(RedemptionResponse)]
-    RedemptionClause {},
+    RedemptionCondition {},
     /// The address of the token being redeemed
     #[returns(TokenAddressResponse)]
     TokenAddress {},
@@ -96,7 +96,7 @@ pub struct RedemptionAssetBalanceResponse {
 #[cw_serde]
 pub struct RedemptionResponse {
     /// The redemption data if it exists
-    pub redemption: Option<RedemptionClause>,
+    pub redemption: Option<RedemptionCondition>,
 }
 
 #[cw_serde]

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -1,0 +1,100 @@
+use andromeda_std::{
+    amp::AndrAddr,
+    andr_exec, andr_instantiate, andr_query,
+    common::{expiration::Expiry, MillisecondsDuration},
+};
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Uint128;
+use cw20::Cw20ReceiveMsg;
+use cw_asset::AssetInfo;
+use cw_utils::Expiration;
+
+#[andr_instantiate]
+#[cw_serde]
+pub struct InstantiateMsg {
+    /// Address of the CW20 token to be redeemed
+    pub token_address: AndrAddr,
+}
+
+#[andr_exec]
+#[cw_serde]
+pub enum ExecuteMsg {
+    /// Cancels an ongoing sale
+    #[attrs(restricted)]
+    CancelRedemptionClause {},
+    /// Purchases tokens with native funds
+    Purchase {
+        recipient: Option<String>,
+    },
+    /// Receive for CW20 tokens, used for purchasing and starting sales
+    #[attrs(nonpayable)]
+    Receive(Cw20ReceiveMsg),
+    /// Starts a redemption with the native funds sent
+    SetRedemptionClause {
+        exchange_rate: Uint128,
+        start_time: Option<Expiry>,
+        duration: Option<MillisecondsDuration>,
+    },
+    Redeem {},
+}
+
+/// Struct used to define a token redemption. The asset used for the redemption is defined as the key for the storage map.
+#[cw_serde]
+pub struct RedemptionClause {
+    /// Recipient of the redeemed tokens
+    pub recipient: String,
+    /// The asset that may be used to redeem the tokens with
+    pub asset: AssetInfo,
+    /// The rate at which to exchange tokens (amount of exchanged asset to purchase sale asset)
+    pub exchange_rate: Uint128,
+    /// The amount for redemption at the given rate
+    pub amount: Uint128,
+    /// The time when the redemption starts
+    pub start_time: Expiration,
+    /// The time when the redemption ends
+    pub end_time: Expiration,
+}
+
+#[cw_serde]
+pub enum Cw20HookMsg {
+    /// Starts a sale
+    StartRedemptionClause {
+        /// The amount of the above asset required to purchase a single token
+        exchange_rate: Uint128,
+        start_time: Option<Expiry>,
+        duration: Option<MillisecondsDuration>,
+    },
+    /// Purchases tokens
+    Redeem {},
+}
+
+#[andr_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    /// Redemption info for a given asset
+    #[returns(RedemptionResponse)]
+    RedemptionClause {},
+    /// The address of the token being redeemed
+    #[returns(TokenAddressResponse)]
+    TokenAddress {},
+    #[returns(RedemptionAssetResponse)]
+    RedemptionAsset {},
+}
+
+#[cw_serde]
+pub struct RedemptionAssetResponse {
+    pub asset: String,
+}
+
+#[cw_serde]
+pub struct RedemptionResponse {
+    /// The redemption data if it exists
+    pub redemption: Option<RedemptionClause>,
+}
+
+#[cw_serde]
+pub struct TokenAddressResponse {
+    /// The address of the token being redeemed
+    pub address: String,
+}

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -47,6 +47,8 @@ pub struct RedemptionCondition {
     pub exchange_rate: Uint128,
     /// The amount for redemption at the given rate
     pub amount: Uint128,
+    /// The amount paid out so far in redemptions
+    pub total_amount_redeemed: Uint128,
     /// The time when the redemption starts
     pub start_time: Expiration,
     /// The time when the redemption ends

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -22,10 +22,6 @@ pub enum ExecuteMsg {
     /// Cancels an ongoing sale
     #[attrs(restricted)]
     CancelRedemptionClause {},
-    /// Purchases tokens with native funds
-    Purchase {
-        recipient: Option<String>,
-    },
     /// Receive for CW20 tokens, used for purchasing and starting sales
     #[attrs(nonpayable)]
     Receive(Cw20ReceiveMsg),

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -26,6 +26,7 @@ pub enum ExecuteMsg {
     #[attrs(nonpayable)]
     Receive(Cw20ReceiveMsg),
     /// Starts a redemption with the native funds sent
+    #[attrs(restricted)]
     SetRedemptionClause {
         exchange_rate: Uint128,
         start_time: Option<Expiry>,

--- a/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20_redeem.rs
@@ -80,11 +80,18 @@ pub enum QueryMsg {
     TokenAddress {},
     #[returns(RedemptionAssetResponse)]
     RedemptionAsset {},
+    #[returns(RedemptionAssetBalanceResponse)]
+    RedemptionAssetBalance {},
 }
 
 #[cw_serde]
 pub struct RedemptionAssetResponse {
     pub asset: String,
+}
+
+#[cw_serde]
+pub struct RedemptionAssetBalanceResponse {
+    pub balance: Uint128,
 }
 
 #[cw_serde]

--- a/packages/andromeda-fungible-tokens/src/lib.rs
+++ b/packages/andromeda-fungible-tokens/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod airdrop;
 pub mod cw20;
 pub mod cw20_exchange;
+pub mod cw20_redeem;
 pub mod cw20_staking;
 pub mod lockdrop;

--- a/packages/deploy/Cargo.toml
+++ b/packages/deploy/Cargo.toml
@@ -48,6 +48,7 @@ andromeda-string-storage = { path = "../../contracts/data-storage/andromeda-stri
 andromeda-cw20-staking = { path = "../../contracts/fungible-tokens/andromeda-cw20-staking" }
 andromeda-cw20 = { path = "../../contracts/fungible-tokens/andromeda-cw20" }
 andromeda-cw20-exchange = { path = "../../contracts/fungible-tokens/andromeda-cw20-exchange" }
+andromeda-cw20-redeem = { path = "../../contracts/fungible-tokens/andromeda-cw20-redeem" }
 andromeda-lockdrop = { path = "../../contracts/fungible-tokens/andromeda-lockdrop" }
 andromeda-merkle-airdrop = { path = "../../contracts/fungible-tokens/andromeda-merkle-airdrop" }
 

--- a/packages/std/src/common/mod.rs
+++ b/packages/std/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod expiration;
 pub mod message_generators;
 pub mod migration;
 pub mod milliseconds;
+pub mod msg_generation;
 pub mod rates;
 pub mod reply;
 pub mod response;

--- a/packages/std/src/common/msg_generation.rs
+++ b/packages/std/src/common/msg_generation.rs
@@ -1,0 +1,43 @@
+use cw_asset::AssetInfo;
+
+use crate::error::ContractError;
+use cosmwasm_std::{coin, wasm_execute, BankMsg, CosmosMsg, SubMsg, Uint128};
+use cw20::Cw20ExecuteMsg;
+
+/// Used in CW20 Redeem and CW20 Exchange
+/// Generates a transfer message given an asset and an amount
+pub fn generate_transfer_message(
+    asset: AssetInfo,
+    amount: Uint128,
+    recipient: String,
+    reply_id: Option<u64>,
+) -> Result<SubMsg, ContractError> {
+    match asset.clone() {
+        AssetInfo::Native(denom) => {
+            let bank_msg = BankMsg::Send {
+                to_address: recipient,
+                amount: vec![coin(amount.u128(), denom)],
+            };
+
+            let cosmos_msg = CosmosMsg::Bank(bank_msg);
+            Ok(if let Some(id) = reply_id {
+                SubMsg::reply_on_error(cosmos_msg, id)
+            } else {
+                SubMsg::new(cosmos_msg)
+            })
+        }
+        AssetInfo::Cw20(addr) => {
+            let transfer_msg = Cw20ExecuteMsg::Transfer { recipient, amount };
+            let wasm_msg = wasm_execute(addr, &transfer_msg, vec![])?;
+            Ok(if let Some(id) = reply_id {
+                SubMsg::reply_on_error(CosmosMsg::Wasm(wasm_msg), id)
+            } else {
+                SubMsg::new(CosmosMsg::Wasm(wasm_msg))
+            })
+        }
+        // Does not support 1155 currently
+        _ => Err(ContractError::InvalidAsset {
+            asset: asset.to_string(),
+        }),
+    }
+}

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -591,6 +591,9 @@ pub enum ContractError {
     #[error("Sale not ended")]
     SaleNotEnded {},
 
+    #[error("Redemption clause already exists")]
+    RedemptionClauseAlreadyExists {},
+
     #[error("Min sales exceeded")]
     MinSalesExceeded {},
 

--- a/packages/std/src/error.rs
+++ b/packages/std/src/error.rs
@@ -591,8 +591,8 @@ pub enum ContractError {
     #[error("Sale not ended")]
     SaleNotEnded {},
 
-    #[error("Redemption clause already exists")]
-    RedemptionClauseAlreadyExists {},
+    #[error("Redemption condition already exists")]
+    RedemptionConditionAlreadyExists {},
 
     #[error("Min sales exceeded")]
     MinSalesExceeded {},

--- a/packages/std/src/testing/mock_querier.rs
+++ b/packages/std/src/testing/mock_querier.rs
@@ -474,6 +474,12 @@ impl MockAndromedaQuerier {
             ));
         }
 
+        if contract_addr.as_str().contains("owner") {
+            return SystemResult::Ok(ContractResult::Ok(
+                to_json_binary(&Addr::unchecked("owner".to_string())).unwrap(),
+            ));
+        }
+
         panic!("Unsupported query for contract: {contract_addr}")
     }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,10 +44,14 @@ andromeda-cw20 = { path = "../contracts/fungible-tokens/andromeda-cw20", feature
 andromeda-cw20-staking = { path = "../contracts/fungible-tokens/andromeda-cw20-staking", features = [
     "testing",
 ] }
+
+andromeda-cw20-redeem = { path = "../contracts/fungible-tokens/andromeda-cw20-redeem", features = [
+    "testing",
+] }
+
 andromeda-lockdrop = { path = "../contracts/fungible-tokens/andromeda-lockdrop", features = [
     "testing",
 ] }
-# andromeda-cw20-staking = { path = "../contracts/fungible-tokens/andromeda-cw20-staking", features = ["testing"] }
 
 # #Modules
 andromeda-modules = { workspace = true }
@@ -186,6 +190,10 @@ path = "fixed_amount_splitter.rs"
 [[test]]
 name = "cw20_staking"
 path = "cw20_staking.rs"
+
+[[test]]
+name = "cw20_redeem"
+path = "cw20_redeem.rs"
 
 [[test]]
 name = "ibc_registry"

--- a/tests/cw20_redeem.rs
+++ b/tests/cw20_redeem.rs
@@ -257,6 +257,17 @@ fn test_cw20_redeem_app_native() {
     let balance = router.wrap().query_balance(user1.clone(), "uandr").unwrap();
     assert_eq!(balance.amount, Uint128::from(20u128));
 
+    // Query redemption condition
+    let redemption_condition =
+        query_redemption_condition(&mut router, cw20_redeem_addr.to_string());
+    assert_eq!(
+        redemption_condition
+            .redemption
+            .unwrap()
+            .total_amount_redeemed,
+        Uint128::new(20u128)
+    );
+
     // Test cancel redemption condition
 
     // Get native balance of owner before canceling
@@ -420,6 +431,17 @@ fn test_cw20_redeem_app_cw20() {
     assert_eq!(
         redeem_contract_balance,
         OWNER_INITIAL_BALANCE.checked_sub(Uint128::new(20)).unwrap()
+    );
+
+    // Query redemption condition
+    let redemption_condition =
+        query_redemption_condition(&mut router, cw20_redeem_addr.to_string());
+    assert_eq!(
+        redemption_condition
+            .redemption
+            .unwrap()
+            .total_amount_redeemed,
+        Uint128::new(20u128)
     );
 
     // Test cancel redemption condition

--- a/tests/cw20_redeem.rs
+++ b/tests/cw20_redeem.rs
@@ -1,0 +1,366 @@
+use std::fs;
+
+use andromeda_app::app::AppComponent;
+use andromeda_app_contract::mock::{mock_andromeda_app, mock_app_instantiate_msg, MockAppContract};
+use andromeda_cw20::mock::{
+    mock_andromeda_cw20, mock_cw20_instantiate_msg, mock_cw20_send, mock_get_cw20_balance,
+    mock_get_version, mock_minter,
+};
+use andromeda_cw20_redeem::mock::mock_andromeda_cw20_redeem;
+use andromeda_cw20_redeem::mock::mock_cw20_redeem_hook_redeem_msg;
+use andromeda_cw20_redeem::mock::mock_cw20_redeem_instantiate_msg;
+use andromeda_cw20_redeem::mock::mock_cw20_redeem_start_redemption_clause_hook_msg;
+use andromeda_cw20_redeem::mock::mock_cw20_set_redemption_clause_native_msg;
+use andromeda_cw20_redeem::mock::mock_get_redemption_clause;
+use andromeda_fungible_tokens::cw20_redeem::RedemptionResponse;
+
+use andromeda_std::ado_base::version::VersionResponse;
+use andromeda_testing::{
+    mock::{mock_app, MockAndromeda, MockApp},
+    mock_builder::MockAndromedaBuilder,
+    MockContract,
+};
+use cosmwasm_std::{coin, to_json_binary, BlockInfo, Timestamp, Uint128};
+use cw20::{BalanceResponse, Cw20Coin};
+use cw_asset::AssetInfo;
+use cw_multi_test::Executor;
+use toml::Value;
+
+fn setup_andr(router: &mut MockApp) -> MockAndromeda {
+    MockAndromedaBuilder::new(router, "admin")
+        .with_wallets(vec![
+            ("owner", vec![coin(1000, "uandr"), coin(1000, "uusd")]),
+            ("user1", vec![]),
+            ("user2", vec![]),
+        ])
+        .with_contracts(vec![
+            ("cw20", mock_andromeda_cw20()),
+            ("cw20-redeem", mock_andromeda_cw20_redeem()),
+            ("app-contract", mock_andromeda_app()),
+        ])
+        .build(router)
+}
+
+fn setup_app(andr: &MockAndromeda, router: &mut MockApp) -> MockAppContract {
+    let owner = andr.get_wallet("owner");
+    let user1 = andr.get_wallet("user1");
+    let user2 = andr.get_wallet("user2");
+
+    // Create App Components
+    let initial_balances = vec![
+        Cw20Coin {
+            address: user2.to_string(),
+            amount: Uint128::from(2000u128),
+        },
+        Cw20Coin {
+            address: owner.to_string(),
+            amount: Uint128::from(10_000u128),
+        },
+    ];
+    let cw20_init_msg = mock_cw20_instantiate_msg(
+        None,
+        "Test Tokens".to_string(),
+        "TTT".to_string(),
+        6,
+        initial_balances,
+        Some(mock_minter(
+            owner.to_string(),
+            Some(Uint128::from(1000000u128)),
+        )),
+        andr.kernel.addr().to_string(),
+    );
+    let cw20_component_1 = AppComponent::new(
+        "cw20".to_string(),
+        "cw20".to_string(),
+        to_json_binary(&cw20_init_msg).unwrap(),
+    );
+
+    let initial_balances_2 = vec![
+        Cw20Coin {
+            address: user1.to_string(),
+            amount: Uint128::from(1000u128),
+        },
+        Cw20Coin {
+            address: user2.to_string(),
+            amount: Uint128::from(2000u128),
+        },
+    ];
+    let cw20_init_msg = mock_cw20_instantiate_msg(
+        None,
+        "RDM".to_string(),
+        "RDM".to_string(),
+        6,
+        initial_balances_2,
+        Some(mock_minter(
+            owner.to_string(),
+            Some(Uint128::from(1000000u128)),
+        )),
+        andr.kernel.addr().to_string(),
+    );
+    let cw20_component_2 = AppComponent::new(
+        "cw20-2".to_string(),
+        "cw20".to_string(),
+        to_json_binary(&cw20_init_msg).unwrap(),
+    );
+
+    let cw20_redeem_init_msg = mock_cw20_redeem_instantiate_msg(
+        format!("./{}", cw20_component_2.name),
+        andr.kernel.addr().to_string(),
+        Some(owner.to_string()),
+    );
+    let cw20_redeem_component = AppComponent::new(
+        "cw20redeem".to_string(),
+        "cw20-redeem".to_string(),
+        to_json_binary(&cw20_redeem_init_msg).unwrap(),
+    );
+
+    // Create App
+    let app_components = vec![cw20_component_1, cw20_component_2, cw20_redeem_component];
+    let app_init_msg = mock_app_instantiate_msg(
+        "Redeem App".to_string(),
+        app_components,
+        andr.kernel.addr().clone(),
+        None,
+    );
+
+    let app_code_id = andr.get_code_id(router, "app-contract");
+    let app = MockAppContract::instantiate(
+        app_code_id,
+        owner,
+        router,
+        app_init_msg.name,
+        app_init_msg.app_components,
+        andr.kernel.addr(),
+        None,
+    );
+
+    app
+}
+
+fn get_cw20_contract_version() -> Result<String, Box<dyn std::error::Error>> {
+    // Read the Cargo.toml file
+    let content = fs::read_to_string("../contracts/fungible-tokens/andromeda-cw20/Cargo.toml")?;
+
+    // Parse the Cargo.toml content
+    let parsed_toml = content.parse::<Value>()?;
+
+    // Extract the version string
+    if let Some(version) = parsed_toml
+        .get("package")
+        .and_then(|pkg| pkg.get("version"))
+        .and_then(|v| v.as_str())
+    {
+        Ok(version.to_string())
+    } else {
+        Err("Version not found in Cargo.toml".into())
+    }
+}
+
+#[test]
+fn test_cw20_redeem_app_native() {
+    let mut router = mock_app(None);
+
+    let andr = setup_andr(&mut router);
+    let app = setup_app(&andr, &mut router);
+    let owner = andr.get_wallet("owner");
+    let user1 = andr.get_wallet("user1");
+
+    // Component Addresses
+    let cw20_addr = andr
+        .vfs
+        .query_resolve_path(&mut router, format!("/home/{}/cw20", app.addr()));
+
+    let cw20_addr_2 = andr
+        .vfs
+        .query_resolve_path(&mut router, format!("/home/{}/cw20-2", app.addr()));
+
+    let cw20_redeem_addr = andr
+        .vfs
+        .query_resolve_path(&mut router, format!("/home/{}/cw20redeem", app.addr()));
+
+    let version: VersionResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_addr.clone(), &mock_get_version())
+        .unwrap();
+    assert_eq!(version.version, get_cw20_contract_version().unwrap());
+
+    // Start native redemption clause
+    let start_redemption_clause_msg =
+        mock_cw20_set_redemption_clause_native_msg(Uint128::new(2), None, None);
+
+    router
+        .execute_contract(
+            owner.clone(),
+            cw20_redeem_addr.clone(),
+            &start_redemption_clause_msg,
+            &[coin(1000u128, "uandr")],
+        )
+        .unwrap();
+
+    // Query redemption clause
+    let redemption_clause: RedemptionResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_redeem_addr.clone(), &mock_get_redemption_clause())
+        .unwrap();
+
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().asset,
+        AssetInfo::Native("uandr".to_string())
+    );
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().exchange_rate,
+        Uint128::new(2)
+    );
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().amount,
+        Uint128::new(1000)
+    );
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().recipient,
+        owner.to_string()
+    );
+
+    // Let user 1 redeem
+    let redeem_msg = mock_cw20_redeem_hook_redeem_msg();
+    let send_msg = mock_cw20_send(
+        cw20_redeem_addr.clone(),
+        Uint128::new(10u128),
+        to_json_binary(&redeem_msg).unwrap(),
+    );
+    // Forward time for the sale to start
+    router.set_block(BlockInfo {
+        height: router.block_info().height,
+        time: Timestamp::from_seconds(router.block_info().time.seconds() + 51),
+        chain_id: router.block_info().chain_id,
+    });
+
+    router
+        .execute_contract(user1.clone(), cw20_addr_2.clone(), &send_msg, &[])
+        .unwrap();
+
+    // Check that the redeemer has received 200 uandr and that the remetion clause recipient received 10 cw20 tokens
+    let balance_one: BalanceResponse = router
+        .wrap()
+        .query_wasm_smart(
+            cw20_addr_2.clone(),
+            &mock_get_cw20_balance(owner.to_string()),
+        )
+        .unwrap();
+    assert_eq!(balance_one.balance, Uint128::from(10u128));
+
+    // Get native balance of user1
+    let balance = router.wrap().query_balance(user1.clone(), "uandr").unwrap();
+    assert_eq!(balance.amount, Uint128::from(20u128));
+}
+
+#[test]
+fn test_cw20_redeem_app_cw20() {
+    let mut router = mock_app(None);
+
+    let andr = setup_andr(&mut router);
+    let app = setup_app(&andr, &mut router);
+    let owner = andr.get_wallet("owner");
+    let user1 = andr.get_wallet("user1");
+
+    // Component Addresses
+    let cw20_addr = andr
+        .vfs
+        .query_resolve_path(&mut router, format!("/home/{}/cw20", app.addr()));
+
+    let cw20_addr_2 = andr
+        .vfs
+        .query_resolve_path(&mut router, format!("/home/{}/cw20-2", app.addr()));
+
+    let cw20_redeem_addr = andr
+        .vfs
+        .query_resolve_path(&mut router, format!("/home/{}/cw20redeem", app.addr()));
+
+    // Start cw20 redemption clause
+    let start_redemption_clause_msg =
+        mock_cw20_redeem_start_redemption_clause_hook_msg(Uint128::new(2), None, None);
+
+    let send_msg = mock_cw20_send(
+        cw20_redeem_addr.clone(),
+        Uint128::new(100u128),
+        to_json_binary(&start_redemption_clause_msg).unwrap(),
+    );
+
+    router
+        .execute_contract(owner.clone(), cw20_addr.clone(), &send_msg, &[])
+        .unwrap();
+
+    // Query redemption clause
+    let redemption_clause: RedemptionResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_redeem_addr.clone(), &mock_get_redemption_clause())
+        .unwrap();
+
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().asset,
+        AssetInfo::Cw20(cw20_addr.clone())
+    );
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().exchange_rate,
+        Uint128::new(2)
+    );
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().amount,
+        Uint128::new(100)
+    );
+    assert_eq!(
+        redemption_clause.redemption.clone().unwrap().recipient,
+        owner.to_string()
+    );
+
+    // Let user 1 redeem
+    let redeem_msg = mock_cw20_redeem_hook_redeem_msg();
+    let send_msg = mock_cw20_send(
+        cw20_redeem_addr.clone(),
+        Uint128::new(10u128),
+        to_json_binary(&redeem_msg).unwrap(),
+    );
+    // Forward time for the sale to start
+    router.set_block(BlockInfo {
+        height: router.block_info().height,
+        time: Timestamp::from_seconds(router.block_info().time.seconds() + 51),
+        chain_id: router.block_info().chain_id,
+    });
+
+    router
+        .execute_contract(user1.clone(), cw20_addr_2.clone(), &send_msg, &[])
+        .unwrap();
+
+    // Check that the redeemer has received 200 uandr and that the redemption clause recipient received 10 cw20 tokens
+    let balance_one: BalanceResponse = router
+        .wrap()
+        .query_wasm_smart(
+            cw20_addr_2.clone(),
+            &mock_get_cw20_balance(owner.to_string()),
+        )
+        .unwrap();
+    assert_eq!(balance_one.balance, Uint128::from(10u128));
+
+    // Get cw20 balance of user1
+    let balance_one: BalanceResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_addr.clone(), &mock_get_cw20_balance(user1.to_string()))
+        .unwrap();
+    assert_eq!(balance_one.balance, Uint128::from(20u128));
+
+    // Get cw20 balance of owner
+    let balance_one: BalanceResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_addr.clone(), &mock_get_cw20_balance(owner.to_string()))
+        .unwrap();
+    assert_eq!(balance_one.balance, Uint128::from(9900u128));
+
+    // Get cw20 balance of redeem contract
+    let balance_one: BalanceResponse = router
+        .wrap()
+        .query_wasm_smart(
+            cw20_addr.clone(),
+            &mock_get_cw20_balance(cw20_redeem_addr.to_string()),
+        )
+        .unwrap();
+    assert_eq!(balance_one.balance, Uint128::from(80u128));
+}

--- a/tests/cw20_redeem.rs
+++ b/tests/cw20_redeem.rs
@@ -4,22 +4,20 @@ use andromeda_cw20::mock::{
     mock_andromeda_cw20, mock_cw20_instantiate_msg, mock_cw20_send, mock_get_cw20_balance,
     mock_minter,
 };
-use andromeda_cw20_redeem::mock::mock_andromeda_cw20_redeem;
-use andromeda_cw20_redeem::mock::mock_cw20_redeem_cancel_redemption_clause_msg;
-use andromeda_cw20_redeem::mock::mock_cw20_redeem_hook_redeem_msg;
-use andromeda_cw20_redeem::mock::mock_cw20_redeem_instantiate_msg;
-use andromeda_cw20_redeem::mock::mock_cw20_redeem_start_redemption_clause_hook_msg;
-use andromeda_cw20_redeem::mock::mock_cw20_set_redemption_clause_native_msg;
-use andromeda_cw20_redeem::mock::mock_get_redemption_clause;
+use andromeda_cw20_redeem::mock::{
+    mock_andromeda_cw20_redeem, mock_cw20_redeem_cancel_redemption_clause_msg,
+    mock_cw20_redeem_hook_redeem_msg, mock_cw20_redeem_instantiate_msg,
+    mock_cw20_redeem_start_redemption_clause_hook_msg, mock_cw20_set_redemption_clause_native_msg,
+    mock_get_redemption_clause,
+};
 use andromeda_fungible_tokens::cw20_redeem::RedemptionResponse;
-
+use andromeda_std::amp::Recipient;
 use andromeda_testing::{
     mock::{mock_app, MockAndromeda, MockApp},
     mock_builder::MockAndromedaBuilder,
     MockContract,
 };
-use cosmwasm_std::Addr;
-use cosmwasm_std::{coin, to_json_binary, BlockInfo, Timestamp, Uint128};
+use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Timestamp, Uint128};
 use cw20::{BalanceResponse, Cw20Coin};
 use cw_asset::AssetInfo;
 use cw_multi_test::Executor;
@@ -200,7 +198,7 @@ fn test_cw20_redeem_app_native() {
 
     // Start native redemption clause
     let start_redemption_clause_msg =
-        mock_cw20_set_redemption_clause_native_msg(Uint128::new(2), None, None);
+        mock_cw20_set_redemption_clause_native_msg(Uint128::new(2), None, None, None);
 
     router
         .execute_contract(
@@ -228,7 +226,7 @@ fn test_cw20_redeem_app_native() {
     );
     assert_eq!(
         redemption_clause.redemption.clone().unwrap().recipient,
-        owner.to_string()
+        Recipient::new(owner.to_string(), None)
     );
 
     // Let user 1 redeem
@@ -290,7 +288,7 @@ fn test_cw20_redeem_app_native_refund() {
 
     // Start native redemption clause
     let start_redemption_clause_msg =
-        mock_cw20_set_redemption_clause_native_msg(Uint128::new(2), None, None);
+        mock_cw20_set_redemption_clause_native_msg(Uint128::new(2), None, None, None);
 
     router
         .execute_contract(
@@ -315,7 +313,7 @@ fn test_cw20_redeem_app_native_refund() {
         .execute_contract(user1.clone(), cw20_addr_2.clone(), &send_msg, &[])
         .unwrap();
 
-    // Check that the redeemer has received 200 uandr and that the remetion clause recipient received 10 cw20 tokens
+    // Check that the redeemer has received 20 uandr and that the remetion clause recipient received 10 cw20 tokens
     let balance_one: Uint128 =
         query_cw20_balance(&mut router, cw20_addr_2.to_string(), owner.to_string());
     assert_eq!(balance_one, Uint128::from(10u128));
@@ -367,7 +365,7 @@ fn test_cw20_redeem_app_cw20() {
 
     // Start cw20 redemption clause
     let start_redemption_clause_msg =
-        mock_cw20_redeem_start_redemption_clause_hook_msg(Uint128::new(2), None, None);
+        mock_cw20_redeem_start_redemption_clause_hook_msg(Uint128::new(2), None, None, None);
 
     let send_msg = mock_cw20_send(
         cw20_redeem_addr.clone(),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -15,6 +15,9 @@ mod kernel;
 mod cw20_staking;
 
 #[cfg(test)]
+mod cw20_redeem;
+
+#[cfg(test)]
 mod lockdrop;
 
 #[cfg(test)]


### PR DESCRIPTION
# Motivation
[ANDW-179](https://linear.app/andromedaprot/issue/ANDW-179/cw20-exchange-redemption-method)

# Implementation
During instantiation, the cw20 address of the token users will be redeeming is saved in state. 

Limitations: Only one redemption clause in the contract. 

  Functionality: The owner (or admin) of the to be redeemed cw20 starts a redemption clause that sets the return asset and the exchange rate (with optional start and duration). 

The redemption clause can be cancelled anytime(any remaining funds will be refunded to owner). 
  Users can subsequently trade their cw20 for whatever is stipulated in the redemption clause. 

Users redeeming more than necessary will be refunded their surplus tokens. 



# Testing
Unit and integration tests

# Version Changes
- `cw20-exchange`: `2.1.0` -> `2.1.1-b.1`
- `cw20-redeem`: `0.1.0-b.1`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
