### PR TITLE
feat: Dynamic Exchange Rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-exchange"
-version = "3.0.0-b.3"
+version = "3.0.0-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",

--- a/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-exchange"
-version = "3.0.0-b.3"
+version = "3.0.0-b.4"
 edition = "2021"
 rust-version = "1.75.0"
 [lib]

--- a/contracts/fungible-tokens/andromeda-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/contract.rs
@@ -84,9 +84,10 @@ pub fn execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, Contrac
             recipient,
             schedule,
         } => execute_start_redeem_native(ctx, redeem_asset, exchange_rate, recipient, schedule),
-        ExecuteMsg::ReplenishRedeem { redeem_asset } => {
-            execute_replenish_redeem_native(ctx, redeem_asset)
-        }
+        ExecuteMsg::ReplenishRedeem {
+            redeem_asset,
+            exchange_rate_type,
+        } => execute_replenish_redeem_native(ctx, redeem_asset, exchange_rate_type),
         ExecuteMsg::Redeem { recipient } => execute_redeem_native(ctx, recipient),
         ExecuteMsg::Receive(cw20_msg) => execute_receive(ctx, cw20_msg),
         _ => ADOContract::default().execute(ctx, msg),
@@ -143,9 +144,16 @@ pub fn execute_receive(
             recipient,
             schedule,
         ),
