### PR TITLE
fix: handle local now uses resolved AndrAddr to send SubMsg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: macro error crate references [(#799)](https://github.com/andromedaprotocol/andromeda-core/pull/799)
 - fix: Prevent duplicate relay in Kernel [(#802)](https://github.com/andromedaprotocol/andromeda-core/pull/802)
 - fix: ibc username not working for ibc send with funds [(#814)](https://github.com/andromedaprotocol/andromeda-core/pull/814)
+- fix: kernel's handle_local not resolving AndrAddr [(#846)](https://github.com/andromedaprotocol/andromeda-core/pull/846)
 
 ## Release 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.1-b.4"
+version = "1.2.1-b.5"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/contracts/finance/andromeda-conditional-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-conditional-splitter/src/testing/tests.rs
@@ -9,7 +9,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     attr, from_json,
     testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR},
-    to_json_binary, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Response, SubMsg, Timestamp,
+    to_json_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Response, SubMsg, Timestamp,
     Uint128,
 };
 pub const OWNER: &str = "creator";
@@ -415,7 +415,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(4, "uandr"), Coin::new(1, "uandr")]),
             1,
         )
@@ -456,7 +456,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(2, "uandr"), Coin::new(1, "uandr")]),
             1,
         )
@@ -497,7 +497,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(50, "uandr"), Coin::new(50, "uandr")]),
             1,
         )
@@ -602,7 +602,7 @@ fn test_execute_send_ado_recipient() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1000, "uluna"), Coin::new(2000, "uluna")]),
             1,
         )
@@ -882,7 +882,7 @@ fn test_execute_send_with_multiple_thresholds() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(2, "uandr"), Coin::new(4, "uandr")]),
             1,
         )
@@ -926,7 +926,7 @@ fn test_execute_send_with_multiple_thresholds() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(7, "uandr"), Coin::new(7, "uandr")]),
             1,
         )
@@ -967,7 +967,7 @@ fn test_execute_send_with_multiple_thresholds() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1, "uandr"), Coin::new(4, "uandr")]),
             1,
         )

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/testing/tests.rs
@@ -9,7 +9,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     attr, coin, coins, from_json,
     testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR},
-    to_json_binary, BankMsg, Coin, CosmosMsg, DepsMut, Response, SubMsg,
+    to_json_binary, Addr, BankMsg, Coin, CosmosMsg, DepsMut, Response, SubMsg,
 };
 pub const OWNER: &str = "creator";
 
@@ -216,7 +216,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![
                 Coin::new(1, "uandr"),
                 Coin::new(1, "uandr"),
@@ -272,7 +272,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1, "uandr"), Coin::new(30, "usdc")]),
             1,
         )
@@ -343,7 +343,7 @@ fn test_execute_send_ado_recipient() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1, "uandr"), Coin::new(1, "uandr")]),
             1,
         )

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -9,7 +9,7 @@ use andromeda_std::{
 use cosmwasm_std::{
     attr, from_json,
     testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR},
-    to_json_binary, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Response, SubMsg, Timestamp,
+    to_json_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Response, SubMsg, Timestamp,
 };
 pub const OWNER: &str = "creator";
 
@@ -312,7 +312,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1000, "uluna"), Coin::new(2000, "uluna")]),
             1,
         )
@@ -359,7 +359,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(5000, "uluna")]),
             1,
         )
@@ -406,7 +406,7 @@ fn test_execute_send() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1000, "uluna"), Coin::new(2000, "uluna")]),
             1,
         )
@@ -471,7 +471,7 @@ fn test_execute_send_ado_recipient() {
     );
     let amp_msg = amp_pkt
         .to_sub_msg(
-            MOCK_KERNEL_CONTRACT,
+            Addr::unchecked(MOCK_KERNEL_CONTRACT),
             Some(vec![Coin::new(1000, "uluna"), Coin::new(2000, "uluna")]),
             1,
         )

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/testing/tests.rs
@@ -1035,7 +1035,7 @@ mod test {
         );
         let amp_msg = amp_pkt
             .to_sub_msg(
-                MOCK_KERNEL_CONTRACT,
+                Addr::unchecked(MOCK_KERNEL_CONTRACT),
                 Some(coins(10000, MOCK_NATIVE_DENOM)),
                 1,
             )

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.1-b.4"
+version = "1.2.1-b.5"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -456,8 +456,7 @@ pub fn amp_receive(
             .flat_map(|m| m.funds.clone())
             .collect::<Vec<Coin>>();
 
-        let new_pkt_msg =
-            new_pkt.to_sub_msg(env.contract.address.to_string(), Some(new_funds), 0)?;
+        let new_pkt_msg = new_pkt.to_sub_msg(env.contract.address, Some(new_funds), 0)?;
         res.messages.extend_from_slice(&[new_pkt_msg]);
     }
 

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -71,6 +71,8 @@ pub fn handle_local(
         ref recipient,
     } = amp_message;
 
