### PR TITLE
fix: kernel send bypass OS contracts security

### DIFF
--- a/contracts/os/andromeda-vfs/src/mock.rs
+++ b/contracts/os/andromeda-vfs/src/mock.rs
@@ -30,11 +30,15 @@ pub fn mock_register_user(username: impl Into<String>) -> ExecuteMsg {
     }
 }
 
-pub fn mock_add_path(name: impl Into<String>, address: Addr) -> ExecuteMsg {
+pub fn mock_add_path(
+    name: impl Into<String>,
+    address: Addr,
+    parent_address: Option<AndrAddr>,
+) -> ExecuteMsg {
     ExecuteMsg::AddPath {
         name: name.into(),
         address,
-        parent_address: None,
+        parent_address,
     }
 }
 

--- a/packages/andromeda-testing/src/vfs.rs
+++ b/packages/andromeda-testing/src/vfs.rs
@@ -1,5 +1,8 @@
 use crate::{mock::MockApp, mock_ado, mock_contract::ExecuteResult, MockADO, MockContract};
-use andromeda_std::os::vfs::{ExecuteMsg, QueryMsg};
+use andromeda_std::{
+    amp::AndrAddr,
+    os::vfs::{ExecuteMsg, QueryMsg},
+};
 use andromeda_vfs::mock::*;
 use cosmwasm_std::Addr;
 use cw_multi_test::Executor;
@@ -45,8 +48,9 @@ impl MockVFS {
         sender: Addr,
         name: impl Into<String>,
         address: Addr,
+        parent_address: Option<AndrAddr>,
     ) -> ExecuteResult {
-        let msg = mock_add_path(name, address);
+        let msg = mock_add_path(name, address, parent_address);
 
         self.execute(app, &msg, sender, &[])
     }


### PR DESCRIPTION
# Motivation
Users could bypass the security checks of contracts that expect a message sent by the kernel through the kernel's Send msg. 

# Implementation
- Ban the sending of direct message from kernel to OS contracts. 

# Testing
`test_kernel_send_to_vfs`

# Version Changes
- `kernel`: `1.2.2` -> `1.2.3`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