-        Cw20HookMsg::ReplenishRedeem { redeem_asset } => {
-            execute_replenish_redeem(ctx, amount_sent, asset_sent, redeem_asset)
-        }
+        Cw20HookMsg::ReplenishRedeem {
+            redeem_asset,
+            exchange_rate_type,
+        } => execute_replenish_redeem(
+            ctx,
+            amount_sent,
+            asset_sent,
+            redeem_asset,
+            exchange_rate_type,
+        ),
         Cw20HookMsg::Redeem { recipient } => {
             let recipient = Recipient::validate_or_default(recipient, &ctx, sender.as_str())?;
             execute_redeem(ctx, amount_sent, asset_sent, recipient, &sender)

--- a/contracts/fungible-tokens/andromeda-exchange/src/execute_redeem.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/execute_redeem.rs
@@ -123,8 +123,7 @@ pub fn execute_replenish_redeem(
 
     // Adjust the rate and type only if a a new one was provided by the user
     if let Some(exchange_rate_type) = exchange_rate_type {
-        let exchange_rate_amount =
-            exchange_rate_type.get_exchange_rate(redeem.amount.checked_add(amount)?)?;
+        let exchange_rate_amount = exchange_rate_type.get_exchange_rate(redeem.amount)?;
         redeem.exchange_rate = exchange_rate_amount;
         redeem.exchange_type = exchange_rate_type;
     }

--- a/contracts/fungible-tokens/andromeda-exchange/src/execute_redeem.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/execute_redeem.rs
@@ -46,7 +46,9 @@ pub fn execute_start_redeem(
         ExchangeRate::Variable(rate) => {
             let rate_decimal = Decimal256::from_ratio(rate, 1u128);
             let amount_decimal = Decimal256::from_ratio(amount, 1u128);
-            rate_decimal.checked_mul(amount_decimal)?
+            rate_decimal
+                .checked_div(amount_decimal)
+                .map_err(|_| ContractError::Overflow {})?
         }
     };
     ensure!(

--- a/contracts/fungible-tokens/andromeda-exchange/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/mock.rs
@@ -3,7 +3,7 @@
 use crate::contract::{execute, instantiate, query};
 use andromeda_fungible_tokens::cw20::ExecuteMsg as Cw20ExecuteMsg;
 use andromeda_fungible_tokens::exchange::{
-    Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, RedeemResponse, SaleResponse,
+    Cw20HookMsg, ExchangeRate, ExecuteMsg, InstantiateMsg, QueryMsg, RedeemResponse, SaleResponse,
 };
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
@@ -14,7 +14,7 @@ use andromeda_testing::{
     mock_ado,
     mock_contract::{MockADO, MockContract},
 };
-use cosmwasm_std::{to_json_binary, Addr, Binary, Decimal256, Empty, Uint128};
+use cosmwasm_std::{to_json_binary, Addr, Binary, Empty, Uint128};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 
 pub struct MockExchange(Addr);
@@ -67,7 +67,7 @@ impl MockExchange {
         sender: Addr,
         asset: Asset,
         amount: Uint128,
-        exchange_rate: Decimal256,
+        exchange_rate: ExchangeRate,
         cw20_addr: Addr,
         schedule: Schedule,
     ) -> AppResponse {
@@ -165,7 +165,7 @@ pub fn mock_replenish_redeem_native_msg(redeem_asset: Asset) -> ExecuteMsg {
 pub fn mock_start_redeem_cw20_msg(
     recipient: Option<Recipient>,
     redeem_asset: Asset,
-    exchange_rate: Decimal256,
+    exchange_rate: ExchangeRate,
     schedule: Schedule,
 ) -> Cw20HookMsg {
     Cw20HookMsg::StartRedeem {
@@ -186,7 +186,7 @@ pub fn mock_cw20_send(contract: impl Into<String>, amount: Uint128, msg: Binary)
 
 pub fn mock_set_redeem_condition_native_msg(
     redeem_asset: Asset,
-    exchange_rate: Decimal256,
+    exchange_rate: ExchangeRate,
     recipient: Option<Recipient>,
     schedule: Schedule,
 ) -> ExecuteMsg {

--- a/contracts/fungible-tokens/andromeda-exchange/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/mock.rs
@@ -150,16 +150,28 @@ pub fn mock_redeem_cw20_msg(recipient: Option<Recipient>) -> Cw20HookMsg {
     Cw20HookMsg::Redeem { recipient }
 }
 
-pub fn mock_replenish_redeem_cw20_msg(redeem_asset: Asset) -> Cw20HookMsg {
-    Cw20HookMsg::ReplenishRedeem { redeem_asset }
+pub fn mock_replenish_redeem_cw20_msg(
+    redeem_asset: Asset,
+    exchange_rate_type: ExchangeRate,
+) -> Cw20HookMsg {
+    Cw20HookMsg::ReplenishRedeem {
+        redeem_asset,
+        exchange_rate_type,
+    }
 }
 
 pub fn mock_redeem_native_msg(recipient: Option<Recipient>) -> ExecuteMsg {
     ExecuteMsg::Redeem { recipient }
 }
 
-pub fn mock_replenish_redeem_native_msg(redeem_asset: Asset) -> ExecuteMsg {
-    ExecuteMsg::ReplenishRedeem { redeem_asset }
+pub fn mock_replenish_redeem_native_msg(
+    redeem_asset: Asset,
+    exchange_rate_type: ExchangeRate,
+) -> ExecuteMsg {
+    ExecuteMsg::ReplenishRedeem {
+        redeem_asset,
+        exchange_rate_type,
+    }
 }
 
 pub fn mock_start_redeem_cw20_msg(

--- a/contracts/fungible-tokens/andromeda-exchange/src/mock.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/mock.rs
@@ -152,7 +152,7 @@ pub fn mock_redeem_cw20_msg(recipient: Option<Recipient>) -> Cw20HookMsg {
 
 pub fn mock_replenish_redeem_cw20_msg(
     redeem_asset: Asset,
-    exchange_rate_type: ExchangeRate,
+    exchange_rate_type: Option<ExchangeRate>,
 ) -> Cw20HookMsg {
     Cw20HookMsg::ReplenishRedeem {
         redeem_asset,
@@ -166,7 +166,7 @@ pub fn mock_redeem_native_msg(recipient: Option<Recipient>) -> ExecuteMsg {
 
 pub fn mock_replenish_redeem_native_msg(
     redeem_asset: Asset,
-    exchange_rate_type: ExchangeRate,
+    exchange_rate_type: Option<ExchangeRate>,
 ) -> ExecuteMsg {
     ExecuteMsg::ReplenishRedeem {
         redeem_asset,

--- a/contracts/fungible-tokens/andromeda-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/testing/tests.rs
@@ -1422,6 +1422,7 @@ fn test_cancel_redeem() {
                 amount: redeem_amount,
                 amount_paid_out: Uint128::zero(),
                 exchange_rate,
+                exchange_type: ExchangeRate::Fixed(exchange_rate),
                 recipient: Recipient::from_string(owner.to_string()),
                 start_time: Milliseconds::from_nanos(env.block.time.nanos()),
                 end_time: None,
@@ -1523,6 +1524,7 @@ fn test_cancel_redeem_unauthorized() {
                 amount: Uint128::from(100u128),
                 amount_paid_out: Uint128::zero(),
                 exchange_rate: Decimal256::percent(200),
+                exchange_type: ExchangeRate::Fixed(Decimal256::percent(200)),
                 recipient: Recipient::from_string(owner.to_string()),
                 start_time: Milliseconds::from_nanos(env.block.time.nanos()),
                 end_time: None,
@@ -1558,6 +1560,7 @@ fn test_cancel_redeem_unauthorized() {
                 amount: Uint128::from(100u128),
                 amount_paid_out: Uint128::zero(),
                 exchange_rate: Decimal256::percent(200),
+                exchange_type: ExchangeRate::Fixed(Decimal256::percent(200)),
                 recipient: Recipient::from_string(owner.to_string()),
                 start_time: Milliseconds::from_nanos(env.block.time.nanos()),
                 end_time: Some(Milliseconds::from_nanos(
@@ -1579,6 +1582,7 @@ fn test_cancel_redeem_unauthorized() {
                 amount: Uint128::zero(),
                 amount_paid_out: Uint128::zero(),
                 exchange_rate: Decimal256::percent(200),
+                exchange_type: ExchangeRate::Fixed(Decimal256::percent(200)),
                 recipient: Recipient::from_string(owner.to_string()),
                 start_time: Milliseconds::from_nanos(env.block.time.nanos()),
                 end_time: Some(Milliseconds::from_nanos(

--- a/contracts/fungible-tokens/andromeda-exchange/src/testing/tests.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/testing/tests.rs
@@ -1,5 +1,5 @@
 use andromeda_fungible_tokens::exchange::{
-    Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg, Redeem, RedeemResponse, Sale,
+    Cw20HookMsg, ExchangeRate, ExecuteMsg, InstantiateMsg, QueryMsg, Redeem, RedeemResponse, Sale,
     SaleAssetsResponse, SaleResponse, TokenAddressResponse,
 };
 use andromeda_std::{
@@ -1540,7 +1540,7 @@ fn test_cancel_redeem_unauthorized() {
     // Try to create a duplicate redeem
     let redeem_msg = ExecuteMsg::StartRedeem {
         redeem_asset: redeem_asset.clone(),
-        exchange_rate: Decimal256::percent(200),
+        exchange_rate: ExchangeRate::Fixed(Decimal256::percent(200)),
         recipient: None,
         schedule: Schedule::new(None, None),
     };

--- a/packages/andromeda-fungible-tokens/src/exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/exchange.rs
@@ -73,7 +73,7 @@ pub enum ExecuteMsg {
         /// The accepted asset for redemption
         redeem_asset: Asset,
         /// The type of exchange rate whether it was fixed or variable
-        exchange_rate_type: ExchangeRate,
+        exchange_rate_type: Option<ExchangeRate>,
     },
 
     Redeem {
@@ -155,7 +155,7 @@ pub enum Cw20HookMsg {
         /// The accepted asset for redemption
         redeem_asset: Asset,
         /// The type of exchange rate whether it was fixed or variable
-        exchange_rate_type: ExchangeRate,
+        exchange_rate_type: Option<ExchangeRate>,
     },
     /// Redeems tokens
     Redeem {

--- a/packages/andromeda-fungible-tokens/src/exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/exchange.rs
@@ -14,6 +14,12 @@ pub struct InstantiateMsg {
     pub token_address: AndrAddr,
 }
 
+#[cw_serde]
+pub enum ExchangeRate {
+    Fixed(Decimal256),
+    Variable(Uint128),
+}
+
 #[andr_exec]
 #[cw_serde]
 pub enum ExecuteMsg {
@@ -30,7 +36,7 @@ pub enum ExecuteMsg {
         /// The accepted asset for redemption
         redeem_asset: Asset,
         /// The rate at which to exchange tokens (amount of exchanged asset to purchase sale asset)
-        exchange_rate: Decimal256,
+        exchange_rate: ExchangeRate,
         /// The recipient of the sale proceeds
         recipient: Option<Recipient>,
         schedule: Schedule,
@@ -109,7 +115,7 @@ pub enum Cw20HookMsg {
         redeem_asset: Asset,
         /// An exchange rate of 2 would grant the redeemer 2 asset for 1 redeem_asset
         /// An exchange rate of 0.5 would grant the redeemer 2 asset for 4 redeem_asset
-        exchange_rate: Decimal256,
+        exchange_rate: ExchangeRate,
         /// The recipient of the sale proceeds
         recipient: Option<Recipient>,
         schedule: Schedule,

--- a/packages/andromeda-fungible-tokens/src/exchange.rs
+++ b/packages/andromeda-fungible-tokens/src/exchange.rs
@@ -72,6 +72,8 @@ pub enum ExecuteMsg {
     ReplenishRedeem {
         /// The accepted asset for redemption
         redeem_asset: Asset,
+        /// The type of exchange rate whether it was fixed or variable
+        exchange_rate_type: ExchangeRate,
     },
 
     Redeem {
@@ -152,6 +154,8 @@ pub enum Cw20HookMsg {
     ReplenishRedeem {
         /// The accepted asset for redemption
         redeem_asset: Asset,
+        /// The type of exchange rate whether it was fixed or variable
+        exchange_rate_type: ExchangeRate,
     },
     /// Redeems tokens
     Redeem {

--- a/tests/exchange.rs
+++ b/tests/exchange.rs
@@ -407,11 +407,13 @@ fn test_exchange_app_cw20_to_cw20() {
     let balance = query_cw20_balance(&mut router, cw20_addr_2.to_string(), user1.to_string());
     assert_eq!(balance, Uint128::new(1000 + 5u128));
 
+    let exchange_rate =
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)));
     // Now the owner will setup a redeem condition for 2 cw20 per cw20addr
     let start_redeem_msg = mock_start_redeem_cw20_msg(
         None,
         cw20_addr_2_asset.clone(),
-        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))),
+        exchange_rate.clone(),
         Schedule::default(),
     );
 
@@ -518,7 +520,7 @@ fn test_exchange_app_cw20_to_cw20() {
     );
 
     // Replenish the redeem
-    let replenish_msg = mock_replenish_redeem_cw20_msg(cw20_addr_2_asset.clone());
+    let replenish_msg = mock_replenish_redeem_cw20_msg(cw20_addr_2_asset.clone(), exchange_rate);
     let cw20_send_msg = mock_cw20_send(
         exchange_addr.clone(),
         Uint128::new(10u128),
@@ -639,10 +641,12 @@ fn test_exchange_app_redeem_native_to_native() {
     let exchange_addr = addresses.exchange;
     let uandr_asset = Asset::NativeToken("uandr".to_string());
 
+    let exchange_rate =
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)));
     // Now the owner will setup a redeem condition for 2 uandr per uusd
     let redeem_msg = mock_set_redeem_condition_native_msg(
         uandr_asset.clone(),
-        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))),
+        exchange_rate.clone(),
         Some(Recipient::from_string(owner.to_string())),
         Schedule::default(),
     );
@@ -763,7 +767,7 @@ fn test_exchange_app_redeem_native_to_native() {
     );
 
     // Replenish the redeem
-    let replenish_msg = mock_replenish_redeem_native_msg(uandr_asset.clone());
+    let replenish_msg = mock_replenish_redeem_native_msg(uandr_asset.clone(), exchange_rate);
     router
         .execute_contract(
             owner.clone(),

--- a/tests/exchange.rs
+++ b/tests/exchange.rs
@@ -21,7 +21,9 @@ use andromeda_testing::{
     mock_builder::MockAndromedaBuilder,
     MockContract,
 };
-use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Decimal256, Timestamp, Uint128};
+use cosmwasm_std::{
+    coin, to_json_binary, Addr, BlockInfo, Decimal256, Timestamp, Uint128, Uint256,
+};
 use cw20::{BalanceResponse, Cw20Coin};
 use rstest::rstest;
 
@@ -1057,14 +1059,20 @@ fn test_exchange_app_redeem_native_fractional() {
 }
 
 #[rstest]
-#[case::rate_100(Uint128::new(100), 100u128, Decimal256::one())]
-#[case::rate_50(
-    Uint128::new(200),
+#[case::variable_rate_200(
+    Uint256::from(200u128),
+    100u128,
+    Decimal256::from_ratio(Uint128::new(1), Uint128::new(2))
+)]
+#[case::variable_rate_100(Uint256::from(100u128), 100u128, Decimal256::one())]
+#[case::variable_rate_50(
+    Uint256::from(50u128),
     100u128,
     Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))
 )]
+
 fn test_exchange_app_redeem_native_to_native_dynamic_exchange_rate(
-    #[case] variable_rate: Uint128,
+    #[case] variable_rate: Uint256,
     #[case] amount_sent: u128,
     #[case] expected_exchange_rate: Decimal256,
 ) {
@@ -1106,7 +1114,7 @@ fn test_exchange_app_redeem_native_to_native_dynamic_exchange_rate(
     );
     assert_eq!(
         redeem_query_resp.redeem.clone().unwrap().amount,
-        Uint128::new(100)
+        Uint128::new(amount_sent)
     );
     assert_eq!(
         redeem_query_resp.redeem.clone().unwrap().amount_paid_out,

--- a/tests/exchange.rs
+++ b/tests/exchange.rs
@@ -10,7 +10,7 @@ use andromeda_exchange::mock::{
     mock_redeem_query_msg, mock_replenish_redeem_cw20_msg, mock_replenish_redeem_native_msg,
     mock_set_redeem_condition_native_msg, mock_start_redeem_cw20_msg, MockExchange,
 };
-use andromeda_fungible_tokens::exchange::{RedeemResponse, SaleResponse};
+use andromeda_fungible_tokens::exchange::{ExchangeRate, RedeemResponse, SaleResponse};
 use andromeda_std::{
     amp::{AndrAddr, Recipient},
     common::{denom::Asset, schedule::Schedule},
@@ -245,7 +245,7 @@ fn test_exchange_app_cw20_to_native() {
     // Now the owner will setup a redeem condition for 2 uandr per cw20addr
     let redeem_msg = mock_set_redeem_condition_native_msg(
         cw20_addr_2_asset.clone(),
-        Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)),
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))),
         Some(Recipient::from_string(owner.to_string())),
         Schedule::default(),
     );
@@ -408,7 +408,7 @@ fn test_exchange_app_cw20_to_cw20() {
     let start_redeem_msg = mock_start_redeem_cw20_msg(
         None,
         cw20_addr_2_asset.clone(),
-        Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)),
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))),
         Schedule::default(),
     );
 
@@ -596,7 +596,8 @@ fn test_exchange_app_cancel_redeem() {
     let exchange: MockExchange = app.query_ado_by_component_name(&router, "exchange");
 
     // Now the owner will setup a redeem condition for 2 cw20 per cw20addr
-    let exchange_rate = Decimal256::from_ratio(Uint128::new(2), Uint128::new(1));
+    let exchange_rate =
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)));
     exchange.execute_cw20_start_redeem(
         &mut router,
         owner.clone(),
@@ -638,7 +639,7 @@ fn test_exchange_app_redeem_native_to_native() {
     // Now the owner will setup a redeem condition for 2 uandr per uusd
     let redeem_msg = mock_set_redeem_condition_native_msg(
         uandr_asset.clone(),
-        Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)),
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))),
         Some(Recipient::from_string(owner.to_string())),
         Schedule::default(),
     );
@@ -798,7 +799,7 @@ fn test_exchange_app_redeem_native_to_cw20() {
     let start_redeem_msg = mock_start_redeem_cw20_msg(
         None,
         uandr_asset.clone(),
-        Decimal256::from_ratio(Uint128::new(2), Uint128::new(1)),
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(2), Uint128::new(1))),
         Schedule::default(),
     );
 
@@ -933,7 +934,7 @@ fn test_exchange_app_redeem_native_fractional() {
 
     let redeem_msg = mock_set_redeem_condition_native_msg(
         uandr_asset.clone(),
-        Decimal256::from_ratio(Uint128::new(1), Uint128::new(2)),
+        ExchangeRate::Fixed(Decimal256::from_ratio(Uint128::new(1), Uint128::new(2))),
         Some(Recipient::from_string(owner.to_string())),
         Schedule::default(),
     );

--- a/tests/exchange.rs
+++ b/tests/exchange.rs
@@ -520,7 +520,7 @@ fn test_exchange_app_cw20_to_cw20() {
     );
 
     // Replenish the redeem
-    let replenish_msg = mock_replenish_redeem_cw20_msg(cw20_addr_2_asset.clone(), exchange_rate);
+    let replenish_msg = mock_replenish_redeem_cw20_msg(cw20_addr_2_asset.clone(), None);
     let cw20_send_msg = mock_cw20_send(
         exchange_addr.clone(),
         Uint128::new(10u128),
@@ -767,7 +767,7 @@ fn test_exchange_app_redeem_native_to_native() {
     );
 
     // Replenish the redeem
-    let replenish_msg = mock_replenish_redeem_native_msg(uandr_asset.clone(), exchange_rate);
+    let replenish_msg = mock_replenish_redeem_native_msg(uandr_asset.clone(), Some(exchange_rate));
     router
         .execute_contract(
             owner.clone(),


### PR DESCRIPTION
# Motivation
Added `ExchangeRate` enum that supports fixed and variable rates. 

# Implementation
- The variable exchange rate is divided by the amount of tokens sent with the `StartRedeem` message, the result of that operation is the exchange rate. 

# Testing
Integration tests

# Version Changes
- `exchange`: `3.0.0-b.3` -> `3.0.0-b.4`

# Checklist

- [x] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
