### PR TITLE
feat: redeem native assets in cw20 redeem

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20-redeem/examples/schema.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/examples/schema.rs
@@ -12,5 +12,5 @@ fn main() {
         query: QueryMsg,
         execute: ExecuteMsg,
     };
-    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20redeem");
+    export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
 }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/contract.rs
@@ -1,30 +1,25 @@
-use andromeda_fungible_tokens::cw20_redeem::{
-    Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, RedemptionAssetResponse,
-    RedemptionCondition, RedemptionResponse, TokenAddressResponse,
-};
+use andromeda_fungible_tokens::cw20_redeem::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 use andromeda_std::{
     ado_base::{InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
     ado_contract::ADOContract,
-    amp::Recipient,
     andr_execute_fn,
-    common::{
-        context::ExecuteContext,
-        encode_binary,
-        expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},
-        msg_generation::generate_transfer_message,
-        Milliseconds, MillisecondsDuration,
-    },
+    common::{context::ExecuteContext, encode_binary},
     error::ContractError,
 };
 use cosmwasm_std::{
-    attr, ensure, entry_point, from_json, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo,
-    Reply, Response, StdError, Uint128,
+    ensure, entry_point, from_json, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdError,
 };
-use cw20::{BalanceResponse, Cw20Coin, Cw20QueryMsg, Cw20ReceiveMsg};
+use cw20::Cw20ReceiveMsg;
 use cw_asset::AssetInfo;
-use cw_utils::{one_coin, Expiration};
 
