### PR TITLE
fix: remove auth check in start redeem & sale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-exchange"
-version = "3.0.0-b.4"
+version = "3.0.0-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",

--- a/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-exchange"
-version = "3.0.0-b.4"
+version = "3.0.0-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 [lib]

--- a/contracts/fungible-tokens/andromeda-exchange/src/execute_redeem.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/execute_redeem.rs
@@ -46,10 +46,6 @@ pub fn execute_start_redeem(
         !derived_exchange_rate.is_zero(),
         ContractError::InvalidZeroAmount {}
     );
-    ensure!(
-        ctx.contract.is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
 
     let (start_time, end_time) = schedule.validate(&env.block)?;
     // Do not allow duplicate redeems

--- a/contracts/fungible-tokens/andromeda-exchange/src/execute_sale.rs
+++ b/contracts/fungible-tokens/andromeda-exchange/src/execute_sale.rs
@@ -44,10 +44,6 @@ pub fn execute_start_sale(
         !exchange_rate.is_zero(),
         ContractError::InvalidZeroAmount {}
     );
-    ensure!(
-        ctx.contract.is_contract_owner(deps.storage, &sender)?,
-        ContractError::Unauthorized {}
-    );
     // Message sender in this case should be the token address
     ensure!(
         info.sender == token_addr.get_raw_address(&deps.as_ref())?,


### PR DESCRIPTION
# Motivation
Only the contract owner was allowed to start a redeem. 

# Implementation
- Removed the check that enforced the owner to start the redeem. 

# Testing
No tests were impacted 

# Version Changes
- `exchange`: `x.x.x-b.4` -> `x.x.x-b.5`

# Checklist

- [x] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
