### PR TITLE
ref: Merge Limited Permission into Whitelisted

### DIFF
--- a/contracts/data-storage/andromeda-boolean/src/contract.rs
+++ b/contracts/data-storage/andromeda-boolean/src/contract.rs
@@ -60,7 +60,7 @@ pub fn instantiate(
                 None => info.sender,
                 Some(owner) => Addr::unchecked(owner),
             },
-            Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+            Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
         )?;
     }
 

--- a/contracts/data-storage/andromeda-form/src/contract.rs
+++ b/contracts/data-storage/andromeda-form/src/contract.rs
@@ -113,7 +113,7 @@ pub fn instantiate(
                 deps.storage,
                 SUBMIT_FORM_ACTION,
                 addr,
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
         }
     }

--- a/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/testing/tests.rs
@@ -124,7 +124,7 @@ fn test_transfer() {
     assert_eq!(err, ContractError::Unauthorized {});
 
     // Now whitelist the sender, that should allow him to call the function successfully
-    let permission = Permission::Local(LocalPermission::whitelisted(None, None, None, None));
+    let permission = Permission::Local(LocalPermission::whitelisted(None, None, None, None, None));
     let actors = vec![AndrAddr::from_string("sender")];
     let action = "Transfer";
     let ctx = ExecuteContext::new(deps.as_mut(), mock_info("owner", &[]), mock_env());

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/src/contract.rs
@@ -68,7 +68,7 @@ pub fn instantiate(
             deps.storage,
             SEND_CW20_ACTION,
             addr,
-            Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+            Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
         )?;
     }
 

--- a/contracts/math/andromeda-curve/src/contract.rs
+++ b/contracts/math/andromeda-curve/src/contract.rs
@@ -60,13 +60,13 @@ pub fn instantiate(
                 deps.storage,
                 UPDATE_CURVE_CONFIG_ACTION,
                 addr.clone(),
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
             ADOContract::set_permission(
                 deps.storage,
                 RESET_ACTION,
                 addr.clone(),
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
         }
     }

--- a/contracts/math/andromeda-matrix/src/contract.rs
+++ b/contracts/math/andromeda-matrix/src/contract.rs
@@ -57,13 +57,13 @@ pub fn instantiate(
                 deps.storage,
                 STORE_MATRIX_ACTION,
                 addr.clone(),
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
             ADOContract::set_permission(
                 deps.storage,
                 DELETE_MATRIX_ACTION,
                 addr.clone(),
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
         }
     }

--- a/contracts/modules/andromeda-address-list/src/contract.rs
+++ b/contracts/modules/andromeda-address-list/src/contract.rs
@@ -44,6 +44,7 @@ pub fn instantiate(
         actor_permission.permission = if let LocalPermission::Whitelisted {
             start,
             expiration,
+            uses,
             frequency,
             ..
         } = actor_permission.permission
@@ -51,6 +52,7 @@ pub fn instantiate(
             LocalPermission::Whitelisted {
                 start,
                 expiration,
+                uses,
                 frequency,
                 last_used: None,
             }
@@ -69,7 +71,7 @@ pub fn instantiate(
         deps.storage,
         PERMISSION_ACTORS_ACTION.to_string(),
         info.sender.clone(),
-        Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+        Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
     )?;
 
     let inst_resp = ADOContract::default().instantiate(

--- a/contracts/modules/andromeda-address-list/src/testing/tests.rs
+++ b/contracts/modules/andromeda-address-list/src/testing/tests.rs
@@ -26,7 +26,7 @@ fn init(deps: DepsMut, info: MessageInfo) {
             owner: None,
             actor_permission: Some(ActorPermission {
                 actors: vec![AndrAddr::from_string("actor")],
-                permission: LocalPermission::whitelisted(None, None, None, None),
+                permission: LocalPermission::whitelisted(None, None, None, None, None),
             }),
         },
     )

--- a/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/contract.rs
@@ -284,7 +284,7 @@ fn execute_start_auction(
                 deps.storage,
                 auction_id.to_string(),
                 whitelisted_address,
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
         }
     };
@@ -406,7 +406,7 @@ fn execute_update_auction(
                 deps.storage,
                 token_auction_state.auction_id.to_string(),
                 whitelisted_address,
-                Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+                Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
             )?;
         }
     };

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/src/contract.rs
@@ -73,7 +73,7 @@ pub fn instantiate(
             deps.storage,
             SEND_CW20_ACTION,
             addr,
-            Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+            Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
         )?;
     }
 

