### PR TITLE
fix: query response for app get components query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: kernel's handle_local not resolving AndrAddr [(#846)](https://github.com/andromedaprotocol/andromeda-core/pull/846)
 - fix: Timelock Release Funds [(#857)](https://github.com/andromedaprotocol/andromeda-core/pull/857)
 - fix: Added missing version bumps [(#858)](https://github.com/andromedaprotocol/andromeda-core/pull/858)
+- fix: GetComponents query's schema  [(#873)](https://github.com/andromedaprotocol/andromeda-core/pull/873)
+
 
 ## Release 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema",

--- a/packages/andromeda-app/Cargo.toml
+++ b/packages/andromeda-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Utility methods and message definitions for the Andromeda App Contract"

--- a/packages/andromeda-app/src/app.rs
+++ b/packages/andromeda-app/src/app.rs
@@ -338,7 +338,7 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(String)]
     GetAddress { name: String },
-    #[returns(AppComponent)]
+    #[returns(Vec<AppComponent>)]
     GetComponents {},
     #[returns(ComponentExistsResponse)]
     ComponentExists { name: String },


### PR DESCRIPTION
# Motivation

Resolve issue with wrong schema for app get components query response

# Implementation

- Changed response from `AppComponent` to `Vec<AppComponent`.

# Testing

Was there any on-chain, or other types, of testing run with this change?

# Version Changes

Were there any required version changes?

Example:

- `kernel`: `x.x.x-b.x` -> `x.x.x-b.y`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
