### PR TITLE
fix: permission query discrepancies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-address-list"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-modules",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-adodb"
-version = "1.1.6-b.2"
+version = "1.1.6-b.3"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-app-contract"
-version = "1.2.1-b.4"
+version = "1.2.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-std",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-auction"
-version = "2.2.6-b.6"
+version = "2.2.6-b.7"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-boolean"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-conditional-splitter"
-version = "1.3.1-b.4"
+version = "1.3.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-counter"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-crowdfund"
-version = "2.2.1-b.7"
+version = "2.2.1-b.8"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-curve"
-version = "0.2.1-b.4"
+version = "0.2.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw20-staking"
-version = "2.1.1-b.6"
+version = "2.1.1-b.7"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-cw721"
-version = "2.2.0-b.12"
+version = "2.2.0-b.13"
 dependencies = [
  "andromeda-non-fungible-tokens",
  "andromeda-std",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-date-time"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-distance"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-economics"
-version = "1.2.3-b.2"
+version = "1.2.3-b.3"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-exchange"
-version = "3.0.0-b.7"
+version = "3.0.0-b.8"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.1-b.5"
+version = "1.2.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-fixed-multisig"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-accounts",
  "andromeda-app",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-form"
-version = "0.1.0-a.4"
+version = "0.1.0-a.5"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-modules",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-graph"
-version = "0.1.1-b.4"
+version = "0.1.1-b.5"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-ibc-registry"
-version = "1.1.3-b.2"
+version = "1.1.3-b.3"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-kernel"
-version = "1.2.5-b.2"
+version = "1.2.5-b.3"
 dependencies = [
  "andromeda-std",
  "base64 0.22.1",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-lockdrop"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-marketplace"
-version = "2.3.1-b.6"
+version = "2.3.1-b.7"
 dependencies = [
  "andromeda-app",
  "andromeda-non-fungible-tokens",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-matrix"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-merkle-airdrop"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-fungible-tokens",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-osmosis-token-factory"
-version = "0.1.1-b.4"
+version = "0.1.1-b.5"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-point"
-version = "0.1.1-b.4"
+version = "0.1.1-b.5"
 dependencies = [
  "andromeda-math",
  "andromeda-std",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-primitive"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-schema"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-app",
  "andromeda-cw-json",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-shunting"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-app",
  "andromeda-cw-json",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket-astroport"
-version = "0.1.8-b.6"
+version = "0.1.8-b.7"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-socket-osmosis"
-version = "0.1.2-b.5"
+version = "0.1.2-b.6"
 dependencies = [
  "andromeda-socket",
  "andromeda-std",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-splitter"
-version = "2.3.1-b.5"
+version = "2.3.1-b.6"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-std"
-version = "1.5.1-b.11"
+version = "1.5.1-b.12"
 dependencies = [
  "andromeda-macros",
  "cosmwasm-schema 2.2.2",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-string-storage"
-version = "0.1.0-a.4"
+version = "0.1.0-a.5"
 dependencies = [
  "andromeda-data-storage",
  "andromeda-std",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-time-gate"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 dependencies = [
  "andromeda-app",
  "andromeda-math",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-timelock"
-version = "2.1.1-b.6"
+version = "2.1.1-b.7"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-validator-staking"
-version = "1.1.1-b.6"
+version = "1.1.1-b.7"
 dependencies = [
  "andromeda-finance",
  "andromeda-std",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vesting"
-version = "3.1.1-b.4"
+version = "3.1.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-vfs"
-version = "1.2.4-b.2"
+version = "1.2.4-b.3"
 dependencies = [
  "andromeda-std",
  "cosmwasm-schema 2.2.2",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 dependencies = [
  "andromeda-app",
  "andromeda-finance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "andromeda-macros"
-version = "1.1.0-b.3"
+version = "1.1.0-b.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/accounts/andromeda-fixed-multisig/Cargo.toml
+++ b/contracts/accounts/andromeda-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-multisig"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/app/andromeda-app-contract/Cargo.toml
+++ b/contracts/app/andromeda-app-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-app-contract"
-version = "1.2.1-b.4"
+version = "1.2.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/data-storage/andromeda-boolean/Cargo.toml
+++ b/contracts/data-storage/andromeda-boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-boolean"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/data-storage/andromeda-form/Cargo.toml
+++ b/contracts/data-storage/andromeda-form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-form"
-version = "0.1.0-a.4"
+version = "0.1.0-a.5"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/data-storage/andromeda-primitive/Cargo.toml
+++ b/contracts/data-storage/andromeda-primitive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-primitive"
-version = "2.1.1-b.3"
+version = "2.1.1-b.4"
 authors = [
   "Connor Barr <crnbarr@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/data-storage/andromeda-string-storage/Cargo.toml
+++ b/contracts/data-storage/andromeda-string-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-string-storage"
-version = "0.1.0-a.4"
+version = "0.1.0-a.5"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/finance/andromeda-conditional-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-conditional-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-conditional-splitter"
-version = "1.3.1-b.4"
+version = "1.3.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-fixed-amount-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-fixed-amount-splitter"
-version = "1.2.1-b.5"
+version = "1.2.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
+++ b/contracts/finance/andromeda-rate-limiting-withdrawals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-rate-limiting-withdrawals"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-splitter"
-version = "2.3.1-b.5"
+version = "2.3.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-timelock/Cargo.toml
+++ b/contracts/finance/andromeda-timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-timelock"
-version = "2.1.1-b.6"
+version = "2.1.1-b.7"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-validator-staking/Cargo.toml
+++ b/contracts/finance/andromeda-validator-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-validator-staking"
-version = "1.1.1-b.6"
+version = "1.1.1-b.7"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-vesting/Cargo.toml
+++ b/contracts/finance/andromeda-vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vesting"
-version = "3.1.1-b.4"
+version = "3.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
+++ b/contracts/finance/andromeda-weighted-distribution-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-weighted-distribution-splitter"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20-staking"
-version = "2.1.1-b.6"
+version = "2.1.1-b.7"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw20"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-exchange/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-exchange"
-version = "3.0.0-b.7"
+version = "3.0.0-b.8"
 edition = "2021"
 rust-version = "1.86.0"
 [lib]

--- a/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-lockdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-lockdrop"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
+++ b/contracts/fungible-tokens/andromeda-merkle-airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-merkle-airdrop"
-version = "2.1.1-b.5"
+version = "2.1.1-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-counter/Cargo.toml
+++ b/contracts/math/andromeda-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-counter"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/math/andromeda-curve/Cargo.toml
+++ b/contracts/math/andromeda-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-curve"
-version = "0.2.1-b.4"
+version = "0.2.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-date-time/Cargo.toml
+++ b/contracts/math/andromeda-date-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-date-time"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-distance/Cargo.toml
+++ b/contracts/math/andromeda-distance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-distance"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-graph/Cargo.toml
+++ b/contracts/math/andromeda-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-graph"
-version = "0.1.1-b.4"
+version = "0.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-matrix/Cargo.toml
+++ b/contracts/math/andromeda-matrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-matrix"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/math/andromeda-point/Cargo.toml
+++ b/contracts/math/andromeda-point/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-point"
-version = "0.1.1-b.4"
+version = "0.1.1-b.5"
 authors = ["Mitar Djakovic <mdjakovic0920@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/math/andromeda-shunting/Cargo.toml
+++ b/contracts/math/andromeda-shunting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-shunting"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 
 [lib]

--- a/contracts/math/andromeda-time-gate/Cargo.toml
+++ b/contracts/math/andromeda-time-gate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-time-gate"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/modules/andromeda-address-list/Cargo.toml
+++ b/contracts/modules/andromeda-address-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-address-list"
-version = "2.1.1-b.4"
+version = "2.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/modules/andromeda-schema/Cargo.toml
+++ b/contracts/modules/andromeda-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-schema"
-version = "0.1.0-a.5"
+version = "0.1.0-a.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-auction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-auction"
-version = "2.2.6-b.6"
+version = "2.2.6-b.7"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-crowdfund/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-crowdfund"
-version = "2.2.1-b.7"
+version = "2.2.1-b.8"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-cw721"
-version = "2.2.0-b.12"
+version = "2.2.0-b.13"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-marketplace"
-version = "2.3.1-b.6"
+version = "2.3.1-b.7"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/os/andromeda-adodb/Cargo.toml
+++ b/contracts/os/andromeda-adodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-adodb"
-version = "1.1.6-b.2"
+version = "1.1.6-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/os/andromeda-economics/Cargo.toml
+++ b/contracts/os/andromeda-economics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-economics"
-version = "1.2.3-b.2"
+version = "1.2.3-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/os/andromeda-ibc-registry/Cargo.toml
+++ b/contracts/os/andromeda-ibc-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-ibc-registry"
-version = "1.1.3-b.2"
+version = "1.1.3-b.3"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/os/andromeda-kernel/Cargo.toml
+++ b/contracts/os/andromeda-kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-kernel"
-version = "1.2.5-b.2"
+version = "1.2.5-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/contracts/os/andromeda-vfs/Cargo.toml
+++ b/contracts/os/andromeda-vfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-vfs"
-version = "1.2.4-b.2"
+version = "1.2.4-b.3"
 authors = ["Connor Barr <crnbarr@gmail.com>"]
 edition = "2021"
 rust-version = "1.86.0"

--- a/contracts/socket/andromeda-osmosis-token-factory/Cargo.toml
+++ b/contracts/socket/andromeda-osmosis-token-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-osmosis-token-factory"
-version = "0.1.1-b.4"
+version = "0.1.1-b.5"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/socket/andromeda-socket-astroport/Cargo.toml
+++ b/contracts/socket/andromeda-socket-astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket-astroport"
-version = "0.1.8-b.6"
+version = "0.1.8-b.7"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/contracts/socket/andromeda-socket-osmosis/Cargo.toml
+++ b/contracts/socket/andromeda-socket-osmosis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-socket-osmosis"
-version = "0.1.2-b.5"
+version = "0.1.2-b.6"
 edition = "2021"
 rust-version = "1.86.0"
 

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-std"
-version = "1.5.1-b.11"
+version = "1.5.1-b.12"
 edition = "2021"
 rust-version = "1.86.0"
 description = "The standard library for creating an Andromeda Digital Object"

--- a/packages/std/macros/Cargo.toml
+++ b/packages/std/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "andromeda-macros"
-version = "1.1.0-b.3"
+version = "1.1.0-b.4"
 edition = "2021"
 rust-version = "1.86.0"
 description = "Macros for Andromeda Digital Objects"

--- a/packages/std/macros/src/query.rs
+++ b/packages/std/macros/src/query.rs
@@ -27,17 +27,21 @@ pub fn enum_implementation(_metadata: TokenStream, input: TokenStream) -> TokenS
                 #[returns(andromeda_std::ado_base::version::ADOBaseVersionResponse)]
                 #[schemars(example = "andromeda_std::ado_base::version::base_crate_version")]
                 ADOBaseVersion {},
-                #[returns(andromeda_std::ado_base::permissioning::PermissionInfo)]
-                Permissions { actor: String, limit: Option<u32>, start_after: Option<String> },
+                #[returns(Vec<andromeda_std::ado_base::permissioning::PermissionInfo>)]
+                Permissions { actor: andromeda_std::amp::AndrAddr, limit: Option<u32>, start_after: Option<String> },
                 #[returns(andromeda_std::ado_base::permissioning::PermissionedActionsResponse)]
                 PermissionedActions { },
                 #[returns(andromeda_std::ado_base::permissioning::PermissionedActorsResponse)]
                 PermissionedActors {
                     action: String,
-                    start_after: Option<String>,
                     limit: Option<u32>,
+                    start_after: Option<String>,
                     order_by: Option<andromeda_std::common::OrderBy>,
                 },
+                #[returns(andromeda_std::ado_base::permissioning::PermissionedActionsWithExpirationResponse)]
+                PermissionedActionsWithExpiration {},
+                #[returns(andromeda_std::ado_base::permissioning::PermissionedActionExpirationResponse)]
+                PermissionedActionsExpiration { action: String },
             }
         }
         .into(),

--- a/packages/std/macros/src/query.rs
+++ b/packages/std/macros/src/query.rs
@@ -27,7 +27,7 @@ pub fn enum_implementation(_metadata: TokenStream, input: TokenStream) -> TokenS
                 #[returns(andromeda_std::ado_base::version::ADOBaseVersionResponse)]
                 #[schemars(example = "andromeda_std::ado_base::version::base_crate_version")]
                 ADOBaseVersion {},
-                #[returns(Vec<andromeda_std::ado_base::permissioning::PermissionInfo>)]
+                #[returns(andromeda_std::ado_base::permissioning::PermissionsResponse)]
                 Permissions { actor: andromeda_std::amp::AndrAddr, limit: Option<u32>, start_after: Option<String> },
                 #[returns(andromeda_std::ado_base::permissioning::PermissionedActionsResponse)]
                 PermissionedActions { },

--- a/packages/std/src/ado_base/mod.rs
+++ b/packages/std/src/ado_base/mod.rs
@@ -67,7 +67,7 @@ pub enum AndromedaQuery {
     ADOBaseVersion {},
     #[returns(self::app_contract::AppContractResponse)]
     AppContract {},
-    #[returns(Vec<self::permissioning::PermissionInfo>)]
+    #[returns(self::permissioning::PermissionsResponse)]
     Permissions {
         actor: AndrAddr,
         limit: Option<u32>,

--- a/packages/std/src/ado_base/permissioning.rs
+++ b/packages/std/src/ado_base/permissioning.rs
@@ -38,6 +38,11 @@ pub struct PermissionInfo {
 }
 
 #[cw_serde]
+pub struct PermissionsResponse {
+    pub permissions: Vec<PermissionInfo>,
+}
+
+#[cw_serde]
 pub struct PermissionedActionsResponse {
     pub actions: Vec<String>,
 }

--- a/packages/std/src/ado_contract/execute.rs
+++ b/packages/std/src/ado_contract/execute.rs
@@ -595,10 +595,10 @@ mod tests {
                 .unwrap();
 
             // Verify permission is saved
-            let saved_permissions = contract
+            let saved_permissions_response = contract
                 .query_permissions(deps.as_ref(), actor.to_string().as_str(), None, None)
                 .unwrap();
-            assert_eq!(saved_permissions.len(), 1);
+            assert_eq!(saved_permissions_response.permissions.len(), 1);
 
             // Perform migration
             contract
@@ -606,10 +606,10 @@ mod tests {
                 .unwrap();
 
             // Verify permissions were handled correctly during migration
-            let post_migration_permissions = contract
+            let post_migration_permissions_response = contract
                 .query_permissions(deps.as_ref(), actor.to_string().as_str(), None, None)
                 .unwrap();
-            assert_eq!(post_migration_permissions.len(), 1);
+            assert_eq!(post_migration_permissions_response.permissions.len(), 1);
         }
     }
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -249,3 +249,7 @@ path = "set_amount_splitter.rs"
 [[test]]
 name = "cw721"
 path = "cw721.rs"
+
+[[test]]
+name = "permissions"
+path = "permissions.rs"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -51,3 +51,6 @@ mod curve_app;
 
 #[cfg(test)]
 mod cw721;
+
+#[cfg(test)]
+mod permissions;

--- a/tests/permissions.rs
+++ b/tests/permissions.rs
@@ -1,0 +1,304 @@
+use andromeda_app::app::AppComponent;
+use andromeda_app_contract::mock::{mock_andromeda_app, MockAppContract};
+use andromeda_auction::mock::{
+    mock_andromeda_auction, mock_auction_instantiate_msg, mock_place_bid, mock_start_auction,
+    MockAuction,
+};
+use andromeda_cw20::mock::{mock_andromeda_cw20, mock_cw20_instantiate_msg, mock_minter, MockCW20};
+use andromeda_cw721::mock::{mock_andromeda_cw721, mock_cw721_instantiate_msg, MockCW721};
+
+use andromeda_non_fungible_tokens::auction::{AuctionStateResponse, QueryMsg};
+use andromeda_rates::mock::mock_andromeda_rates;
+use andromeda_splitter::mock::mock_andromeda_splitter;
+use andromeda_std::{
+    ado_base::permissioning::{
+        LocalPermission, Permission, PermissionedActionExpirationResponse,
+        PermissionedActionsResponse, PermissionedActionsWithExpirationResponse,
+    },
+    amp::AndrAddr,
+    common::{
+        denom::Asset,
+        expiration::{Expiry, MILLISECONDS_TO_NANOSECONDS_RATIO},
+        schedule::Schedule,
+        Milliseconds,
+    },
+    error::ContractError,
+};
+use andromeda_testing::{
+    mock::mock_app, mock_builder::MockAndromedaBuilder, mock_contract::MockContract,
+};
+use cosmwasm_std::{coin, to_json_binary, Addr, BlockInfo, Timestamp, Uint128};
+use cw20::Cw20Coin;
+use cw_multi_test::Executor;
+#[test]
+fn test_permissions() {
+    let mut router = mock_app(None);
+    let andr = MockAndromedaBuilder::new(&mut router, "admin")
+        .with_wallets(vec![
+            ("owner", vec![]),
+            ("buyer_one", vec![coin(1000, "uandr")]),
+            ("buyer_two", vec![coin(1000, "uandr")]),
+            ("buyer_three", vec![coin(1000, "uandr")]),
+            ("recipient_one", vec![]),
+            ("recipient_two", vec![]),
+        ])
+        .with_contracts(vec![
+            ("cw721", mock_andromeda_cw721()),
+            ("cw20", mock_andromeda_cw20()),
+            ("auction", mock_andromeda_auction()),
+            ("app-contract", mock_andromeda_app()),
+            ("rates", mock_andromeda_rates()),
+            ("splitter", mock_andromeda_splitter()),
+        ])
+        .build(&mut router);
+    let owner = andr.get_wallet("owner");
+    let buyer_one = andr.get_wallet("buyer_one");
+    let buyer_two = andr.get_wallet("buyer_two");
+    let buyer_three = andr.get_wallet("buyer_three");
+    // Generate App Components
+    let cw721_init_msg = mock_cw721_instantiate_msg(
+        "Test Tokens".to_string(),
+        "TT".to_string(),
+        AndrAddr::from_string(owner.to_string()),
+        andr.kernel.addr().to_string(),
+        None,
+    );
+    let cw721_component = AppComponent::new(
+        "cw721".to_string(),
+        "cw721".to_string(),
+        to_json_binary(&cw721_init_msg).unwrap(),
+    );
+
+    let buyer_one_original_balance = Uint128::new(1_000);
+    let buyer_two_original_balance = Uint128::new(2_000);
+    let owner_original_balance = Uint128::new(10_000);
+    let initial_balances = vec![
+        Cw20Coin {
+            address: buyer_one.to_string(),
+            amount: buyer_one_original_balance,
+        },
+        Cw20Coin {
+            address: buyer_two.to_string(),
+            amount: buyer_two_original_balance,
+        },
+        Cw20Coin {
+            address: owner.to_string(),
+            amount: owner_original_balance,
+        },
+    ];
+
+    let cw20_init_msg = mock_cw20_instantiate_msg(
+        None,
+        "Test Tokens".to_string(),
+        "TTT".to_string(),
+        6,
+        initial_balances.clone(),
+        Some(mock_minter(
+            owner.to_string(),
+            Some(Uint128::from(1000000u128)),
+        )),
+        andr.kernel.addr().to_string(),
+    );
+    let cw20_component = AppComponent::new(
+        "cw20".to_string(),
+        "cw20".to_string(),
+        to_json_binary(&cw20_init_msg).unwrap(),
+    );
+
+    let second_cw20_init_msg = mock_cw20_instantiate_msg(
+        None,
+        "Second Test Tokens".to_string(),
+        "STTT".to_string(),
+        6,
+        initial_balances,
+        Some(mock_minter(
+            owner.to_string(),
+            Some(Uint128::from(1000000u128)),
+        )),
+        andr.kernel.addr().to_string(),
+    );
+    let second_cw20_component = AppComponent::new(
+        "second-cw20".to_string(),
+        "cw20".to_string(),
+        to_json_binary(&second_cw20_init_msg).unwrap(),
+    );
+
+    let auction_init_msg = mock_auction_instantiate_msg(
+        andr.kernel.addr().to_string(),
+        None,
+        Some(vec![AndrAddr::from_string(format!(
+            "./{}",
+            cw721_component.name
+        ))]),
+        Some(vec![AndrAddr::from_string(format!(
+            "./{}",
+            cw20_component.name
+        ))]),
+    );
+    let auction_component = AppComponent::new(
+        "auction".to_string(),
+        "auction".to_string(),
+        to_json_binary(&auction_init_msg).unwrap(),
+    );
+
+    // Create App
+    let app_components = vec![
+        auction_component.clone(),
+        cw721_component.clone(),
+        cw20_component.clone(),
+        second_cw20_component.clone(),
+    ];
+
+    let app = MockAppContract::instantiate(
+        andr.get_code_id(&mut router, "app-contract"),
+        owner,
+        &mut router,
+        "Auction App",
+        app_components.clone(),
+        andr.kernel.addr(),
+        Some(owner.to_string()),
+    );
+    let components = app.query_components(&router);
+    assert_eq!(components, app_components);
+    let cw20: MockCW20 = app.query_ado_by_component_name(&router, cw20_component.name);
+
+    // Mint Tokens
+    let cw721: MockCW721 = app.query_ado_by_component_name(&router, cw721_component.name);
+    for i in 1..=2 {
+        cw721
+            .execute_mint(
+                &mut router,
+                owner.clone(),
+                i.to_string(),
+                AndrAddr::from_string(owner.to_string()),
+            )
+            .unwrap();
+    }
+
+    // Authorize NFT contract
+    let auction: MockAuction = app.query_ado_by_component_name(&router, auction_component.name);
+    auction
+        .execute_authorize_token_address(&mut router, owner.clone(), cw721.addr(), None)
+        .unwrap();
+
+    // Send Token to Auction
+    let start_time =
+        Milliseconds(router.block_info().time.nanos() / MILLISECONDS_TO_NANOSECONDS_RATIO + 100);
+    cw721
+        .execute_send_nft(
+            &mut router,
+            owner.clone(),
+            AndrAddr::from_string("./auction".to_string()),
+            "1",
+            &mock_start_auction(
+                Schedule::new(
+                    Some(Expiry::AtTime(start_time)),
+                    Some(Expiry::AtTime(
+                        start_time.plus_milliseconds(Milliseconds(2)),
+                    )),
+                ),
+                None,
+                Asset::Cw20Token(AndrAddr::from_string(cw20.addr().to_string())),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        .unwrap();
+
+    router.set_block(BlockInfo {
+        height: router.block_info().height,
+        time: Timestamp::from_nanos(start_time.0 * MILLISECONDS_TO_NANOSECONDS_RATIO),
+        chain_id: router.block_info().chain_id,
+    });
+
+    // Query Auction State
+    let auction_ids =
+        auction.query_auction_ids(&mut router, "1".to_string(), cw721.addr().to_string());
+    assert_eq!(auction_ids.len(), 1);
+
+    let auction_id = auction_ids.first().unwrap();
+    let auction_state: AuctionStateResponse = auction.query_auction_state(&mut router, *auction_id);
+    assert_eq!(auction_state.coin_denom, cw20.addr().to_string());
+
+    // Try to set permission with an empty vector of actors
+    let actors = vec![];
+    let action = "PlaceBid".to_string();
+    let permission = Permission::Local(LocalPermission::blacklisted(Schedule::new(None, None)));
+    let err: ContractError = auction
+        .execute_set_permission(&mut router, owner.clone(), actors, action, permission)
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, ContractError::NoActorsProvided {});
+
+    // Place Bid One
+    // Blacklist bidder now and blacklist bidder three just to test permissioning multiple actors at the same time
+    let actors = vec![
+        AndrAddr::from_string(buyer_one.clone()),
+        AndrAddr::from_string(buyer_three.clone()),
+    ];
+    let action = "PlaceBid".to_string();
+    let permission = Permission::Local(LocalPermission::blacklisted(Schedule::new(None, None)));
+    auction
+        .execute_set_permission(&mut router, owner.clone(), actors, action, permission)
+        .unwrap();
+
+    // Query permissioned actions
+    let permissioned_actions: PermissionedActionsResponse =
+        auction.query(&router, QueryMsg::PermissionedActions {});
+    assert_eq!(
+        PermissionedActionsResponse {
+            actions: vec!["SEND_CW20".to_string(), "SEND_NFT".to_string()]
+        },
+        permissioned_actions
+    );
+    let permissioned_actions_with_expiration: PermissionedActionsWithExpirationResponse =
+        auction.query(&router, QueryMsg::PermissionedActionsWithExpiration {});
+    assert_eq!(
+        PermissionedActionsWithExpirationResponse {
+            actions_expiration: vec![
+                ("SEND_CW20".to_string(), None),
+                ("SEND_NFT".to_string(), None)
+            ]
+        },
+        permissioned_actions_with_expiration
+    );
+    let permissioned_actions_expiration: PermissionedActionExpirationResponse = auction.query(
+        &router,
+        QueryMsg::PermissionedActionsExpiration {
+            action: "SEND_CW20".to_string(),
+        },
+    );
+    assert_eq!(permissioned_actions_expiration.expiration, None);
+
+    let bid_msg = mock_place_bid("1".to_string(), cw721.addr().to_string());
+
+    // Bid should be rejected because we blacklisted bidder one
+    let err: ContractError = router
+        .execute_contract(
+            buyer_one.clone(),
+            Addr::unchecked(auction.addr().clone()),
+            &bid_msg,
+            &[coin(50, "uandr")],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // Bid should be rejected because we blacklisted bidder three
+    let err: ContractError = router
+        .execute_contract(
+            buyer_three.clone(),
+            Addr::unchecked(auction.addr().clone()),
+            &bid_msg,
+            &[coin(50, "uandr")],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, ContractError::Unauthorized {});
+}


### PR DESCRIPTION
# Motivation
There was a discrepancy between AndromedaQuery enum and its macro
# Implementation
- Made them the same

# Testing
Integration test

# Version Changes
- `kernel`: `x.x.x-b.x` -> `x.x.x-b.y`

# Checklist

- [x] Versions bumped correctly and documented
- [x] Changelog entry added or label applied