-use crate::state::{REDEMPTION_CONDITION, TOKEN_ADDRESS};
+use crate::{
+    execute::{
+        execute_cancel_redemption_condition, execute_redeem_cw20, execute_redeem_native,
+        execute_set_redemption_condition_cw20, execute_set_redemption_condition_native,
+    },
+    query::{query_redemption_asset, query_redemption_asset_balance, query_redemption_condition},
+};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:andromeda-cw20-redeem";
@@ -37,8 +32,6 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    TOKEN_ADDRESS.save(deps.storage, &msg.token_address)?;
-
     let contract = ADOContract::default();
     let resp = contract.instantiate(
         deps.storage,
@@ -72,13 +65,16 @@ pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, Contract
 pub fn execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::Receive(cw20_msg) => execute_receive(ctx, cw20_msg),
+        ExecuteMsg::Redeem {} => execute_redeem_native(ctx),
         ExecuteMsg::SetRedemptionCondition {
+            redeemed_asset,
             exchange_rate,
             recipient,
             start_time,
             duration,
         } => execute_set_redemption_condition_native(
             ctx,
+            redeemed_asset,
             exchange_rate,
             recipient,
             start_time,
@@ -94,6 +90,7 @@ pub fn execute_receive(
     receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
     let ExecuteContext { ref info, .. } = ctx;
+
     let asset_info = AssetInfo::Cw20(info.sender.clone());
     let amount_sent = receive_msg.amount;
     let sender = receive_msg.sender;
@@ -107,6 +104,7 @@ pub fn execute_receive(
 
     match from_json(&receive_msg.msg)? {
         Cw20HookMsg::StartRedemptionCondition {
+            redeemed_asset,
             exchange_rate,
             recipient,
             start_time,
@@ -115,306 +113,15 @@ pub fn execute_receive(
             ctx,
             amount_sent,
             asset_info,
+            redeemed_asset,
             sender,
             exchange_rate,
             recipient,
             start_time,
             duration,
         ),
-        Cw20HookMsg::Redeem {} => execute_redeem(ctx, amount_sent, asset_info, &sender),
+        Cw20HookMsg::Redeem {} => execute_redeem_cw20(ctx, amount_sent, asset_info, &sender),
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn execute_set_redemption_condition_cw20(
-    ctx: ExecuteContext,
-    amount_sent: Uint128,
-    asset_sent: AssetInfo,
-    sender: String,
-    exchange_rate: Uint128,
-    recipient: Option<Recipient>,
-    start_time: Option<Expiry>,
-    duration: Option<MillisecondsDuration>,
-) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, env, .. } = ctx;
-
-    ensure!(
-        !exchange_rate.is_zero(),
-        ContractError::InvalidZeroAmount {}
-    );
-
-    ensure!(
-        ctx.contract.is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
-
-    // If start time wasn't provided, it will be set as the current_time
-    let (start_expiration, _current_time) = get_and_validate_start_time(&env, start_time.clone())?;
-
-    let end_expiration = if let Some(duration) = duration {
-        ensure!(!duration.is_zero(), ContractError::InvalidExpiration {});
-        expiration_from_milliseconds(
-            start_time
-                // If start time isn't provided, it is set one second in advance from the current time
-                .unwrap_or(Expiry::FromNow(Milliseconds::from_seconds(1)))
-                .get_time(&env.block)
-                .plus_milliseconds(duration),
-        )?
-    } else {
-        Expiration::Never {}
-    };
-
-    // Do not allow duplicate sales
-    let redemption_condition = REDEMPTION_CONDITION.may_load(deps.storage)?;
-    ensure!(
-        redemption_condition.is_none(),
-        ContractError::RedemptionConditionAlreadyExists {}
-    );
-
-    let recipient = if let Some(recipient) = recipient {
-        recipient.validate(&deps.as_ref())?;
-        recipient
-    } else {
-        Recipient::new(sender, None)
-    };
-
-    let redemption_condition = RedemptionCondition {
-        recipient,
-        asset: asset_sent.clone(),
-        amount: amount_sent,
-        total_amount_redeemed: Uint128::zero(),
-        exchange_rate,
-        start_time: start_expiration,
-        end_time: end_expiration,
-    };
-    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
-
-    Ok(Response::default().add_attributes(vec![
-        attr("action", "start_redemption_condition"),
-        attr("asset", asset_sent.to_string()),
-        attr("rate", exchange_rate),
-        attr("amount", amount_sent),
-        attr("start_time", start_expiration.to_string()),
-        attr("end_time", end_expiration.to_string()),
-    ]))
-}
-
-pub fn execute_set_redemption_condition_native(
-    ctx: ExecuteContext,
-    exchange_rate: Uint128,
-    recipient: Option<Recipient>,
-    start_time: Option<Expiry>,
-    duration: Option<MillisecondsDuration>,
-) -> Result<Response, ContractError> {
-    let ExecuteContext {
-        deps, env, info, ..
-    } = ctx;
-
-    let payment = one_coin(&info)?;
-    let asset = AssetInfo::Native(payment.denom.to_string());
-    let amount = payment.amount;
-
-    ensure!(
-        !amount.is_zero(),
-        ContractError::InvalidFunds {
-            msg: "Cannot send a 0 amount".to_string()
-        }
-    );
-
-    ensure!(
-        !exchange_rate.is_zero(),
-        ContractError::InvalidZeroAmount {}
-    );
-
-    // Check if a redemption condition already exists
-    let redemption_condition = REDEMPTION_CONDITION.may_load(deps.storage)?;
-    if let Some(condition) = redemption_condition {
-        // If a condition exists, ensure it has expired before allowing a new one
-        ensure!(
-            condition.end_time.is_expired(&env.block),
-            ContractError::RedemptionConditionAlreadyExists {}
-        );
-    }
-
-    // If start time wasn't provided, it will be set as the current_time
-    let (start_expiration, _current_time) = get_and_validate_start_time(&env, start_time.clone())?;
-
-    let end_expiration = if let Some(duration) = duration {
-        ensure!(!duration.is_zero(), ContractError::InvalidExpiration {});
-        expiration_from_milliseconds(
-            start_time
-                // If start time isn't provided, it is set one second in advance from the current time
-                .unwrap_or(Expiry::FromNow(Milliseconds::from_seconds(1)))
-                .get_time(&env.block)
-                .plus_milliseconds(duration),
-        )?
-    } else {
-        Expiration::Never {}
-    };
-
-    let recipient = if let Some(recipient) = recipient {
-        recipient.validate(&deps.as_ref())?;
-        recipient
-    } else {
-        Recipient::new(info.sender.to_string(), None)
-    };
-
-    let redemption_condition = RedemptionCondition {
-        recipient,
-        asset: asset.clone(),
-        amount,
-        total_amount_redeemed: Uint128::zero(),
-        exchange_rate,
-        start_time: start_expiration,
-        end_time: end_expiration,
-    };
-    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
-
-    Ok(Response::default().add_attributes(vec![
-        attr("action", "start_redemption_condition"),
-        attr("asset", asset.to_string()),
-        attr("rate", exchange_rate),
-        attr("amount", amount),
-        attr("start_time", start_expiration.to_string()),
-        attr("end_time", end_expiration.to_string()),
-    ]))
-}
-
-pub fn execute_redeem(
-    ctx: ExecuteContext,
-    amount_sent: Uint128,
-    asset_info: AssetInfo,
-    sender: &str,
-) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, .. } = ctx;
-
-    let Some(mut redemption_condition) = REDEMPTION_CONDITION.may_load(deps.storage)? else {
-        return Err(ContractError::NoOngoingSale {});
-    };
-
-    // Check if sale has started
-    ensure!(
-        redemption_condition.start_time.is_expired(&ctx.env.block),
-        ContractError::SaleNotStarted {}
-    );
-    // Check if sale has ended
-    ensure!(
-        !redemption_condition.end_time.is_expired(&ctx.env.block),
-        ContractError::SaleEnded {}
-    );
-
-    let potential_redeemed = amount_sent.checked_mul(redemption_condition.exchange_rate)?;
-
-    ensure!(
-        !potential_redeemed.is_zero(),
-        ContractError::InvalidFunds {
-            msg: "Not enough funds sent to redeem".to_string()
-        }
-    );
-
-    // Calculate actual redemption amounts
-    let (redeemed_amount, accepted_amount, refund_amount) =
-        if potential_redeemed <= redemption_condition.amount {
-            (potential_redeemed, amount_sent, Uint128::zero())
-        } else {
-            // If we don't have enough tokens, calculate the partial redemption
-            let actual_redeemed = redemption_condition.amount;
-            let actual_amount_needed = redemption_condition
-                .amount
-                .checked_div(redemption_condition.exchange_rate)
-                .map_err(|_| ContractError::Overflow {})?;
-            let refund = amount_sent.checked_sub(actual_amount_needed)?;
-            (actual_redeemed, actual_amount_needed, refund)
-        };
-
-    let mut messages = vec![];
-
-    // Transfer redeemed tokens to the user
-    messages.push(generate_transfer_message(
-        redemption_condition.asset.clone(),
-        redeemed_amount,
-        sender.to_string(),
-        None,
-    )?);
-
-    match asset_info {
-        cw_asset::AssetInfoBase::Cw20(ref address) => {
-            let recipient_msg = redemption_condition.recipient.generate_msg_cw20(
-                &deps.as_ref(),
-                Cw20Coin {
-                    address: address.to_string(),
-                    amount: accepted_amount,
-                }
-                .clone(),
-            )?;
-            messages.push(recipient_msg);
-            Ok(())
-        }
-        _ => Err(ContractError::InvalidAsset {
-            asset: asset_info.to_string(),
-        }),
-    }?;
-
-    // If there's a refund, send it back to the sender
-    if !refund_amount.is_zero() {
-        messages.push(generate_transfer_message(
-            asset_info.clone(),
-            refund_amount,
-            sender.to_string(),
-            None,
-        )?);
-    }
-
-    // Update sale amount remaining
-    redemption_condition.amount = redemption_condition.amount.checked_sub(redeemed_amount)?;
-    redemption_condition.total_amount_redeemed = redemption_condition
-        .total_amount_redeemed
-        .checked_add(redeemed_amount)?;
-    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
-
-    let mut attributes = vec![
-        attr("action", "redeem"),
-        attr("purchaser", sender),
-        attr("amount", redeemed_amount),
-        attr("purchase_asset", asset_info.to_string()),
-        attr("purchase_asset_amount_accepted", accepted_amount),
-    ];
-
-    // Add refund attribute if there was a refund
-    if !refund_amount.is_zero() {
-        attributes.push(attr("refund_amount", refund_amount));
-    }
-
-    Ok(Response::default()
-        .add_submessages(messages)
-        .add_attributes(attributes))
-}
-
-pub fn execute_cancel_redemption_condition(ctx: ExecuteContext) -> Result<Response, ContractError> {
-    let ExecuteContext { deps, info, .. } = ctx;
-
-    let Some(redemption_condition) = REDEMPTION_CONDITION.may_load(deps.storage)? else {
-        return Err(ContractError::NoOngoingSale {});
-    };
-
-    let mut resp = Response::default();
-
-    // Refund any remaining amount
-    if !redemption_condition.amount.is_zero() {
-        resp = resp
-            .add_submessage(generate_transfer_message(
-                redemption_condition.asset.clone(),
-                redemption_condition.amount,
-                info.sender.to_string(),
-                None,
-            )?)
-            .add_attribute("refunded_amount", redemption_condition.amount);
-    }
-
-    // Redemption condition can now be removed
-    REDEMPTION_CONDITION.remove(deps.storage);
-
-    Ok(resp.add_attributes(vec![attr("action", "cancel_redemption_condition")]))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -426,58 +133,10 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::RedemptionCondition {} => encode_binary(&query_redemption_condition(deps)?),
-        QueryMsg::TokenAddress {} => encode_binary(&query_token_address(deps)?),
         QueryMsg::RedemptionAsset {} => encode_binary(&query_redemption_asset(deps)?),
         QueryMsg::RedemptionAssetBalance {} => {
             encode_binary(&query_redemption_asset_balance(deps, env)?)
         }
         _ => ADOContract::default().query(deps, env, msg),
-    }
-}
-
-fn query_redemption_condition(deps: Deps) -> Result<RedemptionResponse, ContractError> {
-    let redemption = REDEMPTION_CONDITION.may_load(deps.storage)?;
-
-    Ok(RedemptionResponse { redemption })
-}
-
-fn query_token_address(deps: Deps) -> Result<TokenAddressResponse, ContractError> {
-    let address = TOKEN_ADDRESS
-        .load(deps.storage)?
-        .get_raw_address(&deps)?
-        .to_string();
-
-    Ok(TokenAddressResponse { address })
-}
-
-fn query_redemption_asset(deps: Deps) -> Result<RedemptionAssetResponse, ContractError> {
-    let redemption_condition = REDEMPTION_CONDITION.load(deps.storage)?;
-
-    Ok(RedemptionAssetResponse {
-        asset: redemption_condition.asset.to_string(),
-    })
-}
-
-fn query_redemption_asset_balance(deps: Deps, env: Env) -> Result<Uint128, ContractError> {
-    let asset = REDEMPTION_CONDITION.load(deps.storage)?.asset;
-
-    match asset {
-        AssetInfo::Native(denom) => {
-            let balance = deps.querier.query_balance(env.contract.address, denom)?;
-            Ok(balance.amount)
-        }
-        AssetInfo::Cw20(addr) => {
-            let balance_msg = Cw20QueryMsg::Balance {
-                address: env.contract.address.into(),
-            };
-            let balance_response: BalanceResponse = deps
-                .querier
-                .query_wasm_smart(addr, &to_json_binary(&balance_msg)?)?;
-            Ok(balance_response.balance)
-        }
-        // Does not support 1155 currently
-        _ => Err(ContractError::InvalidAsset {
-            asset: asset.to_string(),
-        }),
     }
 }

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/execute.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/execute.rs
@@ -1,0 +1,431 @@
+use andromeda_fungible_tokens::cw20_redeem::RedemptionCondition;
+use andromeda_std::{
+    amp::Recipient,
+    common::{
+        context::ExecuteContext,
+        expiration::{expiration_from_milliseconds, get_and_validate_start_time, Expiry},
+        msg_generation::generate_transfer_message,
+        Milliseconds, MillisecondsDuration,
+    },
+    error::ContractError,
+};
+use cosmwasm_std::{attr, ensure, Coin, Response, Uint128};
+use cw20::Cw20Coin;
+use cw_asset::AssetInfo;
+use cw_utils::{one_coin, Expiration};
+
+use crate::state::REDEMPTION_CONDITION;
+
+#[allow(clippy::too_many_arguments)]
+pub fn execute_set_redemption_condition_cw20(
+    ctx: ExecuteContext,
+    amount_sent: Uint128,
+    asset_sent: AssetInfo,
+    redeemed_asset: AssetInfo,
+    sender: String,
+    exchange_rate: Uint128,
+    recipient: Option<Recipient>,
+    start_time: Option<Expiry>,
+    duration: Option<MillisecondsDuration>,
+) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, env, .. } = ctx;
+
+    ensure!(
+        !exchange_rate.is_zero(),
+        ContractError::InvalidZeroAmount {}
+    );
+
+    ensure!(
+        ctx.contract.is_contract_owner(deps.storage, &sender)?,
+        ContractError::Unauthorized {}
+    );
+
+    // If start time wasn't provided, it will be set as the current_time
+    let (start_expiration, _current_time) = get_and_validate_start_time(&env, start_time.clone())?;
+
+    let end_expiration = if let Some(duration) = duration {
+        ensure!(!duration.is_zero(), ContractError::InvalidExpiration {});
+        expiration_from_milliseconds(
+            start_time
+                // If start time isn't provided, it is set one second in advance from the current time
+                .unwrap_or(Expiry::FromNow(Milliseconds::from_seconds(1)))
+                .get_time(&env.block)
+                .plus_milliseconds(duration),
+        )?
+    } else {
+        Expiration::Never {}
+    };
+
+    // Do not allow duplicate sales
+    let redemption_condition = REDEMPTION_CONDITION.may_load(deps.storage)?;
+    ensure!(
+        redemption_condition.is_none(),
+        ContractError::RedemptionConditionAlreadyExists {}
+    );
+
+    let recipient = if let Some(recipient) = recipient {
+        recipient.validate(&deps.as_ref())?;
+        recipient
+    } else {
+        Recipient::new(sender, None)
+    };
+
+    let redemption_condition = RedemptionCondition {
+        recipient,
+        asset: asset_sent.clone(),
+        redeemed_asset,
+        amount: amount_sent,
+        total_amount_redeemed: Uint128::zero(),
+        exchange_rate,
+        start_time: start_expiration,
+        end_time: end_expiration,
+    };
+    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "start_redemption_condition"),
+        attr("asset", asset_sent.to_string()),
+        attr("rate", exchange_rate),
+        attr("amount", amount_sent),
+        attr("start_time", start_expiration.to_string()),
+        attr("end_time", end_expiration.to_string()),
+    ]))
+}
+
+pub fn execute_set_redemption_condition_native(
+    ctx: ExecuteContext,
+    redeemed_asset: AssetInfo,
+    exchange_rate: Uint128,
+    recipient: Option<Recipient>,
+    start_time: Option<Expiry>,
+    duration: Option<MillisecondsDuration>,
+) -> Result<Response, ContractError> {
+    let ExecuteContext {
+        deps, env, info, ..
+    } = ctx;
+
+    let payment = one_coin(&info)?;
+    let asset = AssetInfo::Native(payment.denom.to_string());
+    let amount = payment.amount;
+
+    ensure!(
+        !amount.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Cannot send a 0 amount".to_string()
+        }
+    );
+
+    ensure!(
+        !exchange_rate.is_zero(),
+        ContractError::InvalidZeroAmount {}
+    );
+
+    // Check if a redemption condition already exists
+    let redemption_condition = REDEMPTION_CONDITION.may_load(deps.storage)?;
+    if let Some(condition) = redemption_condition {
+        // If a condition exists, ensure it has expired before allowing a new one
+        ensure!(
+            condition.end_time.is_expired(&env.block),
+            ContractError::RedemptionConditionAlreadyExists {}
+        );
+    }
+
+    // If start time wasn't provided, it will be set as the current_time
+    let (start_expiration, _current_time) = get_and_validate_start_time(&env, start_time.clone())?;
+
+    let end_expiration = if let Some(duration) = duration {
+        ensure!(!duration.is_zero(), ContractError::InvalidExpiration {});
+        expiration_from_milliseconds(
+            start_time
+                // If start time isn't provided, it is set one second in advance from the current time
+                .unwrap_or(Expiry::FromNow(Milliseconds::from_seconds(1)))
+                .get_time(&env.block)
+                .plus_milliseconds(duration),
+        )?
+    } else {
+        Expiration::Never {}
+    };
+
+    let recipient = if let Some(recipient) = recipient {
+        recipient.validate(&deps.as_ref())?;
+        recipient
+    } else {
+        Recipient::new(info.sender.to_string(), None)
+    };
+
+    let redemption_condition = RedemptionCondition {
+        recipient,
+        asset: asset.clone(),
+        redeemed_asset,
+        amount,
+        total_amount_redeemed: Uint128::zero(),
+        exchange_rate,
+        start_time: start_expiration,
+        end_time: end_expiration,
+    };
+    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
+
+    Ok(Response::default().add_attributes(vec![
+        attr("action", "start_redemption_condition"),
+        attr("asset", asset.to_string()),
+        attr("rate", exchange_rate),
+        attr("amount", amount),
+        attr("start_time", start_expiration.to_string()),
+        attr("end_time", end_expiration.to_string()),
+    ]))
+}
+
+pub fn execute_redeem_cw20(
+    ctx: ExecuteContext,
+    amount_sent: Uint128,
+    asset_info: AssetInfo,
+    sender: &str,
+) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, .. } = ctx;
+
+    let Some(mut redemption_condition) = REDEMPTION_CONDITION.may_load(deps.storage)? else {
+        return Err(ContractError::NoOngoingSale {});
+    };
+
+    // Ensure that the provided asset is the same as the redeemed asset
+    ensure!(
+        asset_info == redemption_condition.redeemed_asset,
+        ContractError::InvalidAsset {
+            asset: asset_info.to_string(),
+        }
+    );
+
+    // Check if sale has started
+    ensure!(
+        redemption_condition.start_time.is_expired(&ctx.env.block),
+        ContractError::SaleNotStarted {}
+    );
+    // Check if sale has ended
+    ensure!(
+        !redemption_condition.end_time.is_expired(&ctx.env.block),
+        ContractError::SaleEnded {}
+    );
+
+    let potential_redeemed = amount_sent.checked_mul(redemption_condition.exchange_rate)?;
+
+    ensure!(
+        !potential_redeemed.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Not enough funds sent to redeem".to_string()
+        }
+    );
+
+    // Calculate actual redemption amounts
+    let (redeemed_amount, accepted_amount, refund_amount) =
+        if potential_redeemed <= redemption_condition.amount {
+            (potential_redeemed, amount_sent, Uint128::zero())
+        } else {
+            // If we don't have enough tokens, calculate the partial redemption
+            let actual_redeemed = redemption_condition.amount;
+            let actual_amount_needed = redemption_condition
+                .amount
+                .checked_div(redemption_condition.exchange_rate)
+                .map_err(|_| ContractError::Overflow {})?;
+            let refund = amount_sent.checked_sub(actual_amount_needed)?;
+            (actual_redeemed, actual_amount_needed, refund)
+        };
+
+    let mut messages = vec![];
+
+    // Transfer redeemed tokens to the user
+    messages.push(generate_transfer_message(
+        redemption_condition.asset.clone(),
+        redeemed_amount,
+        sender.to_string(),
+        None,
+    )?);
+
+    match asset_info {
+        cw_asset::AssetInfoBase::Cw20(ref address) => {
+            let recipient_msg = redemption_condition.recipient.generate_msg_cw20(
+                &deps.as_ref(),
+                Cw20Coin {
+                    address: address.to_string(),
+                    amount: accepted_amount,
+                }
+                .clone(),
+            )?;
+            messages.push(recipient_msg);
+            Ok(())
+        }
+        _ => Err(ContractError::InvalidAsset {
+            asset: asset_info.to_string(),
+        }),
+    }?;
+
+    // Update sale amount remaining
+    redemption_condition.amount = redemption_condition.amount.checked_sub(redeemed_amount)?;
+    redemption_condition.total_amount_redeemed = redemption_condition
+        .total_amount_redeemed
+        .checked_add(redeemed_amount)?;
+    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
+
+    let mut attributes = vec![
+        attr("action", "redeem"),
+        attr("purchaser", sender),
+        attr("amount", redeemed_amount),
+        attr("purchase_asset", asset_info.to_string()),
+        attr("purchase_asset_amount_accepted", accepted_amount),
+    ];
+
+    // If there's a refund, send it back to the sender
+    if !refund_amount.is_zero() {
+        messages.push(generate_transfer_message(
+            asset_info.clone(),
+            refund_amount,
+            sender.to_string(),
+            None,
+        )?);
+        // Add refund attribute if there was a refund
+        attributes.push(attr("refund_amount", refund_amount));
+    }
+
+    Ok(Response::default()
+        .add_submessages(messages)
+        .add_attributes(attributes))
+}
+
+pub fn execute_redeem_native(ctx: ExecuteContext) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, .. } = ctx;
+    let payment = one_coin(&ctx.info)?;
+    let amount_sent = payment.amount;
+    let asset_info = AssetInfo::Native(payment.denom.to_string());
+    let sender = ctx.info.sender.to_string();
+    let Some(mut redemption_condition) = REDEMPTION_CONDITION.may_load(deps.storage)? else {
+        return Err(ContractError::NoOngoingSale {});
+    };
+
+    // Ensure that the provided asset is the same as the redeemed asset
+    ensure!(
+        asset_info == redemption_condition.redeemed_asset,
+        ContractError::InvalidAsset {
+            asset: asset_info.to_string(),
+        }
+    );
+
+    // Check if sale has started
+    ensure!(
+        redemption_condition.start_time.is_expired(&ctx.env.block),
+        ContractError::SaleNotStarted {}
+    );
+    // Check if sale has ended
+    ensure!(
+        !redemption_condition.end_time.is_expired(&ctx.env.block),
+        ContractError::SaleEnded {}
+    );
+
+    let potential_redeemed = amount_sent.checked_mul(redemption_condition.exchange_rate)?;
+
+    ensure!(
+        !potential_redeemed.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Not enough funds sent to redeem".to_string()
+        }
+    );
+
+    // Calculate actual redemption amounts
+    let (redeemed_amount, accepted_amount, refund_amount) =
+        if potential_redeemed <= redemption_condition.amount {
+            (potential_redeemed, amount_sent, Uint128::zero())
+        } else {
+            // If we don't have enough tokens, calculate the partial redemption
+            let actual_redeemed = redemption_condition.amount;
+            let actual_amount_needed = redemption_condition
+                .amount
+                .checked_div(redemption_condition.exchange_rate)
+                .map_err(|_| ContractError::Overflow {})?;
+            let refund = amount_sent.checked_sub(actual_amount_needed)?;
+            (actual_redeemed, actual_amount_needed, refund)
+        };
+
+    let mut messages = vec![];
+
+    // Transfer redeemed tokens to the user
+    messages.push(generate_transfer_message(
+        redemption_condition.asset.clone(),
+        redeemed_amount,
+        sender.to_string(),
+        None,
+    )?);
+
+    match asset_info {
+        cw_asset::AssetInfoBase::Native(ref denom) => {
+            let recipient_msg: cosmwasm_std::SubMsg =
+                redemption_condition.recipient.generate_direct_msg(
+                    &deps.as_ref(),
+                    vec![Coin {
+                        denom: denom.to_string(),
+                        amount: accepted_amount,
+                    }],
+                )?;
+            messages.push(recipient_msg);
+            Ok(())
+        }
+        _ => Err(ContractError::InvalidAsset {
+            asset: asset_info.to_string(),
+        }),
+    }?;
+
+    // Update sale amount remaining
+    redemption_condition.amount = redemption_condition.amount.checked_sub(redeemed_amount)?;
+    redemption_condition.total_amount_redeemed = redemption_condition
+        .total_amount_redeemed
+        .checked_add(redeemed_amount)?;
+    REDEMPTION_CONDITION.save(deps.storage, &redemption_condition)?;
+
+    let mut attributes = vec![
+        attr("action", "redeem"),
+        attr("purchaser", &sender),
+        attr("amount", redeemed_amount),
+        attr("purchase_asset", asset_info.to_string()),
+        attr("purchase_asset_amount_accepted", accepted_amount),
+    ];
+
+    // If there's a refund, send it back to the sender
+    if !refund_amount.is_zero() {
+        messages.push(generate_transfer_message(
+            asset_info.clone(),
+            refund_amount,
+            sender.to_string(),
+            None,
+        )?);
+        // Add refund attribute if there was a refund
+        attributes.push(attr("refund_amount", refund_amount));
+    }
+
+    Ok(Response::default()
+        .add_submessages(messages)
+        .add_attributes(attributes))
+}
+
+pub fn execute_cancel_redemption_condition(ctx: ExecuteContext) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, info, .. } = ctx;
+
+    let Some(redemption_condition) = REDEMPTION_CONDITION.may_load(deps.storage)? else {
+        return Err(ContractError::NoOngoingSale {});
+    };
+
+    let mut resp = Response::default();
+
+    // Refund any remaining amount
+    if !redemption_condition.amount.is_zero() {
+        resp = resp
+            .add_submessage(generate_transfer_message(
+                redemption_condition.asset.clone(),
+                redemption_condition.amount,
+                info.sender.to_string(),
+                None,
+            )?)
+            .add_attribute("refunded_amount", redemption_condition.amount);
+    }
+
+    // Redemption condition can now be removed
+    REDEMPTION_CONDITION.remove(deps.storage);
+
+    Ok(resp.add_attributes(vec![attr("action", "cancel_redemption_condition")]))
+}

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/lib.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod contract;
+pub mod execute;
 #[cfg(all(not(target_arch = "wasm32"), feature = "testing"))]
 pub mod mock;
