### PR TITLE
refactor: Optional Recipients List in Splitter

### DIFF
--- a/contracts/finance/andromeda-fixed-amount-splitter/src/interface.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/interface.rs
@@ -29,7 +29,7 @@ macro_rules! fixed_amount_splitter_instantiate {
     // Multiple recipients with array syntax
     ($env:expr, [$(($recipient:expr, $denom:expr, $amount:expr)),*]) => {
         &andromeda_finance::fixed_amount_splitter::InstantiateMsg {
-            recipients: vec![
+            recipients: Some(vec![
                 $(
                     andromeda_finance::fixed_amount_splitter::AddressAmount {
                         recipient: Recipient {
@@ -43,7 +43,7 @@ macro_rules! fixed_amount_splitter_instantiate {
                         }],
                     }
                 ),*
-            ],
+            ]),
             default_recipient: None,
             lock_time: None,
             kernel_address: $env.kernel.address().unwrap().into_string(),

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/mock.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/mock.rs
@@ -20,7 +20,7 @@ impl MockFixedAmountSplitter {
         app: &mut MockApp,
         code_id: u64,
         sender: Addr,
-        recipients: Vec<AddressAmount>,
+        recipients: Option<Vec<AddressAmount>>,
         kernel_address: impl Into<String>,
         lock_time: Option<Expiry>,
         owner: Option<String>,
@@ -55,7 +55,7 @@ impl MockFixedAmountSplitter {
         app: &mut MockApp,
         sender: Addr,
         funds: &[Coin],
-        recipients: Vec<AddressAmount>,
+        recipients: Option<Vec<AddressAmount>>,
     ) -> ExecuteResult {
         let msg = mock_fixed_amount_splitter_update_recipients_msg(recipients);
 
@@ -69,7 +69,7 @@ pub fn mock_andromeda_fixed_amount_splitter() -> Box<dyn Contract<Empty>> {
 }
 
 pub fn mock_fixed_amount_splitter_instantiate_msg(
-    recipients: Vec<AddressAmount>,
+    recipients: Option<Vec<AddressAmount>>,
     kernel_address: impl Into<String>,
     lock_time: Option<Expiry>,
     owner: Option<String>,
@@ -89,7 +89,7 @@ pub fn mock_fixed_amount_splitter_send_msg(config: Option<Vec<AddressAmount>>) -
 }
 
 pub fn mock_fixed_amount_splitter_update_recipients_msg(
-    recipients: Vec<AddressAmount>,
+    recipients: Option<Vec<AddressAmount>>,
 ) -> ExecuteMsg {
     ExecuteMsg::UpdateRecipients { recipients }
 }

--- a/contracts/finance/andromeda-fixed-amount-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-fixed-amount-splitter/src/testing/tests.rs
@@ -34,7 +34,7 @@ fn init(deps: &mut TestDeps) -> Response {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
-        recipients: mock_recipient,
+        recipients: Some(mock_recipient),
         lock_time: Some(Expiry::AtTime(Milliseconds::from_seconds(100_000))),
         default_recipient: None,
     };
@@ -121,7 +121,7 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: duplicate_recipients,
+        recipients: Some(duplicate_recipients),
     };
 
     let owner = deps.api.addr_make(OWNER);
@@ -141,7 +141,7 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipients.clone(),
+        recipients: Some(recipients.clone()),
     };
     let incorrect_owner = deps.api.addr_make("incorrect_owner");
     let info = message_info(&incorrect_owner, &[]);

--- a/contracts/finance/andromeda-splitter/src/mock.rs
+++ b/contracts/finance/andromeda-splitter/src/mock.rs
@@ -18,7 +18,7 @@ impl MockSplitter {
         app: &mut MockApp,
         code_id: u64,
         sender: Addr,
-        recipients: Vec<AddressPercent>,
+        recipients: Option<Vec<AddressPercent>>,
         kernel_address: impl Into<String>,
         lock_time: Option<Expiry>,
         owner: Option<String>,
@@ -53,7 +53,7 @@ impl MockSplitter {
         app: &mut MockApp,
         sender: Addr,
         funds: &[Coin],
-        recipients: Vec<AddressPercent>,
+        recipients: Option<Vec<AddressPercent>>,
     ) -> ExecuteResult {
         let msg = mock_splitter_update_recipients_msg(recipients);
 
@@ -67,7 +67,7 @@ pub fn mock_andromeda_splitter() -> Box<dyn Contract<Empty>> {
 }
 
 pub fn mock_splitter_instantiate_msg(
-    recipients: Vec<AddressPercent>,
+    recipients: Option<Vec<AddressPercent>>,
     kernel_address: impl Into<String>,
     lock_time: Option<Expiry>,
     owner: Option<String>,
@@ -86,6 +86,6 @@ pub fn mock_splitter_send_msg(config: Option<Vec<AddressPercent>>) -> ExecuteMsg
     ExecuteMsg::Send { config }
 }
 
-pub fn mock_splitter_update_recipients_msg(recipients: Vec<AddressPercent>) -> ExecuteMsg {
+pub fn mock_splitter_update_recipients_msg(recipients: Option<Vec<AddressPercent>>) -> ExecuteMsg {
     ExecuteMsg::UpdateRecipients { recipients }
 }

--- a/contracts/finance/andromeda-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-splitter/src/testing/tests.rs
@@ -34,7 +34,7 @@ fn init(deps: &mut TestDeps) -> Response {
     let msg = InstantiateMsg {
         owner: Some(OWNER.to_string()),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
-        recipients: mock_recipient,
+        recipients: Some(mock_recipient),
         lock_time: Some(Expiry::FromNow(Milliseconds(86400000))),
         default_recipient: None,
     };
@@ -69,7 +69,7 @@ fn test_different_lock_times() {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: kernel_address.to_string(),
-        recipients: vec![],
+        recipients: Some(vec![]),
         lock_time: Some(lock_time),
         default_recipient: None,
     };
@@ -86,7 +86,7 @@ fn test_different_lock_times() {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: kernel_address.to_string(),
-        recipients: vec![],
+        recipients: Some(vec![]),
         lock_time: Some(lock_time),
         default_recipient: None,
     };
@@ -102,10 +102,10 @@ fn test_different_lock_times() {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: kernel_address.to_string(),
-        recipients: vec![AddressPercent {
+        recipients: Some(vec![AddressPercent {
             recipient: Recipient::from_string(some_address.to_string()),
             percent: Decimal::percent(100),
-        }],
+        }]),
         lock_time: Some(lock_time),
         default_recipient: None,
     };
@@ -121,7 +121,7 @@ fn test_different_lock_times() {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: kernel_address.to_string(),
-        recipients: vec![],
+        recipients: Some(vec![]),
         lock_time: Some(lock_time),
         default_recipient: None,
     };
@@ -136,7 +136,7 @@ fn test_different_lock_times() {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: kernel_address.to_string(),
-        recipients: vec![],
+        recipients: Some(vec![]),
         lock_time: Some(lock_time),
         default_recipient: None,
     };
@@ -151,10 +151,10 @@ fn test_different_lock_times() {
     let msg = InstantiateMsg {
         owner: Some(owner.to_string()),
         kernel_address: kernel_address.to_string(),
-        recipients: vec![AddressPercent {
+        recipients: Some(vec![AddressPercent {
             recipient: Recipient::from_string(some_address),
             percent: Decimal::percent(100),
-        }],
+        }]),
         lock_time: Some(lock_time),
         default_recipient: None,
     };
@@ -234,7 +234,7 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: duplicate_recipients,
+        recipients: Some(duplicate_recipients),
     };
 
     let info = message_info(&Addr::unchecked(OWNER), &[]);
@@ -254,7 +254,7 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipients.clone(),
+        recipients: Some(recipients.clone()),
     };
 
     let incorrect_owner = deps.api.addr_make("incorrect_owner");

--- a/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/src/testing/tests.rs
@@ -31,7 +31,7 @@ fn init(deps: &mut TestDeps) -> Response {
     let msg = InstantiateMsg {
         owner: Some(OWNER.to_owned()),
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
-        recipients: mock_recipient,
+        recipients: Some(mock_recipient),
         lock_time: Some(Expiry::FromNow(Milliseconds(86400000))),
         default_recipient: None,
     };
@@ -46,7 +46,7 @@ fn test_update_app_contract() {
     let recipient1 = deps.api.addr_make("recipient1");
     let recipient2 = deps.api.addr_make("recipient2");
     let msg = InstantiateMsg {
-        recipients: vec![
+        recipients: Some(vec![
             AddressWeight {
                 recipient: Recipient::new(recipient1, None),
                 weight: Uint128::new(50),
@@ -55,7 +55,7 @@ fn test_update_app_contract() {
                 recipient: Recipient::new(recipient2, None),
                 weight: Uint128::new(50),
             },
-        ],
+        ]),
         lock_time: None,
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,
@@ -123,10 +123,10 @@ fn test_instantiate() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
     let recipient1 = deps.api.addr_make("recipient1");
     let msg = InstantiateMsg {
-        recipients: vec![AddressWeight {
+        recipients: Some(vec![AddressWeight {
             recipient: Recipient::from_string(recipient1.to_string()),
             weight: Uint128::new(1),
-        }],
+        }]),
 
         lock_time: None,
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
@@ -421,7 +421,7 @@ fn test_execute_remove_recipient() {
     let info = message_info(&owner, &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -517,7 +517,7 @@ fn test_execute_remove_recipient_not_on_list() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -583,7 +583,7 @@ fn test_execute_remove_recipient_contract_locked() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient.clone(),
@@ -635,7 +635,7 @@ fn test_execute_remove_recipient_unauthorized() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient,
+        recipients: Some(recipient),
     };
 
     let deps_mut = deps.as_mut();
@@ -685,7 +685,7 @@ fn test_update_recipient_weight() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
 
     let deps_mut = deps.as_mut();
@@ -714,7 +714,7 @@ fn test_update_recipient_weight() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient.clone(),
@@ -812,7 +812,7 @@ fn test_update_recipient_weight_locked_contract() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let current_time = env.block.time.seconds();
     let splitter = Splitter {
@@ -866,7 +866,7 @@ fn test_update_recipient_weight_user_not_found() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
 
     let deps_mut = deps.as_mut();
@@ -895,7 +895,7 @@ fn test_update_recipient_weight_user_not_found() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -942,7 +942,7 @@ fn test_update_recipient_weight_invalid_weight() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
 
     let deps_mut = deps.as_mut();
@@ -971,7 +971,7 @@ fn test_update_recipient_weight_invalid_weight() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -1036,7 +1036,7 @@ fn test_execute_add_recipient() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -1145,7 +1145,7 @@ fn test_execute_add_recipient_duplicate_recipient() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -1227,7 +1227,7 @@ fn test_execute_add_recipient_invalid_weight() {
     let info = message_info(&Addr::unchecked(OWNER), &[]);
 
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let splitter = Splitter {
         recipients: recipient,
@@ -1276,7 +1276,7 @@ fn test_execute_add_recipient_locked_contract() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
 
     let deps_mut = deps.as_mut();
@@ -1336,7 +1336,7 @@ fn test_execute_add_recipient_unauthorized() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient,
+        recipients: Some(recipient),
     };
 
     let deps_mut = deps.as_mut();
@@ -1407,7 +1407,7 @@ fn test_execute_update_recipients() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient.clone(),
+        recipients: Some(recipient.clone()),
     };
     let info = message_info(&Addr::unchecked(OWNER), &[]);
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
@@ -1439,7 +1439,7 @@ fn test_execute_update_recipients_invalid_weight() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient,
+        recipients: Some(recipient),
     };
 
     let splitter = Splitter {
@@ -1493,7 +1493,7 @@ fn test_execute_update_recipients_contract_locked() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient,
+        recipients: Some(recipient),
     };
 
     let current_time = env.block.time.seconds();
@@ -1549,7 +1549,7 @@ fn test_execute_update_recipients_unauthorized() {
         },
     ];
     let msg = ExecuteMsg::UpdateRecipients {
-        recipients: recipient,
+        recipients: Some(recipient),
     };
 
     let splitter = Splitter {
@@ -1710,7 +1710,7 @@ fn locked_splitter() -> (
     let addr2 = deps.api.addr_make("addr2");
     // Call instantiate with the recipients
     let msg = InstantiateMsg {
-        recipients: vec![
+        recipients: Some(vec![
             AddressWeight {
                 recipient: Recipient::from_string(addr1.to_string()),
                 weight: Uint128::new(40), // 40% weight
@@ -1719,7 +1719,7 @@ fn locked_splitter() -> (
                 recipient: Recipient::from_string(addr2.to_string()),
                 weight: Uint128::new(60), // 60% weight
             },
-        ],
+        ]),
         lock_time: Some(Expiry::AtTime(Milliseconds::from_seconds(
             lock_time.seconds(),
         ))),
@@ -1749,7 +1749,7 @@ fn unlocked_splitter() -> (
     let addr2 = deps.api.addr_make("addr2");
     // Call instantiate with the recipients
     let msg = InstantiateMsg {
-        recipients: vec![
+        recipients: Some(vec![
             AddressWeight {
                 recipient: Recipient::from_string(addr1.to_string()),
                 weight: Uint128::new(40), // 40% weight
@@ -1758,7 +1758,7 @@ fn unlocked_splitter() -> (
                 recipient: Recipient::from_string(addr2.to_string()),
                 weight: Uint128::new(60), // 60% weight
             },
-        ],
+        ]),
         lock_time: None,
         kernel_address: MOCK_KERNEL_CONTRACT.to_string(),
         owner: None,

--- a/packages/andromeda-finance/src/weighted_splitter.rs
+++ b/packages/andromeda-finance/src/weighted_splitter.rs
@@ -28,7 +28,7 @@ pub struct Splitter {
 pub struct InstantiateMsg {
     /// The vector of recipients for the contract. Anytime a `Send` execute message is
     /// sent the amount sent will be divided amongst these recipients depending on their assigned weight.
-    pub recipients: Vec<AddressWeight>,
+    pub recipients: Option<Vec<AddressWeight>>,
     pub lock_time: Option<Expiry>,
     pub default_recipient: Option<Recipient>,
 }
@@ -38,7 +38,9 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     /// Update the recipients list. Only executable by the contract owner when the contract is not locked.
     #[attrs(restricted, nonpayable, direct)]
-    UpdateRecipients { recipients: Vec<AddressWeight> },
+    UpdateRecipients {
+        recipients: Option<Vec<AddressWeight>>,
+    },
     /// Update a specific recipient's weight. Only executable by the contract owner when the contract is not locked.
     #[attrs(restricted, nonpayable, direct)]
     UpdateRecipientWeight { recipient: AddressWeight },

--- a/tests/auction_app.rs
+++ b/tests/auction_app.rs
@@ -81,7 +81,7 @@ fn test_auction_app_modules() {
     );
 
     let splitter_init_msg = mock_splitter_instantiate_msg(
-        vec![
+        Some(vec![
             AddressPercent {
                 recipient: Recipient::new(recipient_one, None),
                 percent: Decimal::percent(50),
@@ -90,7 +90,7 @@ fn test_auction_app_modules() {
                 recipient: Recipient::new(recipient_two, None),
                 percent: Decimal::percent(50),
             },
-        ],
+        ]),
         andr.kernel.addr().to_string(),
         None,
         None,
@@ -306,7 +306,7 @@ fn test_auction_app_recipient() {
     );
 
     let splitter_init_msg = mock_splitter_instantiate_msg(
-        vec![
+        Some(vec![
             AddressPercent::new(
                 Recipient::from_string(format!("{recipient_one}")),
                 Decimal::from_ratio(1u8, 2u8),
@@ -315,7 +315,7 @@ fn test_auction_app_recipient() {
                 Recipient::from_string(format!("{recipient_two}")),
                 Decimal::from_ratio(1u8, 2u8),
             ),
-        ],
+        ]),
         andr.kernel.addr(),
         None,
         None,

--- a/tests/crowdfund_app.rs
+++ b/tests/crowdfund_app.rs
@@ -97,7 +97,7 @@ fn setup(
         },
     ];
     let splitter_init_msg = mock_splitter_instantiate_msg(
-        splitter_recipients,
+        Some(splitter_recipients),
         andr.kernel.addr().clone(),
         None,
         None,

--- a/tests/e2e/tests/crowdfund.rs
+++ b/tests/e2e/tests/crowdfund.rs
@@ -159,7 +159,7 @@ fn setup(
 
     let kernel_address = mock_andromeda.kernel_contract.addr_str().unwrap();
     let splitter_init_msg = splitter::InstantiateMsg {
-        recipients,
+        recipients: Some(recipients),
         lock_time: None,
         kernel_address: kernel_address.clone(),
         owner: None,

--- a/tests/e2e/tests/socket_astroport.rs
+++ b/tests/e2e/tests/socket_astroport.rs
@@ -93,7 +93,7 @@ fn setup(
         },
     ];
     let splitter_init_msg = andromeda_finance::splitter::InstantiateMsg {
-        recipients,
+        recipients: Some(recipients),
         default_recipient: None,
         lock_time: None,
         kernel_address: kernel_address.to_string(),

--- a/tests/e2e/tests/socket_osmosis.rs
+++ b/tests/e2e/tests/socket_osmosis.rs
@@ -84,7 +84,7 @@ fn setup(
         },
     ];
     let splitter_init_msg = andromeda_finance::splitter::InstantiateMsg {
-        recipients,
+        recipients: Some(recipients),
         default_recipient: None,
         lock_time: None,
         kernel_address: kernel_address.to_string(),

--- a/tests/fixed_amount_splitter.rs
+++ b/tests/fixed_amount_splitter.rs
@@ -78,7 +78,7 @@ fn setup(
         },
     ];
     let splitter_init_msg = mock_fixed_amount_splitter_instantiate_msg(
-        splitter_recipients,
+        Some(splitter_recipients),
         andr.kernel.addr().clone(),
         None,
         None,
@@ -150,7 +150,7 @@ fn setup(
         ];
 
         splitter
-            .execute_update_recipients(&mut router, owner.clone(), &[], splitter_recipients)
+            .execute_update_recipients(&mut router, owner.clone(), &[], Some(splitter_recipients))
             .unwrap();
     }
     TestCase {

--- a/tests/ibc-tests/fixed_amount_splitter_ibc.rs
+++ b/tests/ibc-tests/fixed_amount_splitter_ibc.rs
@@ -41,17 +41,19 @@ fn test_fixed_amount_splitter_ibc() {
     splitter_osmosis
         .instantiate(
             &andromeda_finance::fixed_amount_splitter::InstantiateMsg {
-                recipients: vec![andromeda_finance::fixed_amount_splitter::AddressAmount {
-                    recipient: Recipient {
-                        address: AndrAddr::from_string(recipient.clone()),
-                        msg: None,
-                        ibc_recovery_address: None,
+                recipients: Some(vec![
+                    andromeda_finance::fixed_amount_splitter::AddressAmount {
+                        recipient: Recipient {
+                            address: AndrAddr::from_string(recipient.clone()),
+                            msg: None,
+                            ibc_recovery_address: None,
+                        },
+                        coins: vec![Coin {
+                            denom: expected_denom.clone(),
+                            amount: Uint128::new(100),
+                        }],
                     },
-                    coins: vec![Coin {
-                        denom: expected_denom.clone(),
-                        amount: Uint128::new(100),
-                    }],
-                }],
+                ]),
                 default_recipient: None,
                 lock_time: None,
                 kernel_address: osmosis.aos.kernel.address().unwrap().into_string(),

--- a/tests/ibc-tests/interchain.rs
+++ b/tests/ibc-tests/interchain.rs
@@ -220,14 +220,14 @@ fn test_kernel_ibc_funds_and_execute_msg() {
     splitter_osmosis
         .instantiate(
             &andromeda_finance::splitter::InstantiateMsg {
-                recipients: vec![andromeda_finance::splitter::AddressPercent {
+                recipients: Some(vec![andromeda_finance::splitter::AddressPercent {
                     recipient: Recipient {
                         address: AndrAddr::from_string(recipient.to_string()),
                         msg: None,
                         ibc_recovery_address: None,
                     },
                     percent: Decimal::one(),
-                }],
+                }]),
                 default_recipient: None,
                 lock_time: None,
                 kernel_address: osmosis.aos.kernel.address().unwrap().into_string(),

--- a/tests/ibc-tests/splitter_ibc.rs
+++ b/tests/ibc-tests/splitter_ibc.rs
@@ -60,7 +60,7 @@ fn run_splitter_test_on_multiple_combos(#[case] chain1_name: &str, #[case] chain
     let deployed_contract = deploy_splitter!(
         contract,
         &InstantiateMsg {
-            recipients: vec![
+            recipients: Some(vec![
                 AddressPercent {
                     recipient: Recipient {
                         address: AndrAddr::from_string(recipient1.clone()),
@@ -77,7 +77,7 @@ fn run_splitter_test_on_multiple_combos(#[case] chain1_name: &str, #[case] chain
                     },
                     percent: Decimal::percent(40),
                 },
-            ],
+            ]),
             kernel_address: chain1.aos.kernel.address().unwrap().into_string(),
             owner: None,
             lock_time: None,
@@ -200,7 +200,7 @@ fn test_splitter_ibc_update_recipients() {
     splitter_osmosis
         .instantiate(
             &InstantiateMsg {
-                recipients: vec![
+                recipients: Some(vec![
                     AddressPercent {
                         recipient: Recipient {
                             address: AndrAddr::from_string(&recipient1),
@@ -217,7 +217,7 @@ fn test_splitter_ibc_update_recipients() {
                         },
                         percent: Decimal::percent(40),
                     },
-                ],
+                ]),
                 kernel_address: osmosis.aos.kernel.address().unwrap().into_string(),
                 owner: None,
                 lock_time: None,
@@ -273,7 +273,9 @@ fn test_splitter_ibc_update_recipients() {
                         splitter_osmosis.address().unwrap()
                     )),
                     message: to_json_binary(
-                        &andromeda_splitter::mock::mock_splitter_update_recipients_msg(recipients),
+                        &andromeda_splitter::mock::mock_splitter_update_recipients_msg(Some(
+                            recipients,
+                        )),
                     )
                     .unwrap(),
                     funds: vec![],

--- a/tests/kernel.rs
+++ b/tests/kernel.rs
@@ -48,10 +48,10 @@ fn kernel() {
     let user1 = andr.get_wallet("user1");
 
     let splitter_msg = mock_splitter_instantiate_msg(
-        vec![AddressPercent::new(
+        Some(vec![AddressPercent::new(
             Recipient::from_string(user1.to_string()).with_ibc_recovery(owner.clone()),
             Decimal::one(),
-        )],
+        )]),
         andr.kernel.addr().clone(),
         None,
         None,

--- a/tests/kernel_orch.rs
+++ b/tests/kernel_orch.rs
@@ -2049,14 +2049,14 @@ fn test_kernel_ibc_funds_and_execute_msg() {
     splitter_osmosis
         .instantiate(
             &SplitterInstantiateMsg {
-                recipients: vec![AddressPercent {
+                recipients: Some(vec![AddressPercent {
                     recipient: Recipient {
                         address: AndrAddr::from_string(recipient),
                         msg: None,
                         ibc_recovery_address: None,
                     },
                     percent: Decimal::one(),
-                }],
+                }]),
                 lock_time: None,
                 kernel_address: kernel_osmosis.address().unwrap().into_string(),
                 owner: None,
@@ -2659,14 +2659,14 @@ fn test_kernel_ibc_funds_and_execute_msg_unhappy() {
     splitter_osmosis
         .instantiate(
             &SplitterInstantiateMsg {
-                recipients: vec![AddressPercent {
+                recipients: Some(vec![AddressPercent {
                     recipient: Recipient {
                         address: AndrAddr::from_string(recipient),
                         msg: None,
                         ibc_recovery_address: None,
                     },
                     percent: Decimal::one(),
-                }],
+                }]),
                 lock_time: None,
                 kernel_address: kernel_osmosis.address().unwrap().into_string(),
                 owner: None,

--- a/tests/marketplace_app.rs
+++ b/tests/marketplace_app.rs
@@ -324,10 +324,10 @@ fn test_marketplace_app_recipient() {
     );
 
     let splitter_init_msg = mock_splitter_instantiate_msg(
-        vec![AddressPercent::new(
+        Some(vec![AddressPercent::new(
             Recipient::from_string(receiver),
             Decimal::one(),
-        )],
+        )]),
         andr.kernel.addr(),
         None,
         None,

--- a/tests/set_amount_splitter.rs
+++ b/tests/set_amount_splitter.rs
@@ -78,7 +78,7 @@ fn setup(
         },
     ];
     let splitter_init_msg = mock_fixed_amount_splitter_instantiate_msg(
-        splitter_recipients,
+        Some(splitter_recipients),
         andr.kernel.addr().clone(),
         None,
         None,
@@ -150,7 +150,7 @@ fn setup(
         ];
 
         splitter
-            .execute_update_recipients(&mut router, owner.clone(), &[], splitter_recipients)
+            .execute_update_recipients(&mut router, owner.clone(), &[], Some(splitter_recipients))
             .unwrap();
     }
     TestCase {

--- a/tests/splitter.rs
+++ b/tests/splitter.rs
@@ -84,7 +84,7 @@ fn setup(
         },
     ];
     let splitter_init_msg = mock_splitter_instantiate_msg(
-        splitter_recipients,
+        Some(splitter_recipients),
         andr.kernel.addr().clone(),
         None,
         None,
@@ -204,7 +204,7 @@ fn test_successful_fixed_amount_splitter_with_remainder_native(setup: TestCase) 
     ];
 
     splitter
-        .execute_update_recipients(&mut router, owner.clone(), &[], splitter_recipients)
+        .execute_update_recipients(&mut router, owner.clone(), &[], Some(splitter_recipients))
         .unwrap();
 
     splitter
@@ -290,7 +290,7 @@ fn test_successful_fixed_amount_splitter_cw20_with_remainder(setup: TestCase) {
     ];
 
     splitter
-        .execute_update_recipients(&mut router, owner.clone(), &[], splitter_recipients)
+        .execute_update_recipients(&mut router, owner.clone(), &[], Some(splitter_recipients))
         .unwrap();
 
     let hook_msg = Cw20HookMsg::Send { config: None };
@@ -348,7 +348,7 @@ fn test_splitter_cross_chain_recipient() {
     splitter_juno
         .instantiate(
             &andromeda_finance::splitter::InstantiateMsg {
-                recipients: vec![
+                recipients: Some(vec![
                     andromeda_finance::splitter::AddressPercent {
                         recipient: Recipient {
                             address: AndrAddr::from_string(format!("ibc://osmosis/{}", recipient)),
@@ -368,7 +368,7 @@ fn test_splitter_cross_chain_recipient() {
                         },
                         percent: Decimal::from_ratio(Uint128::from(1u128), Uint128::from(2u128)),
                     },
-                ],
+                ]),
                 lock_time: None,
                 kernel_address: juno.aos.kernel.address().unwrap().into_string(),
                 owner: None,

--- a/tests/timelock.rs
+++ b/tests/timelock.rs
@@ -43,10 +43,10 @@ fn test_timelock() {
     );
 
     let splitter_init_msg = mock_splitter_instantiate_msg(
-        vec![AddressPercent {
+        Some(vec![AddressPercent {
             recipient: Recipient::new(recipient, None),
             percent: Decimal::percent(100),
-        }],
+        }]),
         andr.kernel.addr().to_string(),
         None,
         None,


### PR DESCRIPTION
# Motivation
Some splitter builds exclusively use the optional Config when sending funds, making instantiating the contract with a recipients list unnecessary and confusing. This was brought to my attention by @daniel-wehbe 

# Implementation
- Make the recipients list optional, if it's empty an empty vector is saved in state
- If there's no config sent, and the recipients list is empty, the appropriate error is returned

# Testing
No tests were impacted. 

# Version Changes
- `splitter`: `x.x.x-b.x` -> `x.x.x-b.y`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
