### PR TITLE
fix: CI Deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
     steps:
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.87.0
-      - run: rustup override set 1.87.0
+          toolchain: 1.86.0
+      - run: rustup override set 1.86.0
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions/checkout@v4
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.86.0
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
       - name: Install Binaryen

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 1
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.86.0
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo fetch --quiet
@@ -51,6 +51,6 @@ jobs:
           fetch-depth: 1
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.86.0
       - uses: Swatinem/rust-cache@v2
       - run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,22 +3910,21 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.0.0"
+name = "icu_locid"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3935,10 +3934,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.0.0"
+name = "icu_locid_transform"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3946,52 +3965,65 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locale_core",
+ "icu_locid_transform",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
- "zerotrie",
+ "tinystr",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "displaydoc",
- "icu_locale_core",
+ "icu_locid",
+ "icu_provider_macros",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
- "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4007,9 +4039,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4232,9 +4264,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -4669,15 +4701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -6243,9 +6266,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6642,6 +6665,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -7072,16 +7101,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.1"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7091,9 +7126,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7163,21 +7198,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerotrie"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7186,9 +7210,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.2.1-b.1"
+version = "1.2.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-ibc-registry"
-version = "1.1.1-b.3"
+version = "1.1.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.1-b.7"
+version = "1.2.2"
 dependencies = [
  "andromeda-std",
  "base64 0.22.1",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.2.1-b.3"
+version = "1.2.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.2.1-b.1"
+version = "1.2.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/contracts/os/andromeda-ibc-registry/Cargo.toml
+++ b/contracts/os/andromeda-ibc-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-ibc-registry"
-version = "1.1.1-b.3"
+version = "1.1.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.1-b.7"
+version = "1.2.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.2.1-b.3"
+version = "1.2.2"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,49 +1,15 @@
 #!/bin/bash
-set -euo pipefail
-
 mkdir -p ./artifacts
 
-# Determine architecture and set custom image tag
 if [[ $(uname -m) == "arm64" ]]; then
-  OPTIMIZER_TAG="cosmwasm/optimizer-arm64:main"
-  PLATFORM="linux/arm64"
+  OPTIMIZER_IMAGE="cosmwasm/optimizer-arm64:0.16.1"
 else
-  OPTIMIZER_TAG="cosmwasm/optimizer:main"
-  PLATFORM="linux/amd64"
+  OPTIMIZER_IMAGE="cosmwasm/optimizer:0.16.1"
 fi
 
-# Check if Rust Alpine 1.86.0 is installed, if not install it via Docker
-if ! rustc --version | grep -q "1.86.0"; then
-  echo "🔧 Rust Alpine 1.86.0 not found. Installing via Docker..."
-  
-  # Create a temporary Dockerfile for Rust installation
-  cat > Dockerfile.rust << 'EOF'
-FROM rust:1.86.0-alpine
-RUN apk add --no-cache musl-dev
-EOF
+docker build --build-arg OPTIMIZER_IMAGE="$OPTIMIZER_IMAGE" -t cosmwasm-optimizer-clang .
 
-  # Build the Rust image
-  docker build -t rust-alpine-1.86.0 -f Dockerfile.rust .
-  
-  # Clean up the temporary Dockerfile
-  rm Dockerfile.rust
-  
-  echo "✅ Rust Alpine 1.86.0 has been installed via Docker"
-fi
-
-# Check if the image already exists
-if ! docker image inspect "$OPTIMIZER_TAG" > /dev/null 2>&1; then
-  echo "🔧 Building $OPTIMIZER_TAG from GitHub repo..."
-  docker buildx build --platform "$PLATFORM" \
-    --pull \
-    --tag "$OPTIMIZER_TAG" \
-    "https://github.com/CosmWasm/optimizer.git#main"
-fi
-
-# Build the custom image that adds clang
-docker build --build-arg OPTIMIZER_IMAGE="$OPTIMIZER_TAG" -t cosmwasm-optimizer-clang .
-
-echo "📦 Building contracts for $(uname -m) architecture..."
+echo "Building contracts for $(uname -m) architecture"
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,15 +1,30 @@
 #!/bin/bash
+set -euo pipefail
+
 mkdir -p ./artifacts
 
+# Determine architecture and set custom image tag
 if [[ $(uname -m) == "arm64" ]]; then
-  OPTIMIZER_IMAGE="cosmwasm/optimizer-arm64:0.16.1"
+  OPTIMIZER_TAG="cosmwasm/optimizer-arm64:main"
+  PLATFORM="linux/arm64"
 else
-  OPTIMIZER_IMAGE="cosmwasm/optimizer:0.16.1"
+  OPTIMIZER_TAG="cosmwasm/optimizer:main"
+  PLATFORM="linux/amd64"
 fi
 
-docker build --build-arg OPTIMIZER_IMAGE="$OPTIMIZER_IMAGE" -t cosmwasm-optimizer-clang .
+# Check if the image already exists
+if ! docker image inspect "$OPTIMIZER_TAG" > /dev/null 2>&1; then
+  echo "🔧 Building $OPTIMIZER_TAG from GitHub repo..."
+  docker buildx build --platform "$PLATFORM" \
+    --pull \
+    --tag "$OPTIMIZER_TAG" \
+    "https://github.com/CosmWasm/optimizer.git#main"
+fi
 
-echo "Building contracts for $(uname -m) architecture"
+# Build the custom image that adds clang
+docker build --build-arg OPTIMIZER_IMAGE="$OPTIMIZER_TAG" -t cosmwasm-optimizer-clang .
+
+echo "📦 Building contracts for $(uname -m) architecture..."
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -12,6 +12,25 @@ else
   PLATFORM="linux/amd64"
 fi
 
+# Check if Rust Alpine 1.86.0 is installed, if not install it via Docker
+if ! rustc --version | grep -q "1.86.0"; then
+  echo "🔧 Rust Alpine 1.86.0 not found. Installing via Docker..."
+  
+  # Create a temporary Dockerfile for Rust installation
+  cat > Dockerfile.rust << 'EOF'
+FROM rust:1.86.0-alpine
+RUN apk add --no-cache musl-dev
+EOF
+
+  # Build the Rust image
+  docker build -t rust-alpine-1.86.0 -f Dockerfile.rust .
+  
+  # Clean up the temporary Dockerfile
+  rm Dockerfile.rust
+  
+  echo "✅ Rust Alpine 1.86.0 has been installed via Docker"
+fi
+
 # Check if the image already exists
 if ! docker image inspect "$OPTIMIZER_TAG" > /dev/null 2>&1; then
   echo "🔧 Building $OPTIMIZER_TAG from GitHub repo..."


### PR DESCRIPTION
# Motivation
We were getting an error related to the toolchain version, and migration error for OS contracts. 

# Implementation
- Set toolchain's version to 1.86.0
- Used the old build_all.sh script
- Bumped the OS Contracts versions and dropped their beta tags

# Testing
[Link](https://github.com/andromedaprotocol/andromeda-core/actions/runs/15712235941) to the successful deployment 

# Version Changes
- `economics`: `1.2.1-b.1` -> `1.2.2`
- `ibc-registry`: `1.1.1-b.3` -> `1.1.2`
- `kernel`: `1.2.1-b.7` -> `1.2.2`
- `vfs`: `1.2.1-b.3` -> `1.2.2`

# Checklist

- [x] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
