### PR TITLE
fix: Cancel Sale in exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Timelock Release Funds [(#857)](https://github.com/andromedaprotocol/andromeda-core/pull/857)
 - fix: Added missing version bumps [(#858)](https://github.com/andromedaprotocol/andromeda-core/pull/858)
 - fix: GetComponents query's schema  [(#873)](https://github.com/andromedaprotocol/andromeda-core/pull/873)
+- fix: Remove sale after Cancel Sale in Exchange  [(#913)](https://github.com/andromedaprotocol/andromeda-core/pull/913)
 
 
 ## Release 4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
  "andromeda-std",
+ "andromeda-testing",
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
  "cw-multi-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-exchange"
-version = "3.0.0-b.1"
+version = "3.0.0-b.2"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # use library feature to disable all instantiate/execute/query exports
 library = []
-testing = ["cw-multi-test"]
+testing = ["cw-multi-test", "andromeda-testing"]
 
 
 [dependencies]
@@ -24,6 +24,7 @@ andromeda-fungible-tokens = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = { workspace = true, optional = true }
+andromeda-testing = { workspace = true, optional = true }
 cw-orch = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-exchange"
-version = "3.0.0-b.1"
+version = "3.0.0-b.2"
 edition = "2021"
 rust-version = "1.75.0"
 [lib]

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/execute_sale.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/execute_sale.rs
@@ -218,8 +218,9 @@ pub fn execute_purchase_native(
 
 pub fn execute_cancel_sale(ctx: ExecuteContext, asset: Asset) -> Result<Response, ContractError> {
     let ExecuteContext { deps, info, .. } = ctx;
+    let inner_asset = asset.inner(&deps.as_ref())?;
 
-    let Some(sale) = SALE.may_load(deps.storage, &asset.inner(&deps.as_ref())?)? else {
+    let Some(sale) = SALE.may_load(deps.storage, &inner_asset)? else {
         return Err(ContractError::NoOngoingSale {});
     };
 
@@ -242,7 +243,7 @@ pub fn execute_cancel_sale(ctx: ExecuteContext, asset: Asset) -> Result<Response
     }
 
     // Sale can now be removed
-    SALE.remove(deps.storage, &asset.to_string());
+    SALE.remove(deps.storage, &inner_asset);
 
     Ok(resp.add_attributes(vec![
         attr("action", "cancel_sale"),

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/mock.rs
@@ -102,3 +102,11 @@ pub fn mock_set_redeem_condition_native_msg(
 pub fn mock_redeem_query_msg(asset: Asset) -> QueryMsg {
     QueryMsg::Redeem { asset }
 }
+
+pub fn mock_sale_query_msg(asset: String) -> QueryMsg {
+    QueryMsg::Sale { asset }
+}
+
+pub fn mock_cancel_sale_msg(asset: Asset) -> ExecuteMsg {
+    ExecuteMsg::CancelSale { asset }
+}

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/mock.rs
@@ -110,3 +110,7 @@ pub fn mock_sale_query_msg(asset: String) -> QueryMsg {
 pub fn mock_cancel_sale_msg(asset: Asset) -> ExecuteMsg {
     ExecuteMsg::CancelSale { asset }
 }
+
+pub fn mock_cancel_redeem_msg(asset: Asset) -> ExecuteMsg {
+    ExecuteMsg::CancelRedeem { asset }
+}

--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/mock.rs
@@ -92,6 +92,21 @@ impl MockExchange {
             .unwrap()
     }
 
+    pub fn execute_cw20_purchase(
+        &self,
+        app: &mut MockApp,
+        sender: Addr,
+        recipient: Option<Recipient>,
+        amount: Uint128,
+        cw20_addr: Addr,
+    ) -> AppResponse {
+        let msg = mock_cw20_exchange_purchase_msg(recipient);
+        let cw20_send_msg =
+            mock_cw20_send(self.addr().clone(), amount, to_json_binary(&msg).unwrap());
+        app.execute_contract(sender, cw20_addr, &cw20_send_msg, &[])
+            .unwrap()
+    }
+
     pub fn query_redeem(&self, app: &mut MockApp, asset: Asset) -> RedeemResponse {
         let msg = mock_redeem_query_msg(asset);
         let res: RedeemResponse = self.query(app, msg);

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -17,7 +17,7 @@ use andromeda_testing::{
     mock_ado,
     mock_contract::{ExecuteResult, MockADO, MockContract},
 };
-use cosmwasm_std::{Addr, Coin, Empty, Uint128}; 
+use cosmwasm_std::{Addr, Coin, Empty, Uint128};
 use cw20::Cw20ReceiveMsg;
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 

--- a/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
+++ b/contracts/non-fungible-tokens/andromeda-auction/src/mock.rs
@@ -17,7 +17,7 @@ use andromeda_testing::{
     mock_ado,
     mock_contract::{ExecuteResult, MockADO, MockContract},
 };
-use cosmwasm_std::{Addr, Coin, Empty, Uint128};
+use cosmwasm_std::{Addr, Coin, Empty, Uint128}; 
 use cw20::Cw20ReceiveMsg;
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 

--- a/tests/cw20_exchange.rs
+++ b/tests/cw20_exchange.rs
@@ -5,11 +5,11 @@ use andromeda_cw20::mock::{
     mock_minter,
 };
 use andromeda_cw20_exchange::mock::{
-    mock_andromeda_cw20_exchange, mock_cancel_sale_msg, mock_cw20_exchange_hook_purchase_msg,
-    mock_cw20_exchange_instantiate_msg, mock_cw20_exchange_start_sale_msg, mock_redeem_cw20_msg,
-    mock_redeem_native_msg, mock_redeem_query_msg, mock_replenish_redeem_cw20_msg,
-    mock_replenish_redeem_native_msg, mock_sale_query_msg, mock_set_redeem_condition_native_msg,
-    mock_start_redeem_cw20_msg,
+    mock_andromeda_cw20_exchange, mock_cancel_redeem_msg, mock_cancel_sale_msg,
+    mock_cw20_exchange_hook_purchase_msg, mock_cw20_exchange_instantiate_msg,
+    mock_cw20_exchange_start_sale_msg, mock_redeem_cw20_msg, mock_redeem_native_msg,
+    mock_redeem_query_msg, mock_replenish_redeem_cw20_msg, mock_replenish_redeem_native_msg,
+    mock_sale_query_msg, mock_set_redeem_condition_native_msg, mock_start_redeem_cw20_msg,
 };
 use andromeda_fungible_tokens::cw20_exchange::{RedeemResponse, SaleResponse};
 use andromeda_std::{
@@ -607,6 +607,115 @@ fn test_cw20_exchange_app_cancel_sale() {
         .query_wasm_smart(cw20_exchange_addr.clone(), &sale_query_msg)
         .unwrap();
     assert!(sale_query_resp.sale.is_none());
+}
+
+#[test]
+fn test_cw20_exchange_app_cancel_redeem() {
+    let mut router = mock_app(None);
+
+    let andr = setup_andr(&mut router);
+    let app = setup_app(&andr, &mut router);
+    let owner = andr.get_wallet("owner");
+    let user1 = andr.get_wallet("user1");
+
+    let addresses = get_addresses(&mut router, &andr, &app);
+
+    let cw20_addr = addresses.cw20;
+    let cw20_addr_2 = addresses.cw20_2;
+    let cw20_exchange_addr = addresses.cw20_exchange;
+
+    let cw20_addr_2_asset = Asset::Cw20Token(AndrAddr::from_string(cw20_addr_2.to_string()));
+    let cw20_redeem_asset = Asset::Cw20Token(AndrAddr::from_string(cw20_addr.to_string()));
+
+    // Sell a cw20
+    let start_sale_msg =
+        mock_cw20_exchange_start_sale_msg(cw20_redeem_asset, Uint128::new(2), None, None, None);
+
+    let cw20_send_msg = mock_cw20_send(
+        cw20_exchange_addr.clone(),
+        ORIGINAL_SALE_AMOUNT,
+        to_json_binary(&start_sale_msg).unwrap(),
+    );
+
+    router
+        .execute_contract(owner.clone(), cw20_addr_2.clone(), &cw20_send_msg, &[])
+        .unwrap();
+
+    // Now there's a sale for cw20addr2 for 2 cw20addr per token
+    // user1 will purchase 10 cw20addr2
+
+    let purchase_msg =
+        mock_cw20_exchange_hook_purchase_msg(Some(Recipient::from_string(user1.to_string())));
+    let cw20_send_msg = mock_cw20_send(
+        cw20_exchange_addr.clone(),
+        Uint128::new(10u128),
+        to_json_binary(&purchase_msg).unwrap(),
+    );
+
+    router
+        .execute_contract(user1.clone(), cw20_addr.clone(), &cw20_send_msg, &[])
+        .unwrap();
+
+    // Check that user1 has received 5 cw20addr_2
+    let balance = query_cw20_balance(&mut router, cw20_addr_2.to_string(), user1.to_string());
+    assert_eq!(balance, Uint128::new(1000 + 5u128));
+
+    // Now the owner will setup a redeem condition for 2 cw20 per cw20addr
+    let start_redeem_msg = mock_start_redeem_cw20_msg(
+        None,
+        cw20_addr_2_asset.clone(),
+        Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)),
+        None,
+        None,
+    );
+
+    let cw20_send_msg = mock_cw20_send(
+        cw20_exchange_addr.clone(),
+        Uint128::new(100u128),
+        to_json_binary(&start_redeem_msg).unwrap(),
+    );
+
+    router
+        .execute_contract(owner.clone(), cw20_addr.clone(), &cw20_send_msg, &[])
+        .unwrap();
+
+    let redeem_query_msg = mock_redeem_query_msg(cw20_addr_2_asset.clone());
+    let redeem_query_resp: RedeemResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_exchange_addr.clone(), &redeem_query_msg)
+        .unwrap();
+    assert_eq!(
+        redeem_query_resp.redeem.clone().unwrap().asset,
+        Asset::Cw20Token(AndrAddr::from_string(cw20_addr.to_string()))
+    );
+    assert_eq!(redeem_query_resp.redeem.unwrap().amount, Uint128::new(100));
+
+    // Query to see that the redeem exists
+    let redeem_query_msg = mock_redeem_query_msg(cw20_addr_2_asset.clone());
+    let redeem_query_resp: RedeemResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_exchange_addr.clone(), &redeem_query_msg)
+        .unwrap();
+    assert!(redeem_query_resp.redeem.is_some());
+
+    // Cancel the redeem
+    let cancel_redeem_msg = mock_cancel_redeem_msg(cw20_addr_2_asset.clone());
+    router
+        .execute_contract(
+            owner.clone(),
+            cw20_exchange_addr.clone(),
+            &cancel_redeem_msg,
+            &[],
+        )
+        .unwrap();
+
+    // Query to see that the redeem does not exist
+    let redeem_query_msg = mock_redeem_query_msg(cw20_addr_2_asset.clone());
+    let redeem_query_resp: RedeemResponse = router
+        .wrap()
+        .query_wasm_smart(cw20_exchange_addr.clone(), &redeem_query_msg)
+        .unwrap();
+    assert!(redeem_query_resp.redeem.is_none());
 }
 
 #[test]


### PR DESCRIPTION
# Motivation
Cancelling the sale wasn't removing the sale from state. 

# Implementation
- Access the inner value of the asset during removal

# Testing
Integration tests for cancel sale and cancel redeem. 

# Version Changes
- `exchange`: `3.0.0-b.1` -> `3.0.0-b.2`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
