### PR TITLE
fix: Base Queries for astroport and osmosis sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket-astroport"
-version = "0.1.8-b.3"
+version = "0.1.8-b.4"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket-osmosis"
-version = "0.1.2-b.2"
+version = "0.1.2-b.3"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",

--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -102,22 +102,23 @@ pub fn handle_local(
     // Check if the recipient is an ADO
     let ado_type = AOSQuerier::ado_type_getter(&deps.querier, &adodb_addr, code_id)?;
 
+    // Ensure that the recipient addr is not an OS contract
+    if let Some(ado_type) = &ado_type {
+        ensure!(
+            !is_os_contract(ado_type),
+            ContractError::InvalidRecipientType {
+                msg: "Recipient is an OS contract".to_string(),
+            }
+        );
+    }
+
     // Generate submessage based on whether recipient is an ADO or if the message is direct
     let sub_msg = if config.direct || ado_type.is_none() {
-        // Ensure that the recipient addr is not an OS contract
-        if let Some(ado_type) = ado_type {
-            ensure!(
-                !is_os_contract(&ado_type),
-                ContractError::InvalidRecipientType {
-                    msg: "Recipient is an OS contract".to_string(),
-                }
-            );
-        }
         amp_message.generate_sub_msg_direct(recipient_addr, ReplyId::AMPMsg.repr())
     } else {
         let origin = ctx.map_or(info.sender.to_string(), |ctx| ctx.get_origin());
         let previous_sender = info.sender.to_string();
-        // OS contracts don't have an AMP Receive entry point, so there's no risk of bypassing authorization checks
+
         AMPPkt::new(origin, previous_sender, vec![amp_message.clone()]).to_sub_msg(
             recipient_addr,
             Some(funds.clone()),

--- a/contracts/socket/andromeda-socket-astroport/Cargo.toml
+++ b/contracts/socket/andromeda-socket-astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket-astroport"
-version = "0.1.8-b.3"
+version = "0.1.8-b.4"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/socket/andromeda-socket-astroport/src/contract.rs
+++ b/contracts/socket/andromeda-socket-astroport/src/contract.rs
@@ -476,7 +476,7 @@ fn withdraw_liquidity(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::SimulateSwapOperation {
             offer_amount,
@@ -486,6 +486,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
             offer_amount,
             operations,
         )?),
+        _ => ADOContract::default().query(deps, env, msg),
     }
 }
 

--- a/contracts/socket/andromeda-socket-osmosis/Cargo.toml
+++ b/contracts/socket/andromeda-socket-osmosis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket-osmosis"
-version = "0.1.2-b.2"
+version = "0.1.2-b.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/socket/andromeda-socket-osmosis/src/contract.rs
+++ b/contracts/socket/andromeda-socket-osmosis/src/contract.rs
@@ -277,12 +277,13 @@ fn execute_update_swap_router(
     ]))
 }
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::GetRoute {
             from_denom,
             to_denom,
         } => encode_binary(&query_get_route(deps, from_denom, to_denom)?),
+        _ => ADOContract::default().query(deps, env, msg),
     }
 }
 

--- a/packages/andromeda-socket/Cargo.toml
+++ b/packages/andromeda-socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 rust-version = "1.75.0"
 description = "Utility methods and message definitions for the Andromeda Socket"

--- a/packages/andromeda-socket/src/astroport.rs
+++ b/packages/andromeda-socket/src/astroport.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
-    andr_exec, andr_instantiate,
+    andr_exec, andr_instantiate, andr_query,
     common::denom::Asset,
     error::ContractError,
 };
@@ -110,8 +110,10 @@ pub enum Cw20HookMsg {
         operations: Option<Vec<SwapOperation>>,
     },
 }
-#[cw_serde]
+
 #[cfg_attr(not(target_arch = "wasm32"), derive(cw_orch::QueryFns))]
+#[andr_query]
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(SimulateSwapOperationResponse)]

--- a/packages/andromeda-socket/src/osmosis.rs
+++ b/packages/andromeda-socket/src/osmosis.rs
@@ -1,6 +1,6 @@
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
-    andr_exec, andr_instantiate,
+    andr_exec, andr_instantiate, andr_query,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Coin, Decimal, Uint128};
@@ -78,9 +78,9 @@ pub enum OsmosisExecuteMsg {
         route: Option<Vec<SwapAmountInRoute>>,
     },
 }
-
-#[cw_serde]
 #[cfg_attr(not(target_arch = "wasm32"), derive(cw_orch::QueryFns))]
+#[andr_query]
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(GetRouteResponse)]


### PR DESCRIPTION
# Motivation
Andr queries were missing from those ADOs

# Implementation
- `#[andr_query]` was implemented for their `QueryMsg` enum. 

# Testing
N/A

# Version Changes
- `kernel`: `x.x.x-b.x` -> `x.x.x-b.y`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
