### PR TITLE
fix: compilation error

### DIFF
--- a/contracts/fungible-tokens/andromeda-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/testing/tests.rs
@@ -1542,8 +1542,7 @@ fn test_cancel_redeem_unauthorized() {
         redeem_asset: redeem_asset.clone(),
         exchange_rate: Decimal256::percent(200),
         recipient: None,
-        start_time: None,
-        end_time: None,
+        schedule: Schedule::new(None, None),
     };
     let info = message_info(&owner, &[coin(100u128, "uusd")]);
     let err = execute(deps.as_mut(), env.clone(), info.clone(), redeem_msg.clone()).unwrap_err();


### PR DESCRIPTION
# Motivation
Resolves a basic compilation error. I think it occurred because two PRs were merged in quick succession, not giving enough time for the second one to recompile which would have revealed that simple error. 

# Implementation
Added the expected input to a unit test

# Testing
Mentioned above. 

# Version Changes
None

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
