### PR TITLE
fix: bump version for all ado after permission update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.1.1-b.2"
+version = "2.1.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-adodb"
-version = "1.1.5"
+version = "1.1.6-b.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.2.1-b.2"
+version = "1.2.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.2.6-b.4"
+version = "2.2.6-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-boolean"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.3.1-b.2"
+version = "1.3.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-counter"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.2.1-b.5"
+version = "2.2.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-curve"
-version = "0.2.1-b.2"
+version = "0.2.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-staking"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.2.0-b.10"
+version = "2.2.0-b.11"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-date-time"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-distance"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.2.2"
+version = "1.2.3-b.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-exchange"
-version = "3.0.0-b.5"
+version = "3.0.0-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.1-b.3"
+version = "1.2.1-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-multisig"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-accounts",
  "andromeda-app",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-form"
-version = "0.1.0-a.2"
+version = "0.1.0-a.3"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-modules",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-graph"
-version = "0.1.1-b.2"
+version = "0.1.1-b.3"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-ibc-registry"
-version = "1.1.2"
+version = "1.1.3-b.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.4"
+version = "1.2.5-b.1"
 dependencies = [
  "andromeda-std",
  "base64 0.22.1",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-lockdrop"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-marketplace"
-version = "2.3.1-b.4"
+version = "2.3.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-matrix"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-merkle-airdrop"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-osmosis-token-factory"
-version = "0.1.1-b.2"
+version = "0.1.1-b.3"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-point"
-version = "0.1.1-b.2"
+version = "0.1.1-b.3"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-primitive"
-version = "2.1.1-b.1"
+version = "2.1.1-b.2"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rates"
-version = "2.0.5-b.3"
+version = "2.0.5-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-schema"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-app",
  "andromeda-cw-json",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-shunting"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-app",
  "andromeda-cw-json",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket-astroport"
-version = "0.1.8-b.4"
+version = "0.1.8-b.5"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket-osmosis"
-version = "0.1.2-b.3"
+version = "0.1.2-b.4"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.3.1-b.3"
+version = "2.3.1-b.4"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.1-b.8"
+version = "1.5.1-b.9"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema 2.2.2",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-string-storage"
-version = "0.1.0-a.2"
+version = "0.1.0-a.3"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-time-gate"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "1.1.1-b.4"
+version = "1.1.1-b.5"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.1.1-b.2"
+version = "3.1.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.2.3"
+version = "1.2.4-b.1"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.1-b.2"
+version = "2.1.1-b.3"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/contracts/accounts/andromeda-fixed-multisig/Cargo.toml
+++ b/contracts/accounts/andromeda-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-multisig"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.2.1-b.2"
+version = "1.2.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/data-storage/andromeda-boolean/Cargo.toml
+++ b/contracts/data-storage/andromeda-boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-boolean"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/data-storage/andromeda-form/Cargo.toml
+++ b/contracts/data-storage/andromeda-form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-form"
-version = "0.1.0-a.2"
+version = "0.1.0-a.3"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-primitive"
-version = "2.1.1-b.1"
+version = "2.1.1-b.2"
 authors = [
   "Connor Barr <crnbarr@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/data-storage/andromeda-string-storage/Cargo.toml
+++ b/contracts/data-storage/andromeda-string-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-string-storage"
-version = "0.1.0-a.2"
+version = "0.1.0-a.3"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.3.1-b.2"
+version = "1.3.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.1-b.3"
+version = "1.2.1-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.3.1-b.3"
+version = "2.3.1-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "1.1.1-b.4"
+version = "1.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.1.1-b.2"
+version = "3.1.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.1-b.2"
+version = "2.1.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-staking"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-exchange"
-version = "3.0.0-b.5"
+version = "3.0.0-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 [lib]

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-lockdrop"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-merkle-airdrop"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-counter/Cargo.toml
+++ b/contracts/math/andromeda-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-counter"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/math/andromeda-curve/Cargo.toml
+++ b/contracts/math/andromeda-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-curve"
-version = "0.2.1-b.2"
+version = "0.2.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-date-time/Cargo.toml
+++ b/contracts/math/andromeda-date-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-date-time"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-distance/Cargo.toml
+++ b/contracts/math/andromeda-distance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-distance"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-graph/Cargo.toml
+++ b/contracts/math/andromeda-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-graph"
-version = "0.1.1-b.2"
+version = "0.1.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-matrix/Cargo.toml
+++ b/contracts/math/andromeda-matrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-matrix"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-point/Cargo.toml
+++ b/contracts/math/andromeda-point/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-point"
-version = "0.1.1-b.2"
+version = "0.1.1-b.3"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/math/andromeda-shunting/Cargo.toml
+++ b/contracts/math/andromeda-shunting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-shunting"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 
 [lib]

--- a/contracts/math/andromeda-time-gate/Cargo.toml
+++ b/contracts/math/andromeda-time-gate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-time-gate"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.1.1-b.2"
+version = "2.1.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/modules/andromeda-rates/Cargo.toml
+++ b/contracts/modules/andromeda-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rates"
-version = "2.0.5-b.3"
+version = "2.0.5-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/modules/andromeda-schema/Cargo.toml
+++ b/contracts/modules/andromeda-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-schema"
-version = "0.1.0-a.3"
+version = "0.1.0-a.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.2.6-b.4"
+version = "2.2.6-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.2.1-b.5"
+version = "2.2.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.2.0-b.10"
+version = "2.2.0-b.11"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-marketplace"
-version = "2.3.1-b.4"
+version = "2.3.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/os/andromeda-adodb/Cargo.toml
+++ b/contracts/os/andromeda-adodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-adodb"
-version = "1.1.5"
+version = "1.1.6-b.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.2.2"
+version = "1.2.3-b.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/os/andromeda-ibc-registry/Cargo.toml
+++ b/contracts/os/andromeda-ibc-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-ibc-registry"
-version = "1.1.2"
+version = "1.1.3-b.1"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.4"
+version = "1.2.5-b.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.2.3"
+version = "1.2.4-b.1"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/socket/andromeda-osmosis-token-factory/Cargo.toml
+++ b/contracts/socket/andromeda-osmosis-token-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-osmosis-token-factory"
-version = "0.1.1-b.2"
+version = "0.1.1-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/socket/andromeda-socket-astroport/Cargo.toml
+++ b/contracts/socket/andromeda-socket-astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket-astroport"
-version = "0.1.8-b.4"
+version = "0.1.8-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/socket/andromeda-socket-osmosis/Cargo.toml
+++ b/contracts/socket/andromeda-socket-osmosis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket-osmosis"
-version = "0.1.2-b.3"
+version = "0.1.2-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/packages/andromeda-testing-e2e/Cargo.toml
+++ b/packages/andromeda-testing-e2e/Cargo.toml
@@ -21,18 +21,18 @@ cw20 = { workspace = true }
 anyhow = "1.0.98"
 
 andromeda-non-fungible-tokens = { workspace = true }
-andromeda-app = { version = "1.0.0", path = "../andromeda-app" }
-andromeda-modules = { version = "2.0.0", path = "../andromeda-modules" }
-andromeda-adodb = { version = "1.1.5", path = "../../contracts/os/andromeda-adodb", features = [
+andromeda-app = { path = "../andromeda-app" }
+andromeda-modules = {  path = "../andromeda-modules" }
+andromeda-adodb = {  path = "../../contracts/os/andromeda-adodb", features = [
     "testing",
 ] }
-andromeda-kernel = { version = "1.2.1-b.7", path = "../../contracts/os/andromeda-kernel", features = [
+andromeda-kernel = { path = "../../contracts/os/andromeda-kernel", features = [
     "testing",
 ] }
 andromeda-vfs = { path = "../../contracts/os/andromeda-vfs", features = [
     "testing",
 ] }
-andromeda-economics = { version = "1.2.1-b.1", path = "../../contracts/os/andromeda-economics", features = [
+andromeda-economics = { path = "../../contracts/os/andromeda-economics", features = [
     "testing",
     "library",
 ] }

--- a/packages/andromeda-testing/Cargo.toml
+++ b/packages/andromeda-testing/Cargo.toml
@@ -21,18 +21,18 @@ cw20 = { workspace = true }
 anyhow = "1.0.98"
 
 andromeda-non-fungible-tokens = { workspace = true }
-andromeda-app = { version = "1.0.0", path = "../andromeda-app" }
-andromeda-modules = { version = "2.0.0", path = "../andromeda-modules" }
-andromeda-adodb = { version = "1.1.5", path = "../../contracts/os/andromeda-adodb", features = [
+andromeda-app = { path = "../andromeda-app" }
+andromeda-modules = { path = "../andromeda-modules" }
+andromeda-adodb = { path = "../../contracts/os/andromeda-adodb", features = [
     "testing",
 ] }
-andromeda-kernel = { version = "1.2.1-b.7", path = "../../contracts/os/andromeda-kernel", features = [
+andromeda-kernel = { path = "../../contracts/os/andromeda-kernel", features = [
     "testing",
 ] }
 andromeda-vfs = { path = "../../contracts/os/andromeda-vfs", features = [
     "testing",
 ] }
-andromeda-economics = { version = "1.2.1-b.1", path = "../../contracts/os/andromeda-economics", features = [
+andromeda-economics = { path = "../../contracts/os/andromeda-economics", features = [
     "testing",
     "library",
 ] }

--- a/packages/deploy/Cargo.toml
+++ b/packages/deploy/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = "1.0"
 chrono = "0.4"
 
 # OS Contracts
-andromeda-kernel = { version = "1.2.1-b.7", path = "../../contracts/os/andromeda-kernel" }
-andromeda-adodb = { version = "1.1.5", path = "../../contracts/os/andromeda-adodb" }
+andromeda-kernel = { path = "../../contracts/os/andromeda-kernel" }
+andromeda-adodb = { path = "../../contracts/os/andromeda-adodb" }
 andromeda-vfs = { path = "../../contracts/os/andromeda-vfs" }
-andromeda-economics = { version = "1.2.1-b.1", path = "../../contracts/os/andromeda-economics" }
+andromeda-economics = { path = "../../contracts/os/andromeda-economics" }
 andromeda-ibc-registry = { path = "../../contracts/os/andromeda-ibc-registry" }
 
 # Finance Contracts
@@ -74,8 +74,8 @@ andromeda-graph = { path = "../../contracts/math/andromeda-graph" }
 andromeda-point = { path = "../../contracts/math/andromeda-point" }
 
 # Socket Contracts
-andromeda-socket-astroport = { path = "../../contracts/socket/andromeda-socket-astroport"}
-andromeda-socket-osmosis = { path = "../../contracts/socket/andromeda-socket-osmosis"}
+andromeda-socket-astroport = { path = "../../contracts/socket/andromeda-socket-astroport" }
+andromeda-socket-osmosis = { path = "../../contracts/socket/andromeda-socket-osmosis" }
 
 
 andromeda-std = { workspace = true }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.1-b.8"
+version = "1.5.1-b.9"
 edition = "2021"
 rust-version = "1.86.0"
 description = "The standard library for creating an Andromeda Digital Object"


### PR DESCRIPTION
# Motivation

Closes: #XXX (Link to Linear ticket)

State the reason or purpose behind this change.

# Implementation

Explain the details of the change.

Examples:

- Added validation checks for all inputs

# Testing

Was there any on-chain, or other types, of testing run with this change?

# Version Changes

Were there any required version changes?

Example:

- `kernel`: `x.x.x-b.x` -> `x.x.x-b.y`

# Checklist

- [ ] Versions bumped correctly and documented
- [ ] Changelog entry added or label applied
