### PR TITLE
feat: add update minter to cw20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.1.1-b.2"
+version = "2.1.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fungible-tokens"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.1.1-b.2"
+version = "2.1.1-b.3"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20/src/contract.rs
@@ -76,6 +76,7 @@ pub fn execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, Contrac
             msg,
         } => execute_send_from(ctx, contract, amount, msg, action, owner),
         ExecuteMsg::Mint { recipient, amount } => execute_mint(ctx, recipient, amount),
+        ExecuteMsg::UpdateMinter { new_minter } => execute_update_minter(ctx, new_minter),
         _ => {
             let serialized = encode_binary(&msg)?;
             match from_json::<AndromedaMsg>(&serialized) {
@@ -335,6 +336,26 @@ fn execute_mint(
         env,
         info,
         Cw20ExecuteMsg::Mint { recipient, amount },
+    )?)
+}
+
+fn execute_update_minter(
+    ctx: ExecuteContext,
+    new_minter: Option<AndrAddr>,
+) -> Result<Response, ContractError> {
+    let ExecuteContext {
+        deps, info, env, ..
+    } = ctx;
+
+    let new_minter = new_minter
+        .and_then(|minter| minter.get_raw_address(&deps.as_ref()).ok())
+        .map(|addr| addr.to_string());
+
+    Ok(execute_cw20(
+        deps,
+        env,
+        info,
+        Cw20ExecuteMsg::UpdateMinter { new_minter },
     )?)
 }
 

--- a/packages/andromeda-fungible-tokens/Cargo.toml
+++ b/packages/andromeda-fungible-tokens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fungible-tokens"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "Utility methods and message definitions for the Andromeda Fungible Tokens Contracts"

--- a/packages/andromeda-fungible-tokens/src/cw20.rs
+++ b/packages/andromeda-fungible-tokens/src/cw20.rs
@@ -42,7 +42,9 @@ pub enum ExecuteMsg {
         amount: Uint128,
     },
     /// Burn is a base message to destroy tokens forever
-    Burn { amount: Uint128 },
+    Burn {
+        amount: Uint128,
+    },
     /// Send is a base message to transfer tokens to a contract and trigger an action
     /// on the receiving contract.
     Send {
@@ -82,10 +84,16 @@ pub enum ExecuteMsg {
         msg: Binary,
     },
     /// Only with "approval" extension. Destroys tokens forever
-    BurnFrom { owner: String, amount: Uint128 },
+    BurnFrom {
+        owner: String,
+        amount: Uint128,
+    },
     /// Only with the "mintable" extension. If authorized, creates amount new tokens
     /// and adds to the recipient balance.
-    Mint { recipient: String, amount: Uint128 },
+    Mint {
+        recipient: String,
+        amount: Uint128,
+    },
     /// Only with the "marketing" extension. If authorized, updates marketing metadata.
     /// Setting None/null for any of these will leave it unchanged.
     /// Setting Some("") will clear this field on the contract storage
@@ -99,6 +107,9 @@ pub enum ExecuteMsg {
     },
     /// If set as the "marketing" role on the contract, upload a new URL, SVG, or PNG for the token
     UploadLogo(Logo),
+    UpdateMinter {
+        new_minter: Option<AndrAddr>,
+    },
 }
 
 impl From<ExecuteMsg> for Cw20ExecuteMsg {
@@ -168,6 +179,9 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
                 marketing,
             },
             ExecuteMsg::UploadLogo(logo) => Cw20ExecuteMsg::UploadLogo(logo),
+            ExecuteMsg::UpdateMinter { new_minter } => Cw20ExecuteMsg::UpdateMinter {
+                new_minter: new_minter.map(|minter| minter.to_string()),
+            },
             _ => panic!("Unsupported message"),
         }
     }


### PR DESCRIPTION
# Motivation
The update minter message was missing. 

# Implementation
```rust
UpdateMinter {
        new_minter: Option<AndrAddr>,
    },
```

# Testing
None

# Version Changes
- `cw20`: `2.1.1-b.2` -> `2.1.1-b.3`
- `andromeda-fungible-tokens`: `1.0.0` -> `1.0.1`

# Checklist

- [x] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
