### PR TITLE
chore: version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Prevent duplicate relay in Kernel [(#802)](https://github.com/andromedaprotocol/andromeda-core/pull/802)
 - fix: ibc username not working for ibc send with funds [(#814)](https://github.com/andromedaprotocol/andromeda-core/pull/814)
 - fix: kernel's handle_local not resolving AndrAddr [(#846)](https://github.com/andromedaprotocol/andromeda-core/pull/846)
+- fix: Added missing version bumps [(#858)](https://github.com/andromedaprotocol/andromeda-core/pull/858)
 
 ## Release 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.1.0"
+version = "2.1.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.2.0"
+version = "1.2.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.3.0-beta"
+version = "1.3.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-curve"
-version = "0.2.0"
+version = "0.2.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.1.0"
+version = "2.1.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.2.0-b.2"
+version = "2.2.0-b.3"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-distance"
-version = "0.1.0-a.1"
+version = "0.1.0-a.2"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.1-b.1"
+version = "1.2.1-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-graph"
-version = "0.1.0"
+version = "0.1.1-b.1"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-point"
-version = "0.1.0"
+version = "0.1.1-b.1"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-primitive"
-version = "2.1.0"
+version = "2.1.1-b.1"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.1-b.1"
+version = "2.1.1-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rates"
-version = "2.0.4"
+version = "2.0.5-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.3.1-b.1"
+version = "2.3.1-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-time-gate"
-version = "0.1.0-b.1"
+version = "0.1.0-a.2"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.1.0"
+version = "3.1.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0"
+version = "2.1.1-b.1"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.2.0"
+version = "1.2.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-primitive"
-version = "2.1.0"
+version = "2.1.1-b.1"
 authors = [
   "Connor Barr <crnbarr@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.3.0-beta"
+version = "1.3.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.1-b.1"
+version = "1.2.1-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.1-b.1"
+version = "2.1.1-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.3.1-b.1"
+version = "2.3.1-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.1.0"
+version = "3.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.0"
+version = "2.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.1.0"
+version = "2.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/math/andromeda-curve/Cargo.toml
+++ b/contracts/math/andromeda-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-curve"
-version = "0.2.0"
+version = "0.2.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/math/andromeda-distance/Cargo.toml
+++ b/contracts/math/andromeda-distance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-distance"
-version = "0.1.0-a.1"
+version = "0.1.0-a.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/math/andromeda-graph/Cargo.toml
+++ b/contracts/math/andromeda-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-graph"
-version = "0.1.0"
+version = "0.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/math/andromeda-point/Cargo.toml
+++ b/contracts/math/andromeda-point/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-point"
-version = "0.1.0"
+version = "0.1.1-b.1"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/math/andromeda-time-gate/Cargo.toml
+++ b/contracts/math/andromeda-time-gate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-time-gate"
-version = "0.1.0-b.1"
+version = "0.1.0-a.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.1.0"
+version = "2.1.1-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rates"
-version = "2.0.4"
+version = "2.0.5-b.1"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.2.0-b.2"
+version = "2.2.0-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"


### PR DESCRIPTION
# Motivation
Version updates that should've taken place with the amp ctx PR

# Implementation
Bumped ADOs:

1. address-list 
2. app-contract 
3. conditional-splitter
4. curve 
5. cw20 
6. cw721
7. distance
8. fixed amount splitter
9. graph
10. point
11. primitive
12. rate-limiting-withdrawl
13. rates
14. splitter
15. timegate (also changed from beta tag to alpha tag)
16. vesting
17. weighted-distribution-splitter

# Testing
None

# Version Changes
One minor version bump for all of the above

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
