### PR TITLE
fix: TimeLock Hold Funds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5103,6 +5103,7 @@ dependencies = [
  "andromeda-splitter",
  "andromeda-std",
  "andromeda-testing",
+ "andromeda-timelock",
  "andromeda-validator-staking",
  "andromeda-vesting",
  "andromeda-vfs",

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
-testing = ["cw-multi-test"]
+testing = ["cw-multi-test", "andromeda-testing"]
 
 
 [dependencies]
@@ -27,7 +27,7 @@ andromeda-finance = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-orch = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
-
+andromeda-testing = { workspace = true, optional = true }
 
 [dev-dependencies]
 andromeda-app = { workspace = true }

--- a/contracts/finance/andromeda-timelock/src/contract.rs
+++ b/contracts/finance/andromeda-timelock/src/contract.rs
@@ -1,5 +1,5 @@
 use andromeda_finance::timelock::{
-    Escrow, EscrowCondition, ExecuteMsg, GetLockedFundsForRecipientResponse,
+    Escrow, EscrowConditionInput, ExecuteMsg, GetLockedFundsForRecipientResponse,
     GetLockedFundsResponse, InstantiateMsg, QueryMsg,
 };
 use andromeda_std::{
@@ -69,7 +69,7 @@ pub fn execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, Contrac
 
 fn execute_hold_funds(
     ctx: ExecuteContext,
-    condition: Option<EscrowCondition>,
+    condition: Option<EscrowConditionInput>,
     recipient: Option<Recipient>,
 ) -> Result<Response, ContractError> {
     let ExecuteContext {
@@ -85,7 +85,7 @@ fn execute_hold_funds(
     let key = get_key(info.sender.as_str(), recipient_addr.as_str());
     let mut escrow = Escrow {
         coins: info.funds,
-        condition,
+        condition: condition.map(|c| c.to_condition(&env.block)),
         recipient: rec,
         recipient_addr: recipient_addr.into_string(),
     };
@@ -119,7 +119,7 @@ fn execute_release_funds(
     let ExecuteContext {
         deps, info, env, ..
     } = ctx;
-    let recipient_addr = recipient_addr.unwrap_or_else(|| info.sender.to_string());
+    let recipient_addr = recipient_addr.unwrap_or(info.sender.to_string());
 
     let keys = get_keys_for_recipient(deps.storage, &recipient_addr, start_after, limit)?;
 

--- a/contracts/finance/andromeda-timelock/src/lib.rs
+++ b/contracts/finance/andromeda-timelock/src/lib.rs
@@ -7,3 +7,6 @@ mod testing;
 mod interface;
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::interface::TimelockContract;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+pub mod mock;

--- a/contracts/finance/andromeda-timelock/src/mock.rs
+++ b/contracts/finance/andromeda-timelock/src/mock.rs
@@ -1,0 +1,92 @@
+#![cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
+use crate::contract::{execute, instantiate, query, reply};
+use andromeda_finance::timelock::{EscrowConditionInput, ExecuteMsg, InstantiateMsg, QueryMsg};
+use andromeda_std::amp::Recipient;
+use andromeda_testing::{
+    mock::MockApp, mock_ado, mock_contract::ExecuteResult, MockADO, MockContract,
+};
+use cosmwasm_std::{Addr, Coin, Empty};
+use cw_multi_test::{Contract, ContractWrapper, Executor};
+
+pub struct MockTimelock(Addr);
+mock_ado!(MockTimelock, ExecuteMsg, QueryMsg);
+
+impl MockTimelock {
+    #[allow(clippy::too_many_arguments)]
+    pub fn instantiate(
+        app: &mut MockApp,
+        code_id: u64,
+        sender: Addr,
+        kernel_address: impl Into<String>,
+        owner: Option<String>,
+    ) -> Self {
+        let msg = mock_timelock_instantiate_msg(kernel_address, owner);
+        let res = app.instantiate_contract(code_id, sender, &msg, &[], "Andromeda timelock", None);
+
+        Self(res.unwrap())
+    }
+
+    pub fn execute_hold_funds(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        funds: &[Coin],
+        condition: Option<EscrowConditionInput>,
+        recipient: Option<Recipient>,
+    ) -> ExecuteResult {
+        let msg = mock_timelock_hold_funds_msg(condition, recipient);
+
+        self.execute(app, &msg, sender, funds)
+    }
+
+    pub fn execute_release_funds(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        funds: &[Coin],
+        recipient_addr: Option<String>,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    ) -> ExecuteResult {
+        let msg = mock_timelock_release_funds_msg(recipient_addr, start_after, limit);
+
+        self.execute(app, &msg, sender, funds)
+    }
+}
+
+pub fn mock_andromeda_timelock() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new_with_empty(execute, instantiate, query).with_reply(reply);
+    Box::new(contract)
+}
+
+pub fn mock_timelock_instantiate_msg(
+    kernel_address: impl Into<String>,
+    owner: Option<String>,
+) -> InstantiateMsg {
+    InstantiateMsg {
+        kernel_address: kernel_address.into(),
+        owner,
+    }
+}
+
+pub fn mock_timelock_hold_funds_msg(
+    condition: Option<EscrowConditionInput>,
+    recipient: Option<Recipient>,
+) -> ExecuteMsg {
+    ExecuteMsg::HoldFunds {
+        condition,
+        recipient,
+    }
+}
+
+pub fn mock_timelock_release_funds_msg(
+    recipient_addr: Option<String>,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> ExecuteMsg {
+    ExecuteMsg::ReleaseFunds {
+        recipient_addr,
+        start_after,
+        limit,
+    }
+}

--- a/packages/andromeda-finance/src/timelock.rs
+++ b/packages/andromeda-finance/src/timelock.rs
@@ -1,7 +1,7 @@
 use andromeda_std::{
     amp::recipient::Recipient,
     andr_exec, andr_instantiate, andr_query,
-    common::{expiration::Expiry, merge_coins},
+    common::{expiration::Expiry, merge_coins, MillisecondsExpiration},
     error::ContractError,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
@@ -9,9 +9,31 @@ use cosmwasm_std::{ensure, Api, BlockInfo, Coin};
 
 #[cw_serde]
 /// Enum used to specify the condition which must be met in order for the Escrow to unlock.
-pub enum EscrowCondition {
+pub enum EscrowConditionInput {
     /// Requires a given time
     Expiration(Expiry),
+    /// Requires a minimum amount of funds to be deposited.
+    MinimumFunds(Vec<Coin>),
+}
+
+impl EscrowConditionInput {
+    /// Converts an EscrowConditionInput to an EscrowCondition
+    /// Leaving as it is would cause From Now to never expire since, the "now" would be every time the release function is called.
+    pub fn to_condition(self, block: &BlockInfo) -> EscrowCondition {
+        match self {
+            EscrowConditionInput::Expiration(expiry) => {
+                EscrowCondition::Expiration(expiry.get_time(block))
+            }
+            EscrowConditionInput::MinimumFunds(funds) => EscrowCondition::MinimumFunds(funds),
+        }
+    }
+}
+
+#[cw_serde]
+/// Enum used to specify the condition which must be met in order for the Escrow to unlock.
+pub enum EscrowCondition {
+    /// Requires a given time
+    Expiration(MillisecondsExpiration),
     /// Requires a minimum amount of funds to be deposited.
     MinimumFunds(Vec<Coin>),
 }
@@ -80,9 +102,7 @@ impl Escrow {
         match &self.condition {
             None => Ok(false),
             Some(condition) => match condition {
-                EscrowCondition::Expiration(expiration) => {
-                    Ok(!expiration.get_time(block).is_expired(block))
-                }
+                EscrowCondition::Expiration(expiration) => Ok(!expiration.is_expired(block)),
                 EscrowCondition::MinimumFunds(funds) => {
                     Ok(!self.min_funds_deposited(funds.clone()))
                 }
@@ -123,7 +143,7 @@ pub struct InstantiateMsg {}
 pub enum ExecuteMsg {
     /// Hold funds in Escrow
     HoldFunds {
-        condition: Option<EscrowCondition>,
+        condition: Option<EscrowConditionInput>,
         recipient: Option<Recipient>,
     },
     /// Release funds all held in Escrow for the given recipient
@@ -170,15 +190,13 @@ pub struct GetLockedFundsForRecipientResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use andromeda_std::common::Milliseconds;
     use cosmwasm_std::testing::mock_dependencies;
     use cosmwasm_std::{coin, Timestamp};
 
     #[test]
     fn test_validate() {
         let deps = mock_dependencies();
-        let condition =
-            EscrowCondition::Expiration(Expiry::FromNow(Milliseconds::from_seconds(101)));
+        let condition = EscrowCondition::Expiration(MillisecondsExpiration::from_seconds(101));
         let coins = vec![coin(100u128, "uluna")];
         let recipient = Recipient::from_string("owner");
 
@@ -240,9 +258,9 @@ mod tests {
         let invalid_time_escrow = Escrow {
             recipient,
             coins,
-            condition: Some(EscrowCondition::Expiration(Expiry::AtTime(
-                Milliseconds::from_seconds(0),
-            ))),
+            condition: Some(EscrowCondition::Expiration(
+                MillisecondsExpiration::from_seconds(0),
+            )),
             recipient_addr: "owner".to_string(),
         };
         let block = BlockInfo {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -82,6 +82,10 @@ andromeda-rate-limiting-withdrawals = { path = "../contracts/finance/andromeda-r
     "testing"
 ] }
 
+andromeda-timelock = { path = "../contracts/finance/andromeda-timelock", features = [
+    "testing"
+] }
+
 
 # Data Storage
 andromeda-data-storage = { workspace = true }
@@ -202,6 +206,10 @@ path = "conditional_splitter.rs"
 [[test]]
 name = "cw20_app"
 path = "cw20_app.rs"
+
+[[test]]
+name = "timelock"
+path = "timelock.rs"
 
 [[test]]
 name = "kernel"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -19,8 +19,12 @@ mod lockdrop;
 
 #[cfg(test)]
 mod cw721;
+
 #[cfg(test)]
 mod validator_staking;
+
+#[cfg(test)]
+mod timelock;
 
 #[cfg(test)]
 mod cw20_app;

--- a/tests/timelock.rs
+++ b/tests/timelock.rs
@@ -1,0 +1,221 @@
+use andromeda_app::app::AppComponent;
+use andromeda_app_contract::mock::{mock_andromeda_app, mock_claim_ownership_msg, MockAppContract};
+use andromeda_finance::timelock::EscrowConditionInput;
+use andromeda_std::{
+    common::{expiration::Expiry, Milliseconds},
+    error::ContractError,
+};
+use andromeda_testing::{
+    mock::mock_app, mock_builder::MockAndromedaBuilder, mock_contract::MockContract,
+};
+use andromeda_timelock::mock::{
+    mock_andromeda_timelock, mock_timelock_instantiate_msg, MockTimelock,
+};
+use cosmwasm_std::{coin, to_json_binary, Addr, Uint128};
+use cw_multi_test::Executor;
+const ORIGINAL_BALANCE: u128 = 10_000;
+#[test]
+fn test_timelock() {
+    let mut router = mock_app(None);
+    let andr = MockAndromedaBuilder::new(&mut router, "admin")
+        .with_wallets(vec![("owner", vec![coin(ORIGINAL_BALANCE, "uandr")])])
+        .with_contracts(vec![
+            ("timelock", mock_andromeda_timelock()),
+            ("app-contract", mock_andromeda_app()),
+        ])
+        .build(&mut router);
+    let owner = andr.get_wallet("owner");
+
+    // Generate App Components
+    let timelock_init_msg = mock_timelock_instantiate_msg(andr.kernel.addr().to_string(), None);
+    let timelock_component = AppComponent::new(
+        "timelock".to_string(),
+        "timelock".to_string(),
+        to_json_binary(&timelock_init_msg).unwrap(),
+    );
+
+    // Create App
+    let app_components = vec![timelock_component.clone()];
+    let app = MockAppContract::instantiate(
+        andr.get_code_id(&mut router, "app-contract"),
+        &owner,
+        &mut router,
+        "timelock App",
+        app_components,
+        andr.kernel.addr(),
+        Some(owner.to_string()),
+    );
+
+    router
+        .execute_contract(
+            owner.clone(),
+            Addr::unchecked(app.addr().clone()),
+            &mock_claim_ownership_msg(None),
+            &[],
+        )
+        .unwrap();
+
+    let timelock: MockTimelock = app.query_ado_by_component_name(&router, timelock_component.name);
+
+    // Test Case 1: Expiration from now
+
+    // Hold Funds for 1 day in milliseconds
+    let escrow_condition =
+        EscrowConditionInput::Expiration(Expiry::FromNow(Milliseconds::from_seconds(86_400)));
+    timelock
+        .execute_hold_funds(
+            &mut router,
+            owner.clone(),
+            &[coin(1000, "uandr")],
+            Some(escrow_condition),
+            None,
+        )
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(
+        owner_balance.amount,
+        Uint128::from(ORIGINAL_BALANCE - 1000u128)
+    );
+
+    // Let one hour elapse
+    let block_time_plus_1h = router.block_info().time.plus_hours(1);
+    router.update_block(|block| {
+        block.time = block_time_plus_1h;
+    });
+    assert_eq!(block_time_plus_1h, router.block_info().time);
+
+    // Try to release funds - should fail
+    let err: ContractError = timelock
+        .execute_release_funds(&mut router, owner.clone(), &[], None, None, None)
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+
+    assert_eq!(err, ContractError::FundsAreLocked {});
+
+    // Let two days elapse
+    let block_time_plus_2d = router.block_info().time.plus_days(2);
+    router.update_block(|block| {
+        block.time = block_time_plus_2d;
+    });
+
+    // Ensure that the time has passed
+    assert_eq!(block_time_plus_2d, router.block_info().time);
+
+    // Release funds - should succeed
+    timelock
+        .execute_release_funds(&mut router, owner.clone(), &[], None, None, None)
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(owner_balance.amount, Uint128::from(ORIGINAL_BALANCE));
+
+    // Test Case 2: Expiration at specific time
+
+    // Hold Funds for 1 day in milliseconds
+    let escrow_condition = EscrowConditionInput::Expiration(Expiry::AtTime(
+        Milliseconds::from_seconds(router.block_info().time.plus_days(1).seconds()),
+    ));
+    timelock
+        .execute_hold_funds(
+            &mut router,
+            owner.clone(),
+            &[coin(1000, "uandr")],
+            Some(escrow_condition),
+            None,
+        )
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(
+        owner_balance.amount,
+        Uint128::from(ORIGINAL_BALANCE - 1000u128)
+    );
+
+    // Let one hour elapse
+    let block_time_plus_1h = router.block_info().time.plus_hours(1);
+    router.update_block(|block| {
+        block.time = block_time_plus_1h;
+    });
+    assert_eq!(block_time_plus_1h, router.block_info().time);
+
+    // Try to release funds - should fail
+    let err: ContractError = timelock
+        .execute_release_funds(&mut router, owner.clone(), &[], None, None, None)
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+
+    assert_eq!(err, ContractError::FundsAreLocked {});
+
+    // Let two days elapse
+    let block_time_plus_2d = router.block_info().time.plus_days(2);
+    router.update_block(|block| {
+        block.time = block_time_plus_2d;
+    });
+
+    // Ensure that the time has passed
+    assert_eq!(block_time_plus_2d, router.block_info().time);
+
+    // Release funds - should succeed
+    timelock
+        .execute_release_funds(&mut router, owner.clone(), &[], None, None, None)
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(owner_balance.amount, Uint128::from(ORIGINAL_BALANCE));
+
+    // Test Case 3: Minimum Funds
+
+    let escrow_condition = EscrowConditionInput::MinimumFunds(vec![coin(1000, "uandr")]);
+    timelock
+        .execute_hold_funds(
+            &mut router,
+            owner.clone(),
+            &[coin(100, "uandr")],
+            Some(escrow_condition),
+            None,
+        )
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(
+        owner_balance.amount,
+        Uint128::from(ORIGINAL_BALANCE - 100u128)
+    );
+
+    // Try to release funds - should fail
+    let err: ContractError = timelock
+        .execute_release_funds(&mut router, owner.clone(), &[], None, None, None)
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+
+    assert_eq!(err, ContractError::FundsAreLocked {});
+
+    let escrow_condition = EscrowConditionInput::MinimumFunds(vec![coin(1000, "uandr")]);
+    timelock
+        .execute_hold_funds(
+            &mut router,
+            owner.clone(),
+            &[coin(900, "uandr")],
+            Some(escrow_condition),
+            None,
+        )
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(
+        owner_balance.amount,
+        Uint128::from(ORIGINAL_BALANCE - 1000u128)
+    );
+
+    // Release funds - should succeed
+    timelock
+        .execute_release_funds(&mut router, owner.clone(), &[], None, None, None)
+        .unwrap();
+
+    let owner_balance = router.wrap().query_balance(owner, "uandr").unwrap();
+    assert_eq!(owner_balance.amount, Uint128::from(ORIGINAL_BALANCE));
+}


### PR DESCRIPTION
# Motivation
Saving `Expiration(Expiry)` in `Escrow` lead the `FromNow` expiry type to never expire. It's because the "Now" was every time the user called the function. 

# Implementation
- Added `EscrowConditionInput` to keep the flexibility of using `Expiry`
- Modified `EscrowCondition` to convert Expiry to Milliseconds

# Testing
Integration test

# Version Changes
- `timelock`: `2.1.1-b.1` -> `2.1.1-b.2`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