--- a/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/src/testing/tests.rs
@@ -227,7 +227,7 @@ fn test_instantiate_with_multiple_authorized_cw20_addresses() {
         assert_eq!(
             permission,
             Some(Permission::Local(LocalPermission::whitelisted(
-                None, None, None, None
+                None, None, None, None, None
             )))
         );
     }
@@ -1012,7 +1012,7 @@ fn test_execute_authorize_cw20_contract() {
     assert_eq!(
         permission,
         Some(Permission::Local(LocalPermission::whitelisted(
-            None, None, None, None
+            None, None, None, None, None
         )))
     );
 
@@ -1049,6 +1049,7 @@ fn test_execute_authorize_cw20_contract() {
             Some(expiration),
             None,
             None,
+            None,
         )))
     );
 }
@@ -1074,7 +1075,7 @@ fn test_execute_deauthorize_cw20_contract() {
     assert_eq!(
         permission,
         Some(Permission::Local(LocalPermission::whitelisted(
-            None, None, None, None
+            None, None, None, None, None
         )))
     );
 

--- a/contracts/os/andromeda-ibc-registry/src/contract.rs
+++ b/contracts/os/andromeda-ibc-registry/src/contract.rs
@@ -56,7 +56,7 @@ pub fn instantiate(
         deps.storage,
         STORE_DENOM_INFO,
         service_address.clone(),
-        Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+        Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
     )?;
 
     Ok(resp.add_attribute("service_address", service_address))

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -60,16 +60,12 @@ pub enum LocalPermission {
         start: Option<Expiry>,
         expiration: Option<Expiry>,
     },
-    Limited {
-        #[serde(default)]
-        start: Option<Expiry>,
-        expiration: Option<Expiry>,
-        uses: u32,
-    },
+
     Whitelisted {
         #[serde(default)]
         start: Option<Expiry>,
         expiration: Option<Expiry>,
+        uses: Option<u32>,
         frequency: Option<Milliseconds>,
         last_used: Option<Milliseconds>,
     },
@@ -80,6 +76,7 @@ impl std::default::Default for LocalPermission {
         Self::Whitelisted {
             start: None,
             expiration: None,
+            uses: None,
             frequency: None,
             last_used: None,
         }
@@ -94,22 +91,32 @@ impl LocalPermission {
     pub fn whitelisted(
         start: Option<Expiry>,
         expiration: Option<Expiry>,
+        uses: Option<u32>,
         frequency: Option<Milliseconds>,
         last_used: Option<Milliseconds>,
     ) -> Self {
         Self::Whitelisted {
             start,
             expiration,
+            uses,
             frequency,
             last_used,
         }
     }
 
-    pub fn limited(start: Option<Expiry>, expiration: Option<Expiry>, uses: u32) -> Self {
-        Self::Limited {
+    pub fn limited(
+        start: Option<Expiry>,
+        expiration: Option<Expiry>,
+        uses: u32,
+        frequency: Option<Milliseconds>,
+        last_used: Option<Milliseconds>,
+    ) -> Self {
+        Self::Whitelisted {
             start,
             expiration,
-            uses,
+            uses: Some(uses),
+            frequency,
+            last_used,
         }
     }
 
@@ -129,29 +136,10 @@ impl LocalPermission {
                 }
                 false
             }
-            Self::Limited {
-                start,
-                expiration,
-                uses,
-            } => {
-                if let Some(start) = start {
-                    if !start.get_time(&env.block).is_expired(&env.block) {
-                        return true;
-                    }
-                }
-                if let Some(expiration) = expiration {
-                    if expiration.get_time(&env.block).is_expired(&env.block) {
-                        return !strict;
-                    }
-                }
-                if *uses == 0 {
-                    return !strict;
-                }
-                true
-            }
             Self::Whitelisted {
                 start,
                 expiration,
+                uses,
                 frequency,
                 last_used,
             } => {
@@ -162,6 +150,11 @@ impl LocalPermission {
                 }
                 if let Some(expiration) = expiration {
                     if expiration.get_time(&env.block).is_expired(&env.block) {
+                        return !strict;
+                    }
+                }
+                if let Some(uses) = uses {
+                    if *uses == 0 {
                         return !strict;
                     }
                 }
@@ -187,9 +180,6 @@ impl LocalPermission {
             Self::Blacklisted { expiration, .. } => {
                 expiration.clone().unwrap_or_default().get_time(&env.block)
             }
-            Self::Limited { expiration, .. } => {
-                expiration.clone().unwrap_or_default().get_time(&env.block)
-            }
             Self::Whitelisted { expiration, .. } => {
                 expiration.clone().unwrap_or_default().get_time(&env.block)
             }
@@ -201,7 +191,6 @@ impl LocalPermission {
             Self::Blacklisted { start, .. } => {
                 start.clone().unwrap_or_default().get_time(&env.block)
             }
-            Self::Limited { start, .. } => start.clone().unwrap_or_default().get_time(&env.block),
             Self::Whitelisted { start, .. } => {
                 start.clone().unwrap_or_default().get_time(&env.block)
             }
@@ -209,19 +198,17 @@ impl LocalPermission {
     }
 
     pub fn consume_use(&mut self) -> Result<(), ContractError> {
-        if let Self::Limited { uses, .. } = self {
-            *uses = uses.saturating_sub(1);
+        if let Self::Whitelisted { uses, .. } = self {
+            if let Some(uses) = uses {
+                *uses = uses.saturating_sub(1);
+            }
         }
-
         Ok(())
     }
 
     pub fn validate_times(&self, env: &Env) -> Result<(), ContractError> {
         let (start, expiration) = match self {
             Self::Blacklisted { start, expiration }
-            | Self::Limited {
-                start, expiration, ..
-            }
             | Self::Whitelisted {
                 start, expiration, ..
             } => (start, expiration),
@@ -261,68 +248,107 @@ impl fmt::Display for LocalPermission {
                 (None, Some(e)) => format!("blacklisted until:{e}"),
                 (None, None) => "blacklisted".to_string(),
             },
-            Self::Limited {
-                start,
-                expiration,
-                uses,
-            } => match (start, expiration) {
-                (Some(s), Some(e)) => format!("limited starting from:{s} until:{e} uses:{uses}"),
-                (Some(s), None) => format!("limited starting from:{s} uses:{uses}"),
-                (None, Some(e)) => format!("limited until:{e} uses:{uses}"),
-                (None, None) => format!("limited uses:{uses}"),
-            },
             Self::Whitelisted {
                 start,
                 expiration,
+                uses,
                 frequency,
                 last_used,
-            } => match (start, expiration, frequency, last_used) {
-                (Some(s), Some(e), Some(f), Some(l)) => {
+            } => match (start, expiration, frequency, last_used, uses) {
+                (Some(s), Some(e), Some(f), Some(l), Some(u)) => {
+                    format!("whitelisted starting from:{s} until:{e} frequency:{f} last_used:{l} uses:{u}")
+                }
+                (Some(s), Some(e), Some(f), Some(l), None) => {
                     format!("whitelisted starting from:{s} until:{e} frequency:{f} last_used:{l}")
                 }
-                (Some(s), Some(e), Some(f), None) => {
+                (Some(s), Some(e), Some(f), None, Some(u)) => {
+                    format!("whitelisted starting from:{s} until:{e} frequency:{f} uses:{u}")
+                }
+                (Some(s), Some(e), Some(f), None, None) => {
                     format!("whitelisted starting from:{s} until:{e} frequency:{f}")
                 }
-                (Some(s), Some(e), None, Some(l)) => {
+                (Some(s), Some(e), None, Some(l), Some(u)) => {
+                    format!("whitelisted starting from:{s} until:{e} last_used:{l} uses:{u}")
+                }
+                (Some(s), Some(e), None, Some(l), None) => {
                     format!("whitelisted starting from:{s} until:{e} last_used:{l}")
                 }
-                (Some(s), Some(e), None, None) => {
+                (Some(s), Some(e), None, None, Some(u)) => {
+                    format!("whitelisted starting from:{s} until:{e} uses:{u}")
+                }
+                (Some(s), Some(e), None, None, None) => {
                     format!("whitelisted starting from:{s} until:{e}")
                 }
-                (Some(s), None, Some(f), Some(l)) => {
+                (Some(s), None, Some(f), Some(l), Some(u)) => {
+                    format!("whitelisted starting from:{s} frequency:{f} last_used:{l} uses:{u}")
+                }
+                (Some(s), None, Some(f), Some(l), None) => {
                     format!("whitelisted starting from:{s} frequency:{f} last_used:{l}")
                 }
-                (Some(s), None, Some(f), None) => {
+                (Some(s), None, Some(f), None, Some(u)) => {
+                    format!("whitelisted starting from:{s} frequency:{f} uses:{u}")
+                }
+                (Some(s), None, Some(f), None, None) => {
                     format!("whitelisted starting from:{s} frequency:{f}")
                 }
-                (Some(s), None, None, Some(l)) => {
+                (Some(s), None, None, Some(l), Some(u)) => {
+                    format!("whitelisted starting from:{s} last_used:{l} uses:{u}")
+                }
+                (Some(s), None, None, Some(l), None) => {
                     format!("whitelisted starting from:{s} last_used:{l}")
                 }
-                (Some(s), None, None, None) => {
+                (Some(s), None, None, None, Some(u)) => {
+                    format!("whitelisted starting from:{s} uses:{u}")
+                }
+                (Some(s), None, None, None, None) => {
                     format!("whitelisted starting from:{s}")
                 }
-                (None, Some(e), Some(f), Some(l)) => {
+                (None, Some(e), Some(f), Some(l), Some(u)) => {
+                    format!("whitelisted until:{e} frequency:{f} last_used:{l} uses:{u}")
+                }
+                (None, Some(e), Some(f), Some(l), None) => {
                     format!("whitelisted until:{e} frequency:{f} last_used:{l}")
                 }
-                (None, Some(e), Some(f), None) => {
+                (None, Some(e), Some(f), None, Some(u)) => {
+                    format!("whitelisted until:{e} frequency:{f} uses:{u}")
+                }
+                (None, Some(e), Some(f), None, None) => {
                     format!("whitelisted until:{e} frequency:{f}")
                 }
-                (None, Some(e), None, Some(l)) => {
+                (None, Some(e), None, Some(l), Some(u)) => {
+                    format!("whitelisted until:{e} last_used:{l} uses:{u}")
+                }
+                (None, Some(e), None, Some(l), None) => {
                     format!("whitelisted until:{e} last_used:{l}")
                 }
-                (None, Some(e), None, None) => {
+                (None, Some(e), None, None, Some(u)) => {
+                    format!("whitelisted until:{e} uses:{u}")
+                }
+                (None, Some(e), None, None, None) => {
                     format!("whitelisted until:{e}")
                 }
-                (None, None, Some(f), Some(l)) => {
+                (None, None, Some(f), Some(l), Some(u)) => {
+                    format!("whitelisted frequency:{f} last_used:{l} uses:{u}")
+                }
+                (None, None, Some(f), Some(l), None) => {
                     format!("whitelisted frequency:{f} last_used:{l}")
                 }
-                (None, None, Some(f), None) => {
+                (None, None, Some(f), None, Some(u)) => {
+                    format!("whitelisted frequency:{f} uses:{u}")
+                }
+                (None, None, Some(f), None, None) => {
                     format!("whitelisted frequency:{f}")
                 }
-                (None, None, None, Some(l)) => {
+                (None, None, None, Some(l), Some(u)) => {
+                    format!("whitelisted last_used:{l} uses:{u}")
+                }
+                (None, None, None, Some(l), None) => {
                     format!("whitelisted last_used:{l}")
                 }
-                (None, None, None, None) => "whitelisted".to_string(),
+                (None, None, None, None, Some(u)) => {
+                    format!("whitelisted uses:{u}")
+                }
+                (None, None, None, None, None) => "whitelisted".to_string(),
             },
         };
         write!(f, "{self_as_string}")
@@ -390,6 +416,7 @@ mod tests {
             expiration: Some(Expiry::AtTime(
                 Milliseconds(exp_offset).plus_seconds(current_time),
             )),
+            uses: None,
             frequency: None,
             last_used: None,
         };
@@ -430,6 +457,7 @@ mod tests {
             expiration: Some(Expiry::AtTime(
                 Milliseconds(exp_offset).plus_seconds(current_time),
             )),
+            uses: None,
             frequency: None,
             last_used: None,
         };
@@ -448,6 +476,7 @@ mod tests {
             expiration: None,
             frequency: None,
             last_used: None,
+            uses: None,
         };
 
         let result = permission.validate_times(&env);
@@ -464,6 +493,7 @@ mod tests {
             expiration: None,
             frequency: None,
             last_used: None,
+            uses: None,
         };
 
         let result = permission.validate_times(&env);
@@ -478,6 +508,7 @@ mod tests {
         let permission = LocalPermission::Whitelisted {
             start: None,
             expiration: Some(Expiry::AtTime(Milliseconds(current_time + 100))),
+            uses: None,
             frequency: None,
             last_used: None,
         };
@@ -546,6 +577,7 @@ mod tests {
             } else {
                 None
             },
+            uses: None,
         };
 
         // Test the permission
@@ -577,6 +609,7 @@ mod tests {
             expiration: None,
             frequency: Some(Milliseconds(frequency_ms)),
             last_used: Some(Milliseconds::from_seconds(last_used)),
+            uses: None,
         };
 
         let is_authorized = permission.is_permissioned(&env, true);
@@ -617,6 +650,7 @@ mod tests {
             )),
             frequency: None,
             last_used: None,
+            uses: None,
         };
 
         let is_authorized = permission.is_permissioned(&env, true);

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -563,6 +563,7 @@ mod tests {
             let permission = Permission::Local(LocalPermission::Whitelisted {
                 start: None,
                 expiration: None,
+                uses: None,
                 frequency: None,
                 last_used: None,
             });

--- a/packages/std/src/common/denom.rs
+++ b/packages/std/src/common/denom.rs
@@ -139,7 +139,7 @@ pub fn authorize_addresses(
             deps.storage,
             action,
             addr.to_string(),
-            Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+            Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
         )?;
     }
     Ok(())
@@ -153,11 +153,12 @@ pub fn execute_authorize_contract(
     expiration: Option<Expiry>,
 ) -> Result<Response, ContractError> {
     let permission = expiration.map_or(
-        Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+        Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
         |expiration| {
             Permission::Local(LocalPermission::whitelisted(
                 None,
                 Some(expiration),
+                None,
                 None,
                 None,
             ))

--- a/tests/address_list.rs
+++ b/tests/address_list.rs
@@ -193,6 +193,7 @@ fn test_permission_frequency() {
             LocalPermission::whitelisted(
                 None,
                 None,
+                None,
                 // 1 hour cooldown for each action
                 Some(Milliseconds::from_seconds(3600)),
                 // Last used 1 minute ago
@@ -217,6 +218,7 @@ fn test_permission_frequency() {
 
     // Set valid frequency and last used
     let valid_permission = LocalPermission::whitelisted(
+        None,
         None,
         None,
         // 1 hour cooldown for each action
@@ -248,7 +250,7 @@ fn test_permission_frequency() {
             owner.clone(),
             vec![AndrAddr::from_string("./marketplace")],
             PERMISSION_ACTORS_ACTION.to_string(),
-            Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+            Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
         )
         .unwrap();
 
@@ -269,6 +271,7 @@ fn test_permission_frequency() {
     assert_eq!(balance.amount, Uint128::new(100u128));
 
     let updated_permission = LocalPermission::whitelisted(
+        None,
         None,
         None,
         // 1 hour cooldown for each action

--- a/tests/amp/access_control.rs
+++ b/tests/amp/access_control.rs
@@ -78,7 +78,7 @@ fn setup_cw721() -> (App<BankKeeper, MockApiBech32>, MockAndromeda, MockCW721) {
     let permission_msg = ExecuteMsg::Permissioning(PermissioningMessage::SetPermission {
         actors: vec![AndrAddr::from_string(user)],
         action: CW721_MINT_ACTION.to_string(),
-        permission: Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+        permission: Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
     });
     cw721
         .execute(&mut router, &permission_msg, owner.clone(), &[])

--- a/tests/auction_app.rs
+++ b/tests/auction_app.rs
@@ -692,7 +692,7 @@ fn test_auction_app_cw20_restricted() {
     // Now whitelist bidder one
     let actors = vec![AndrAddr::from_string(buyer_one.clone())];
     let action = "PlaceBid".to_string();
-    let permission = Permission::Local(LocalPermission::whitelisted(None, None, None, None));
+    let permission = Permission::Local(LocalPermission::whitelisted(None, None, None, None, None));
     auction
         .execute_set_permission(&mut router, owner.clone(), actors, action, permission)
         .unwrap();

--- a/tests/crowdfund_app.rs
+++ b/tests/crowdfund_app.rs
@@ -248,7 +248,7 @@ fn setup(
     let permission_msg = ExecuteMsg::Permissioning(PermissioningMessage::SetPermission {
         actors: vec![AndrAddr::from_string(crowdfund.addr().to_string())],
         action: "Mint".to_string(),
-        permission: Permission::Local(LocalPermission::whitelisted(None, None, None, None)),
+        permission: Permission::Local(LocalPermission::whitelisted(None, None, None, None, None)),
     });
 
     cw721

--- a/tests/marketplace_app.rs
+++ b/tests/marketplace_app.rs
@@ -236,7 +236,7 @@ fn test_marketplace_app() {
             &mut router,
             owner.clone(),
             vec![AndrAddr::from_string(buyer.clone())],
-            LocalPermission::whitelisted(None, None, None, None),
+            LocalPermission::whitelisted(None, None, None, None, None),
         )
         .unwrap();
 
@@ -596,7 +596,7 @@ fn test_marketplace_app_cw20_restricted() {
                 AndrAddr::from_string(buyer.clone()),
                 AndrAddr::from_string(owner.clone()),
             ],
-            LocalPermission::whitelisted(None, None, None, None),
+            LocalPermission::whitelisted(None, None, None, None, None),
         )
         .unwrap();
 
@@ -878,7 +878,7 @@ fn test_marketplace_app_cw20_unrestricted() {
                 AndrAddr::from_string(buyer.clone()),
                 AndrAddr::from_string(owner.clone()),
             ],
-            LocalPermission::whitelisted(None, None, None, None),
+            LocalPermission::whitelisted(None, None, None, None, None),
         )
         .unwrap();
 

--- a/tests/validator_staking.rs
+++ b/tests/validator_staking.rs
@@ -275,7 +275,7 @@ fn test_restake() {
             "restake".to_string(),
             andromeda_std::ado_base::permissioning::Permission::Local(
                 andromeda_std::ado_base::permissioning::LocalPermission::whitelisted(
-                    None, None, None, None,
+                    None, None, None, None, None,
                 ),
             ),
         )


### PR DESCRIPTION
# Motivation
The Limited permission was easily integrated into Whitelisted, there was no need to have them separated. 

# Implementation
- Added an optional `uses` variable to whitelisted. 
- Replaced instances of limited with whitelisted (with `uses` as a `Some` value)

# Testing
No tests were impacted

# Version Changes
Already made in the branch this was branched from

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
