### PR TITLE
fix: replace .expect with ok_or in our contracts

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -143,7 +143,9 @@ fn handle_transfer(
             let cw20_msg = if is_transfer_from {
                 Cw20ExecuteMsg::TransferFrom {
                     recipient,
-                    owner: owner.expect("Owner should be provided for TransferFrom"),
+                    owner: owner.ok_or(ContractError::new(
+                        "Owner should be provided for TransferFrom",
+                    ))?,
                     amount: remaining_amount,
                 }
             } else {
@@ -165,7 +167,9 @@ fn handle_transfer(
             let cw20_msg = if is_transfer_from {
                 Cw20ExecuteMsg::TransferFrom {
                     recipient,
-                    owner: owner.expect("Owner should be provided for TransferFrom"),
+                    owner: owner.ok_or(ContractError::new(
+                        "Owner should be provided for TransferFrom",
+                    ))?,
                     amount,
                 }
             } else {
@@ -275,7 +279,8 @@ fn handle_send(
                     contract,
                     amount: remaining_amount,
                     msg,
-                    owner: owner.expect("Owner should be provided for SendFrom"),
+                    owner: owner
+                        .ok_or(ContractError::new("Owner should be provided for SendFrom"))?,
                 }
             } else {
                 Cw20ExecuteMsg::Send {
@@ -300,7 +305,8 @@ fn handle_send(
                     contract,
                     amount,
                     msg,
-                    owner: owner.expect("Owner should be provided for SendFrom"),
+                    owner: owner
+                        .ok_or(ContractError::new("Owner should be provided for SendFrom"))?,
                 }
             } else {
                 Cw20ExecuteMsg::Send {

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -248,8 +248,10 @@ pub fn trigger_relay(
         ContractError::Unauthorized {}
     );
     let ics20_packet_info = CHANNEL_TO_EXECUTE_MSG
-        .load(ctx.deps.storage, (channel_id.clone(), packet_sequence))
-        .expect("No packet found for channel_id and sequence");
+        .may_load(ctx.deps.storage, (channel_id.clone(), packet_sequence))?
+        .ok_or(ContractError::InvalidPacket {
+            error: Some("No packet found for channel_id and sequence".to_string()),
+        })?;
 
     let chain = ics20_packet_info
         .recipient

--- a/contracts/os/andromeda-kernel/src/ibc.rs
+++ b/contracts/os/andromeda-kernel/src/ibc.rs
@@ -221,9 +221,9 @@ pub fn do_ibc_packet_receive(
             let res = execute::send(execute_env, msg)?;
 
             // Refunds must be done via the ICS20 channel
-            let ics20_channel_id = channel_info
-                .ics20_channel_id
-                .expect("Cannot refund, ICS20 Channel ID not set");
+            let ics20_channel_id = channel_info.ics20_channel_id.ok_or(ContractError::new(
+                "Cannot refund, ICS20 Channel ID not set",
+            ))?;
             // Save refund info
             REFUND_DATA.save(
                 deps.storage,


### PR DESCRIPTION
# Motivation
As @SlayerAnsh identified, there were some instances in our contracts where `.expect` was being used. This could potentially cause panics which are unsafe. They were replaced with `ok_or` which safely returns a ContractError instead of a panic. 

# Implementation
- Replace `.expect` with `.ok_or`

# Testing
N/A

# Version Changes
N/A

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