+pub mod query;
 
 mod state;
 

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/mock.rs
@@ -2,9 +2,10 @@
 
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::cw20_redeem::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
-use andromeda_std::amp::{AndrAddr, Recipient};
+use andromeda_std::amp::Recipient;
 use andromeda_std::common::{expiration::Expiry, MillisecondsDuration};
 use cosmwasm_std::{Empty, Uint128};
+use cw_asset::AssetInfo;
 use cw_multi_test::{Contract, ContractWrapper};
 
 pub fn mock_andromeda_cw20_redeem() -> Box<dyn Contract<Empty>> {
@@ -13,24 +14,24 @@ pub fn mock_andromeda_cw20_redeem() -> Box<dyn Contract<Empty>> {
 }
 
 pub fn mock_cw20_redeem_instantiate_msg(
-    token_address: String,
     kernel_address: String,
     owner: Option<String>,
 ) -> InstantiateMsg {
     InstantiateMsg {
-        token_address: AndrAddr::from_string(token_address),
         kernel_address,
         owner,
     }
 }
 
 pub fn mock_cw20_redeem_start_redemption_condition_hook_msg(
+    redeemed_asset: AssetInfo,
     exchange_rate: Uint128,
     recipient: Option<Recipient>,
     start_time: Option<Expiry>,
     duration: Option<MillisecondsDuration>,
 ) -> Cw20HookMsg {
     Cw20HookMsg::StartRedemptionCondition {
+        redeemed_asset,
         exchange_rate,
         recipient,
         start_time,
@@ -42,13 +43,19 @@ pub fn mock_cw20_redeem_hook_redeem_msg() -> Cw20HookMsg {
     Cw20HookMsg::Redeem {}
 }
 
+pub fn mock_redeem_msg() -> ExecuteMsg {
+    ExecuteMsg::Redeem {}
+}
+
 pub fn mock_cw20_set_redemption_condition_native_msg(
+    redeemed_asset: AssetInfo,
     exchange_rate: Uint128,
     recipient: Option<Recipient>,
     start_time: Option<Expiry>,
     duration: Option<MillisecondsDuration>,
 ) -> ExecuteMsg {
     ExecuteMsg::SetRedemptionCondition {
+        redeemed_asset,
         exchange_rate,
         recipient,
         start_time,

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/query.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/query.rs
@@ -1,0 +1,45 @@
+use andromeda_fungible_tokens::cw20_redeem::{RedemptionAssetResponse, RedemptionResponse};
+use andromeda_std::error::ContractError;
+use cosmwasm_std::{to_json_binary, Deps, Env, Uint128};
+use cw20::{BalanceResponse, Cw20QueryMsg};
+use cw_asset::AssetInfo;
+
+use crate::state::REDEMPTION_CONDITION;
+
+pub fn query_redemption_condition(deps: Deps) -> Result<RedemptionResponse, ContractError> {
+    let redemption = REDEMPTION_CONDITION.may_load(deps.storage)?;
+
+    Ok(RedemptionResponse { redemption })
+}
+
+pub fn query_redemption_asset(deps: Deps) -> Result<RedemptionAssetResponse, ContractError> {
+    let redemption_condition = REDEMPTION_CONDITION.load(deps.storage)?;
+
+    Ok(RedemptionAssetResponse {
+        asset: redemption_condition.asset.to_string(),
+    })
+}
+
+pub fn query_redemption_asset_balance(deps: Deps, env: Env) -> Result<Uint128, ContractError> {
+    let asset = REDEMPTION_CONDITION.load(deps.storage)?.asset;
+
+    match asset {
+        AssetInfo::Native(denom) => {
+            let balance = deps.querier.query_balance(env.contract.address, denom)?;
+            Ok(balance.amount)
+        }
+        AssetInfo::Cw20(addr) => {
+            let balance_msg = Cw20QueryMsg::Balance {
+                address: env.contract.address.into(),
+            };
+            let balance_response: BalanceResponse = deps
+                .querier
+                .query_wasm_smart(addr, &to_json_binary(&balance_msg)?)?;
+            Ok(balance_response.balance)
+        }
+        // Does not support 1155 currently
+        _ => Err(ContractError::InvalidAsset {
+            asset: asset.to_string(),
+        }),
+    }
+}

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/state.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/state.rs
@@ -1,6 +1,4 @@
 use andromeda_fungible_tokens::cw20_redeem::RedemptionCondition;
-use andromeda_std::amp::AndrAddr;
 use cw_storage_plus::Item;
 
-pub const TOKEN_ADDRESS: Item<AndrAddr> = Item::new("token_address");
 pub const REDEMPTION_CONDITION: Item<RedemptionCondition> = Item::new("redemption_condition");

--- a/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-redeem/src/testing/tests.rs
@@ -1,20 +1,12 @@
+use super::mock_querier::TestDeps;
+use crate::{contract::instantiate, testing::mock_querier::mock_dependencies_custom};
 use andromeda_fungible_tokens::cw20_redeem::InstantiateMsg;
-use andromeda_std::{
-    amp::AndrAddr, error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT,
-};
+use andromeda_std::{error::ContractError, testing::mock_querier::MOCK_KERNEL_CONTRACT};
 use cosmwasm_std::{
     testing::{message_info, mock_env},
     Response, StdError, StdResult, Uint128,
 };
 use rstest::rstest;
-
-pub const MOCK_TOKEN_ADDRESS: &str = "cw20";
-
-use crate::{
-    contract::instantiate, state::TOKEN_ADDRESS, testing::mock_querier::mock_dependencies_custom,
-};
-
-use super::mock_querier::TestDeps;
 
 fn init(deps: &mut TestDeps) -> Result<Response, ContractError> {
     let owner = deps.api.addr_make("owner");
@@ -23,8 +15,6 @@ fn init(deps: &mut TestDeps) -> Result<Response, ContractError> {
     let msg = InstantiateMsg {
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
-
-        token_address: AndrAddr::from_string("cw20"),
     };
 
     instantiate(deps.as_mut(), mock_env(), info, msg)
@@ -33,10 +23,6 @@ fn init(deps: &mut TestDeps) -> Result<Response, ContractError> {
 pub fn test_instantiate() {
     let mut deps = mock_dependencies_custom(&[]);
     init(&mut deps).unwrap();
-
-    let saved_mock_token_address = TOKEN_ADDRESS.load(deps.as_ref().storage).unwrap();
-
-    assert_eq!(saved_mock_token_address, MOCK_TOKEN_ADDRESS.to_string())
 }
 
 /// Represents the result of a redemption calculation


### PR DESCRIPTION
# Motivation
The cw20 redeem ado only accepted cw20s to redeem for other assets. Now it also accepts native funds. 
With this new functionality, I think we should rename the ADO to just `redeem`. (Hasn't been done yet, waiting to hear your opinions) 

# Implementation
- Native funds can be redeemed by calling `ExecuteMsg::Redeem`, the sent funds will be redeemed according to the condition. 
- The accepted asset to be redeemed is now set in `SetRedemptionCondition` and is called `redeemed_asset`
- Removed the `TOKEN_ADDRESS` Item in state

# Testing
`test_cw20_redeem_app_cw20_and_native_redeem` tests a user redeeming native funds and getting cw20 in return. 

# Version Changes
- `cw20-redeem`: `0.1.0-b.1` -> `0.1.0-b.2`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
