### PR TITLE
Fixed Deploy os workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9.4.2
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.4.2
+          version: 9.14.2
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,10 @@ on:
           - mainnet
           - testnet
           - testnet-staging
+      run_armor_workflow:
+        description: "Run Armor workflow"
+        required: false
+        type: boolean
 
 jobs:
   build_deploy_script:
@@ -150,7 +154,7 @@ jobs:
 
   trigger-armour-workflow:
     needs: [trigger-schema-parser]
-    if: needs.trigger-schema-parser.outputs.should_continue == 'true'
+    if: ${{ inputs.run_armor_workflow == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Wait for schema updates


### PR DESCRIPTION
Fixed pnpm version config error that was breaking the schema parser.
Made Armor workflow optional.
Proof for pnpm version:
https://github.com/andromedaprotocol/andromeda-core/actions/runs/14332059982
armor workflow optional:
https://github.com/andromedaprotocol/andromeda-core/actions/runs/14332433510