+    let recipient_addr = recipient.get_raw_address(&deps.as_ref())?;
+
     // Handle empty message - send funds only
     if message == &Binary::default() {
         ensure!(
@@ -80,11 +82,8 @@ pub fn handle_local(
             }
         );
 
-        let (bank_msg, attrs) = create_bank_send_msg(
-            &recipient.get_raw_address(&deps.as_ref())?,
-            funds,
-            ReplyId::AMPMsg.repr(),
-        );
+        let (bank_msg, attrs) =
+            create_bank_send_msg(&recipient_addr, funds, ReplyId::AMPMsg.repr());
 
         return Ok(Response::default()
             .add_submessage(bank_msg)
@@ -101,16 +100,13 @@ pub fn handle_local(
 
     // Generate submessage based on whether recipient is an ADO or if the message is direct
     let sub_msg = if config.direct || !is_ado {
-        amp_message.generate_sub_msg_direct(
-            recipient.get_raw_address(&deps.as_ref())?,
-            ReplyId::AMPMsg.repr(),
-        )
+        amp_message.generate_sub_msg_direct(recipient_addr, ReplyId::AMPMsg.repr())
     } else {
         let origin = ctx.map_or(info.sender.to_string(), |ctx| ctx.get_origin());
         let previous_sender = info.sender.to_string();
 
         AMPPkt::new(origin, previous_sender, vec![amp_message.clone()]).to_sub_msg(
-            recipient.clone(),
+            recipient_addr,
             Some(funds.clone()),
             ReplyId::AMPMsg.repr(),
         )?

--- a/contracts/os/andromeda-kernel/src/tests/test_handler.rs
+++ b/contracts/os/andromeda-kernel/src/tests/test_handler.rs
@@ -58,7 +58,11 @@ fn test_handle_local() {
                     None,
                 )],
             )
-            .to_sub_msg(MOCK_APP_CONTRACT, None, ReplyId::AMPMsg.repr())
+            .to_sub_msg(
+                Addr::unchecked(MOCK_APP_CONTRACT),
+                None,
+                ReplyId::AMPMsg.repr(),
+            )
             .unwrap(),
             expected_error: None,
         },
@@ -76,7 +80,11 @@ fn test_handle_local() {
                     None,
                 )],
             )
-            .to_sub_msg(MOCK_APP_CONTRACT, None, ReplyId::AMPMsg.repr())
+            .to_sub_msg(
+                Addr::unchecked(MOCK_APP_CONTRACT),
+                None,
+                ReplyId::AMPMsg.repr(),
+            )
             .unwrap(),
             expected_error: None,
         },
@@ -99,7 +107,7 @@ fn test_handle_local() {
                 )],
             )
             .to_sub_msg(
-                MOCK_APP_CONTRACT,
+                Addr::unchecked(MOCK_APP_CONTRACT),
                 Some(vec![coin(100, "denom"), coin(200, "denom_two")]),
                 ReplyId::AMPMsg.repr(),
             )
@@ -221,7 +229,11 @@ fn test_handle_local() {
                 "sender",
                 vec![create_test_msg_with_config(config)],
             )
-            .to_sub_msg(MOCK_APP_CONTRACT, None, ReplyId::AMPMsg.repr())
+            .to_sub_msg(
+                Addr::unchecked(MOCK_APP_CONTRACT),
+                None,
+                ReplyId::AMPMsg.repr(),
+            )
             .unwrap(),
             expected_error: None,
         },

--- a/packages/std/src/amp/messages.rs
+++ b/packages/std/src/amp/messages.rs
@@ -431,7 +431,7 @@ impl AMPPkt {
     /// Generates a SubMsg to send the AMPPkt to the kernel
     pub fn to_sub_msg(
         &self,
-        address: impl Into<String>,
+        address: Addr,
         funds: Option<Vec<Coin>>,
         id: u64,
     ) -> Result<SubMsg, ContractError> {
@@ -630,7 +630,7 @@ mod tests {
 
         let pkt = AMPPkt::new("origin", "previoussender", vec![msg.clone()]);
 
-        let sub_msg = pkt.to_sub_msg("kernel", None, 1).unwrap();
+        let sub_msg = pkt.to_sub_msg(Addr::unchecked("kernel"), None, 1).unwrap();
 
         let expected_msg =
             ExecuteMsg::AMPReceive(AMPPkt::new("origin", "previoussender", vec![msg]));


### PR DESCRIPTION
# Motivation
All non-direct messages to ados were erroring because `handle_local` wasn't resolving the recipient's `AndrAddr`, constructing an invalid `SubMsg`

# Implementation
resolved `AndrAddr`
Changed `to_sub_msg`'s address input to `Addr` to prevent the same mistake from happening again in the future. 

# Testing
The major issue is why wasn't this bug caught in the PR that implemented that change? We already had unit tests that would've caught that bug, but they weren't ran by the CI. 
Those tests are in tests/amp/access_control.rs. 

Another finding is that the integration test `test_crowdfund_app_native_with_ado_recipient` was also failing and not being detected by the CI

# Version Changes
- `kernel`: `1.2.1-b.4` -> `1.2.1-b.5`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
